### PR TITLE
Forcing numeric DataType in GangliaWriter

### DIFF
--- a/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java
@@ -55,6 +55,21 @@ public class GangliaWriter extends BaseOutputWriter {
 				return INT;
 			if (value instanceof Long || value instanceof Float || value instanceof Double)
 				return DOUBLE;
+
+			// Convert to double or int if possible
+			try {
+				Double.parseDouble(value.toString());
+				return DOUBLE;
+			} catch (NumberFormatException e) {
+				// Not a double	
+			}
+			try {
+				Integer.parseInt(value.toString());
+				return INT;
+			} catch (NumberFormatException e) {
+				// Not an int
+			}
+
 			return STRING;
 		}
 


### PR DESCRIPTION
For systems that incorrectly store values as DataType String instead of
as numeric values.  For example, Apache Solr seems to store all data as a String type (see: https://issues.apache.org/jira/browse/SOLR-3083).  Ganglia doesn't know what to do with these String types so this forces them into a numeric type.
