### PR TITLE
Improve the Quartz Job ID generator algorithm

### DIFF
--- a/src/com/googlecode/jmxtrans/JmxTransformer.java
+++ b/src/com/googlecode/jmxtrans/JmxTransformer.java
@@ -18,6 +18,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.pool.KeyedObjectPool;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.quartz.CronExpression;
@@ -400,7 +401,7 @@ public class JmxTransformer implements WatchedCallback {
 	 */
 	private void scheduleJob(Scheduler scheduler, Server server) throws ParseException, SchedulerException {
 
-		String name = server.getHost() + ":" + server.getPort() + "-" + System.currentTimeMillis();
+		String name = server.getHost() + ":" + server.getPort() + "-" + System.currentTimeMillis() + "-" + RandomStringUtils.randomNumeric(10);
 		JobDetail jd = new JobDetail(name, "ServerJob", ServerJob.class);
 
 		JobDataMap map = new JobDataMap();


### PR DESCRIPTION
Sometime, JMXTrans can't start because different jobs have the same generated ID. (issue #15)

In fact, the used algorithm is not good and sometime produce identical ID :

``` java
String name = server.getHost() + ":" + server.getPort() + "-" + System.currentTimeMillis();
```

```
[06 Mar 2012 11:28:09] [main] 1      ERROR (com.googlecode.jmxtrans.JmxTransformer:106) - Error scheduling job for server: Server [host=xxxxxxxx.org, port=32001, url=null, cronExpression=null, numQueryThreads=4]
org.quartz.ObjectAlreadyExistsException: Unable to store Trigger with name: 'xxxxxxxx.org:32001-1331029689802' and group: 'DEFAULT', because one already exists with this identification.
    at org.quartz.simpl.RAMJobStore.storeTrigger(RAMJobStore.java:314)
    at org.quartz.simpl.RAMJobStore.storeJobAndTrigger(RAMJobStore.java:194)
    at org.quartz.core.QuartzScheduler.scheduleJob(QuartzScheduler.java:801)
    at org.quartz.impl.StdScheduler.scheduleJob(StdScheduler.java:243)
    at com.googlecode.jmxtrans.JmxTransformer.scheduleJob(JmxTransformer.java:295)
    at com.googlecode.jmxtrans.JmxTransformer.processServersIntoJobs(JmxTransformer.java:256)
    at com.googlecode.jmxtrans.JmxTransformer.startupSystem(JmxTransformer.java:173)
    at com.googlecode.jmxtrans.JmxTransformer.doMain(JmxTransformer.java:102)
    at com.googlecode.jmxtrans.JmxTransformer.main(JmxTransformer.java:84)
```
