### PR TITLE
Delete .pid file (if any) after shutdown and clean shutdown

### DIFF
--- a/jmxtrans.sh
+++ b/jmxtrans.sh
@@ -84,7 +84,7 @@ stop() {
 		kill -15 "$PID"
 		echo -n "Stopping jmxtrans"
 		while (true); do
-			ps -p $PID 2>&1 > /dev/null
+			ps -p $PID > /dev/null 2>&1 
 			if [ $? -eq 0 ]; then
 				echo -n "."
 				sleep 1


### PR DESCRIPTION
When we use a pid file (to be able to launch several JMXTrans instances from the same server in my case), we have 2 problems :
- inside the while loop of the stop() function, the PSCMD is not good when several instances of JMXTrans are started 
- the PID file is not deleted after shutting down JMXTrans process

My proposed patch fix the 2 problems
