### PR TITLE
Add (optional) JMX username/password support to the YAML converter

### DIFF
--- a/tools/yaml2jmxtrans.py
+++ b/tools/yaml2jmxtrans.py
@@ -49,7 +49,7 @@ class Queries(object):
             queryentry[attr] = self.queries[query_name][attr]
         return queryentry
 
-    def create_host_entry(self, host_name, query_names, query_port):
+    def create_host_entry(self, host_name, query_names, query_port, username, password):
         """
         Create a query snippet for 'host_name' with all queries given
         by 'query_names'
@@ -59,10 +59,17 @@ class Queries(object):
                       'queries' : [] }
         for query_name in query_names:
             hostentry['queries'].append(self.create_query_entry(query_name))
+
+        if username:
+            hostentry['username'] = username
+
+        if password:
+            hostentry['password'] = password
+
         hostentry['numQueryThreads'] = len(hostentry['queries'])
         return hostentry
 
-    def create_host_set_configuration(self, host_names, query_names, query_port):
+    def create_host_set_configuration(self, host_names, query_names, query_port, username, password):
         """
         Return the full jmxtrans compatible configuration for all 'host_names',
         each using all queries given by 'query_names'. 'query_port' is used to
@@ -70,7 +77,7 @@ class Queries(object):
         """
         root = {'servers' : [] }
         for host_name in host_names:
-            root['servers'].append(self.create_host_entry(host_name, query_names, query_port))
+            root['servers'].append(self.create_host_entry(host_name, query_names, query_port, username, password))
         return root
 
     def create_graphite_output_writer(self):
@@ -102,6 +109,16 @@ class HostSets(object):
         for host_set in host_sets:
             set_entry = {'query_names' : host_set['query_names'],
                          'hosts' : host_set['hosts'] }
+            if 'username' in host_set:
+                set_entry['username'] = host_set['username']
+            else:
+                set_entry['username'] = None
+
+            if 'password' in host_set:
+                set_entry['password'] = host_set['password']
+            else:
+                set_entry['password'] = None
+
             self.host_sets[host_set['setname']] = set_entry
 
     def set_names(self):
@@ -137,6 +154,6 @@ if __name__ == '__main__':
     for set_name in h.set_names():
         outfile = open(set_name + ".json", 'w')
         s = h.get_set(set_name)
-        servers = q.create_host_set_configuration(s['hosts'],s['query_names'], query_port)
+        servers = q.create_host_set_configuration(s['hosts'],s['query_names'], query_port, s['username'], s['password'])
         json.dump(servers,outfile, indent=1)
         outfile.close()


### PR DESCRIPTION
Add a 'username' and 'password' attributes at the 'setname' level
in your YAML configuration for hosts that require authentication.

If unset, the default behaviour is unchanged; no 'username' or 'password'
entries will appear in the JSON output.

Example:

```
sets:
  - setname: set1 # default behaviour - no username/password
    query_names:
      - mempool
    hosts:
      - host1.f.q.d.n
  - setname: set2 # Host that requires authentication
    username: "jmx"
    password: "jmx"
    query_names:
      - mempool
    hosts:
      - host2.f.q.d.n
```
