### PR TITLE
make socket dead detection work

### DIFF
--- a/src/com/googlecode/jmxtrans/util/SocketFactory.java
+++ b/src/com/googlecode/jmxtrans/util/SocketFactory.java
@@ -45,6 +45,15 @@ public class SocketFactory extends BaseKeyedPoolableObjectFactory {
 	@Override
 	public boolean validateObject(Object key, Object obj) {
 		Socket socket = (Socket) obj;
+		try {
+			socket.setSoTimeout(100);
+			if (socket.getInputStream().read() == -1) {
+				return false;
+			}
+		} catch (java.net.SocketTimeoutException e) {
+		} catch (Exception e) {
+			return false;
+		}
 		return socket.isBound() && !socket.isClosed() && socket.isConnected() && !socket.isInputShutdown() && !socket.isOutputShutdown();
 	}
 }


### PR DESCRIPTION
socket.setKeepAlive(true) won't work here.
the fix is ugly but that's the best I can find. 
The fix is tested, when use with graphitewrite, it will provide re-connect function if graphite Carbon-Cache daemon restart
