### PR TITLE
Fix KeyOutWriter to use a single Logger instance per file name 

### DIFF
--- a/src/com/googlecode/jmxtrans/model/output/DailyKeyOutWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/DailyKeyOutWriter.java
@@ -1,0 +1,69 @@
+package com.googlecode.jmxtrans.model.output;
+
+import java.io.IOException;
+
+import org.apache.log4j.DailyRollingFileAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.spi.LoggerFactory;
+
+/**
+ * This class is derived from KeyOutWriter. It uses DailyRollingFileAppender
+ * instead of RollingFileAppender.
+ * 
+ * Writes out data in the same format as the GraphiteWriter, except to a file
+ * and tab delimited. Takes advantage of Log4J DailyRollingFileAppender to
+ * automatically handle rolling the files at defined intervals (datePattern).
+ * 
+ * Note that this writer will NOT clean up after itself. The files will not be
+ * deleted. It is up to the user to clean things up.
+ * 
+ * The datePattern is taken directly from DailyRollingFileAppender DatePattern.
+ * 
+ * The default datePattern will roll the files at midnight once a day
+ * ("'.'yyyy-MM-dd") See the documentation for DailyRollingFileAppender for
+ * other useful patterns.
+ * 
+ */
+public class DailyKeyOutWriter extends KeyOutWriter {
+
+	private static final String DATE_PATTERN = "'.'yyyy-MM-dd";
+
+	public DailyKeyOutWriter() {
+		super();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * com.googlecode.jmxtrans.model.output.KeyOutWriter#initLogger(java.lang
+	 * .String)
+	 */
+	@Override
+	protected Logger initLogger(String fileStr) throws IOException {
+		String datePattern = (String) this.getSettings().get("datePattern");
+		if (datePattern == null) {
+			datePattern = DATE_PATTERN;
+		}
+		PatternLayout pl = new PatternLayout(LOG_PATTERN);
+
+		final DailyRollingFileAppender appender = new DailyRollingFileAppender(pl, fileStr, datePattern);
+		appender.setImmediateFlush(true);
+		appender.setBufferedIO(false);
+		appender.setBufferSize(LOG_IO_BUFFER_SIZE_BYTES);
+
+		LoggerFactory loggerFactory = new LoggerFactory() {
+			@Override
+			public Logger makeNewLoggerInstance(String name) {
+				Logger logger = Logger.getLogger(name);
+				logger.addAppender(appender);
+				logger.setLevel(Level.INFO);
+				logger.setAdditivity(false);
+				return logger;
+			}
+		};
+		return loggerFactory.makeNewLoggerInstance("DailyKeyOutWriter" + this.hashCode());
+	}
+}


### PR DESCRIPTION
Files should hopefully be formatted as per project. 
- Fix KeyOutWriter to use a single Logger instance per file name 
- Refactor KeyOutWriter to act as base class for DailyKeyOutWriter
- Add DailyKeyOutWriter which uses DailyRollingFileAppender

I refactored KeyOutWriter because I wanted to reuse most of the code for DailyKeyOutWriter (if you don't want to take DailyKeyOutWriter then the refactored code will also stand on it's own, but I think it's a useful addition).

Another alternative to having a separate DailyKeyOutWriter would be to support the datePattern property directly in KeyOutWriter, but I thought that might complicate things more than it would having a separate class.

I have some wiki text for DailyKeyOutWriter as well, but I haven't figured out how to merge that into the master wiki yet...

cheers,
Kyle
