### PR TITLE
Default JAVA_HOME to /usr

### DIFF
--- a/jmxtrans.sh
+++ b/jmxtrans.sh
@@ -8,7 +8,7 @@ if [ -e "$CONF_FILE" ]; then
 	. "$CONF_FILE"
 fi
 
-JAVA_HOME=${JAVA_HOME:-"/usr/bin"}
+JAVA_HOME=${JAVA_HOME:-"/usr"}
 LOG_DIR=${LOG_DIR:-"."}
 JAR_FILE=${JAR_FILE:-"jmxtrans-all.jar"}
 JSON_DIR=${JSON_DIR:-"."}


### PR DESCRIPTION
In commit b6c8ead8084892104cc7bd2fc933abde3704b127 this default was changed
to /usr/bin which results in the default paths for jps and java becoming
/usr/bin/bin
