### PR TITLE
Fix connection pool usage in GraphiteWriter

### DIFF
--- a/src/com/googlecode/jmxtrans/model/output/GraphiteWriterSatus.java
+++ b/src/com/googlecode/jmxtrans/model/output/GraphiteWriterSatus.java
@@ -1,0 +1,10 @@
+package com.googlecode.jmxtrans.model.output;
+
+public enum GraphiteWriterSatus {
+
+	STARTING,
+	STARTED,
+	STOPPING,
+	STOPPED
+	
+}


### PR DESCRIPTION
Hello,

I noticed that jmxtrans has 900+ open connections to graphite on my system.
The reason is each GraphiteWriter creates its own connection pool with a single connection in it. 
There is the fix (now I have just 10 connections), plus I made it thread safe, may be one day you'll come up with a pluggable architecture or something
