### PR TITLE
Replace parentheses in key names with underscores. 

### DIFF
--- a/src/com/googlecode/jmxtrans/model/output/GraphiteWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/GraphiteWriter.java
@@ -118,7 +118,7 @@ public class GraphiteWriter extends BaseOutputWriter {
 						if (JmxUtils.isNumeric(values.getValue())) {
 							StringBuilder sb = new StringBuilder();
 
-							sb.append(JmxUtils.getKeyString(query, result, values, typeNames, rootPrefix));
+							sb.append(JmxUtils.getKeyString(query, result, values, typeNames, rootPrefix).replaceAll("[()]", "_"));
 
 							sb.append(" ");
 							sb.append(values.getValue().toString());


### PR DESCRIPTION
Graphite doesn't support parentheses in key names. I've opted to replace them with underscores. 
