### PR TITLE
Stasdwriter related changes using StastClient.java example from statsd repo as old code was giving error mentioned below: 

### DIFF
--- a/src/com/googlecode/jmxtrans/model/output/StatsDWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/StatsDWriter.java
@@ -1,9 +1,10 @@
 package com.googlecode.jmxtrans.model.output;
 
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -34,6 +35,7 @@ public class StatsDWriter extends BaseOutputWriter {
 
 	private static final Logger log = LoggerFactory.getLogger(StatsDWriter.class);
 	public static final String ROOT_PREFIX = "rootPrefix";
+	private ByteBuffer sendBuffer;
 
 	private String host;
 	private Integer port;
@@ -41,6 +43,7 @@ public class StatsDWriter extends BaseOutputWriter {
 	private String bucketType = "c";
 	private String rootPrefix = "servers";
 	private SocketAddress address;
+	private final DatagramChannel _channel;
 
 	private static final String BUCKET_TYPE = "bucketType";
 
@@ -50,9 +53,20 @@ public class StatsDWriter extends BaseOutputWriter {
 
 	/**
 	 * Uses JmxUtils.getDefaultPoolMap()
+	 * @throws IOException
 	 */
-	public StatsDWriter() {
+	public StatsDWriter() throws IOException {
+		_channel = DatagramChannel.open();
+        setBufferSize((short) 1500);
 	}
+	
+	public synchronized void setBufferSize(short packetBufferSize) {
+        if(sendBuffer != null) {
+                flush();
+        }
+        sendBuffer = ByteBuffer.allocate(packetBufferSize);
+	}
+
 
 	@Override
 	public void start() throws LifecycleException {
@@ -110,7 +124,6 @@ public class StatsDWriter extends BaseOutputWriter {
 
 		List<String> typeNames = this.getTypeNames();
 
-		DatagramSocket socket = (DatagramSocket) pool.borrowObject(this.address);
 		try {
 			for (Result result : query.getResults()) {
 				if (isDebugEnabled()) {
@@ -132,20 +145,68 @@ public class StatsDWriter extends BaseOutputWriter {
 							sb.append("\n");
 
 							String line = sb.toString();
-							byte[] sendData = line.getBytes();
 
 							if (isDebugEnabled()) {
 								log.debug("StatsD Message: " + line.trim());
 							}
 
-							DatagramPacket sendPacket = new DatagramPacket(sendData, sendData.length);
-							socket.send(sendPacket);
+							doSend(line.trim());
 						}
 					}
 				}
 			}
-		} finally {
-			pool.returnObject(address, socket);
+		}
+	}
+
+	private synchronized boolean doSend(String stat) {
+		try {
+			final byte[] data = stat.getBytes("utf-8");
+
+			// If we're going to go past the threshold of the buffer then flush.
+			// the +1 is for the potential '\n' in multi_metrics below
+			if (sendBuffer.remaining() < (data.length + 1)) {
+				flush();
+			}
+
+			if (sendBuffer.position() > 0) { // multiple metrics are separated
+												// by '\n'
+				sendBuffer.put((byte) '\n');
+			}
+
+			sendBuffer.put(data); // append the data
+
+			flush();
+			return true;
+
+		} catch (IOException e) {
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	public synchronized boolean flush() {
+		try {
+			final int sizeOfBuffer = sendBuffer.position();
+
+			if (sizeOfBuffer <= 0) {
+				return false;
+			} // empty buffer
+
+			// send and reset the buffer
+			sendBuffer.flip();
+			final int nbSentBytes = _channel.send(sendBuffer, this.address);
+			sendBuffer.limit(sendBuffer.capacity());
+			sendBuffer.rewind();
+
+			if (sizeOfBuffer == nbSentBytes) {
+				return true;
+			} else {
+				return false;
+			}
+
+		} catch (IOException e) {
+			e.printStackTrace();
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
...data in file, it is giving below error. For fixing used code from Stastd examples: https://github.com/etsy/statsd/blob/master/examples/StatsdClient.java and not it is working fine

[ServerScheduler_Worker-10] 2340352 ERROR (com.googlecode.jmxtrans.jobs.ServerJob:39) - Error
java.net.BindException: Address already in use
at java.net.PlainDatagramSocketImpl.bind0(Native Method)
at java.net.AbstractPlainDatagramSocketImpl.bind(AbstractPlainDatagramSocketImpl.java:95)
at java.net.DatagramSocket.bind(DatagramSocket.java:376)
at java.net.DatagramSocket.<init>(DatagramSocket.java:231)
at com.googlecode.jmxtrans.util.DatagramSocketFactory.makeObject(DatagramSocketFactory.java:27)
at org.apache.commons.pool.impl.GenericKeyedObjectPool.borrowObject(GenericKeyedObjectPool.java:1212)
at com.googlecode.jmxtrans.model.output.StatsDWriter.doWrite(StatsDWriter.java:113)
at com.googlecode.jmxtrans.util.JmxUtils.runOutputWritersForQuery(JmxUtils.java:336)
at com.googlecode.jmxtrans.util.JmxUtils.processQuery(JmxUtils.java:206)
at com.googlecode.jmxtrans.util.JmxUtils.processQueriesForServer(JmxUtils.java:120)
at com.googlecode.jmxtrans.util.JmxUtils.processServer(JmxUtils.java:456)
at com.googlecode.jmxtrans.jobs.ServerJob.execute(ServerJob.java:37)
at org.quartz.core.JobRunShell.run(JobRunShell.java:216)
at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:549)
