### PR TITLE
Add configurable outputWriters

### DIFF
--- a/doc/tools/README.md
+++ b/doc/tools/README.md
@@ -28,6 +28,8 @@ Limitations
 * _yaml2trans.py_ only supports [Graphite][Graphite] as an output
   writer as that's what I use. Please file issues if you require
   other output writers.
+* EXPERIMENTAL: The "outputWriters:" map in the YAML configuration file supports other
+  output writers. Please file issues if there are problems.
 
 [YAML]: http://yaml.org/
 [PyYAML]: http://pyyaml.org/

--- a/doc/tools/yaml2jmxtrans-example.yaml
+++ b/doc/tools/yaml2jmxtrans-example.yaml
@@ -1,6 +1,14 @@
 # Host/Port Grahpite listens on
+# Deprecated in favor of "outputWriters:" configuration below
 graphite_host: "graphite.yourdomain.com"
 graphite_port: 2003
+
+# Configure your outputWriters here:
+outputWriters:
+    - "@class": "com.googlecode.jmxtrans.model.output.GraphiteWriter"
+      settings:
+          host: "localhost"
+          port: 2003
 
 # Global port to query JMX on
 query_port: 5400


### PR DESCRIPTION
GIT NOTE:"
I'm new to github, and I hope that this commit won't break anything - We had a few unrelated changes in our repository which would be automatically included in the pull request. The only way I got around that was to base my branch on an older version of the repository.

I've added the ability to specify outputWriters in the YAML:

outputWriters:
    - "@class": "com.googlecode.jmxtrans.model.output.GraphiteWriter"
      settings:
          host: "localhost"
          port: 2003

NOTES:
- I've attempted to be completely backwards compatible.
- PLEASE test this before running in production
