### PR TITLE
Minor fix: check for CompositeData instead of CompositeDataSupport

### DIFF
--- a/src/com/googlecode/jmxtrans/util/JmxUtils.java
+++ b/src/com/googlecode/jmxtrans/util/JmxUtils.java
@@ -294,7 +294,7 @@ public class JmxUtils {
 	private static void getResult(List<Result> resList, MBeanInfo info, ObjectInstance oi, Attribute attribute, Query query) {
 		Object value = attribute.getValue();
 		if (value != null) {
-			if (value instanceof CompositeDataSupport) {
+			if (value instanceof CompositeData) {
 				getResult(resList, info, oi, attribute.getName(), (CompositeData) value, query);
 			} else if (value instanceof CompositeData[]) {
 				for (CompositeData cd : (CompositeData[]) value) {


### PR DESCRIPTION
checking for CompositeDataSupport is more specific than it needs to be. (The next line casts the value to "CompositeData") - this change will allow certain Gc fields to be parsed properly that implement CompositeData but do not extend CompositeDataSupport
