### PR TITLE
fixing usage of DatagramSocket

### DIFF
--- a/src/com/googlecode/jmxtrans/model/output/StatsDWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/StatsDWriter.java
@@ -72,7 +72,7 @@ public class StatsDWriter extends BaseOutputWriter {
 	public void start() throws LifecycleException {
 		try {
 			this.pool = JmxUtils.getObjectPool(new DatagramSocketFactory());
-			this.mbean = new ManagedGenericKeyedObjectPool((GenericKeyedObjectPool) pool, Server.SOCKET_FACTORY_POOL);
+			this.mbean = new ManagedGenericKeyedObjectPool((GenericKeyedObjectPool) pool, Server.DATAGRAM_SOCKET_FACTORY_POOL);
 			JmxUtils.registerJMX(this.mbean);
 		} catch (Exception e) {
 			throw new LifecycleException(e);

--- a/src/com/googlecode/jmxtrans/util/DatagramSocketFactory.java
+++ b/src/com/googlecode/jmxtrans/util/DatagramSocketFactory.java
@@ -24,7 +24,9 @@ public class DatagramSocketFactory extends BaseKeyedPoolableObjectFactory {
 	 */
 	@Override
 	public Object makeObject(Object key) throws Exception {
-		return new DatagramSocket((SocketAddress)key);
+		DatagramSocket socket = new DatagramSocket();
+		socket.connect((SocketAddress)key);
+		return socket;
 	}
 
 	/**

--- a/test/com/googlecode/jmxtrans/util/DatagramSocketFactoryTest.java
+++ b/test/com/googlecode/jmxtrans/util/DatagramSocketFactoryTest.java
@@ -1,0 +1,31 @@
+package com.googlecode.jmxtrans.util;
+
+import com.googlecode.jmxtrans.model.Query;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Simon Effenberg Date: 2013-05-16
+ */
+public class DatagramSocketFactoryTest {
+	@Test
+	public void testDatagramSocketFactoryMakeObject() {
+
+    int port = 50123;
+
+    BaseKeyedPoolableObjectFactory socketFactory = new DatagramSocketFactory();
+
+    Object socketAddress = (Object) new InetSocketAddress(Inet4Address.getLocalhost(), port);
+
+    Socket socketObject = (Socket) socketFactory.makeObject(socketAddress);
+
+    // Test if the remote address/port is the correct one.
+    assertEquals(port, socketObject.getPort());
+    assertEquals(Inet4Address.getLocalhost(), socketObject.getInetAddess());
+	}
+}


### PR DESCRIPTION
The DatagramSocket isn't working like the Socket class. The Socket
constructor is taking the _remote_ address and _remote_ port where
it should connect to. The DatagramSocket constructor is taking the
_local_ host/ip and _local_ port where it should bind to.

See:
http://docs.oracle.com/javase/7/docs/api/java/net/DatagramSocket.html#constructor_summary
http://docs.oracle.com/javase/7/docs/api/java/net/Socket.html#constructor_summary

I'm not able to test it easily because the StatsDWriter looks as if it
is bypassing the pool completely and nobody else seems to use it. 
At least in an older version of JMXtrans (201210..) we got exceptions
about "java.net.BindException: Cannot assign requested address".

Please take a look if this looks fine!