### PR TITLE
Jmx Remoting (JSR160) support

### DIFF
--- a/tools/yaml2jmxtrans.py
+++ b/tools/yaml2jmxtrans.py
@@ -125,11 +125,9 @@ class Queries(object):
         	(host, aliasSep, alias) = host_name.partition(";")
         	if aliasSep == "":
         		alias = global_host_alias
-            (host, sep, port) = host.partition(":")
+            (host, sep, port) = host_name.partition(":")
             if sep == "":
                 port = query_port
-            host = host.strip()
-            alias = alias.strip()
             root['servers'].append(self.create_host_entry(host, query_names, port, username, password, urlTemplate, alias, set_name))
         return root
 


### PR DESCRIPTION
The following commits add JSR-160  (JMX Remoting) support. It is used in JBoss7 and should become a lot more common. 

Should it be in upstream though ?
