### PR TITLE
Fixed incorrect edge case hostname parsing.

### DIFF
--- a/tools/yaml2jmxtrans.py
+++ b/tools/yaml2jmxtrans.py
@@ -125,9 +125,11 @@ class Queries(object):
         	(host, aliasSep, alias) = host_name.partition(";")
         	if aliasSep == "":
         		alias = global_host_alias
-            (host, sep, port) = host_name.partition(":")
+            (host, sep, port) = host.partition(":")
             if sep == "":
                 port = query_port
+            host = host.strip()
+            alias = alias.strip()
             root['servers'].append(self.create_host_entry(host, query_names, port, username, password, urlTemplate, alias, set_name))
         return root
 


### PR DESCRIPTION
These two gists demonstrate what the PR fixes,

Before: https://gist.github.com/stdexcept/6449348
After: https://gist.github.com/stdexcept/6449363

Notice how using an alias screws up the url and port.
