### PR TITLE
Added support for JSR-160 (JMX Remoting).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,17 @@
 			<scope>test</scope>
 		</dependency>
 
+        <!-- JSR160 (JMX Remoting) protocol -->
+        <dependency>
+            <groupId>org.jboss.remoting3</groupId>
+            <artifactId>remoting-jmx</artifactId>
+            <version>1.0.1.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.remotingjmx</groupId>
+            <artifactId>remoting-jmx</artifactId>
+            <version>1.1.1.CR2</version>
+        </dependency>
 	</dependencies>
 
 </project>


### PR DESCRIPTION
This commit adds support for the the jsr-160 (JMX Remoting) protocol. It's now default in JBoss7 and should become a lot more common.
