### PR TITLE
LXC container support: Even for "java -version" we specify a heap size as Java might "guess" wrong...

### DIFF
--- a/jmxtrans.sh
+++ b/jmxtrans.sh
@@ -49,7 +49,9 @@ if [ $? != 0 ]; then
     PSCMD="$PSJAVA | grep -i jmxtrans | awk '{ print \$2 };'"
 fi
 
-JAVA_VERSION=`$JAVA -version 2>&1`
+# NOTE: even for "-version" we specify a heap size as Java might 
+# "guess" wrong inside LXC containers with memory limit
+JAVA_VERSION=`$JAVA -Xmx${HEAP_SIZE}M -version 2>&1`
 if [ $? != 0 ]; then
     echo "Cannot execute $JAVA!"
     exit 1


### PR DESCRIPTION
...inside LXC containers with memory limit.

This is necessary on LXC containers with "low" memory limit compared to the hypervisor (in my case the hypervisor has 141GB RAM, but the LXC container is limited to 64GB).
As Java's algorithm for the default heap size only sees the hypervisor's main memory (141GB) it will fail allocating default heap size memory on the LXC container.
