### PR TITLE
Add variables in jmstrans.sh to use directly ps command

### DIFF
--- a/jmxtrans.sh
+++ b/jmxtrans.sh
@@ -23,7 +23,9 @@ SECONDS_BETWEEN_RUNS=${SECONDS_BETWEEN_RUNS:-"60"}
 HARDKILL_THRESHOLD=${HARDKILL_THRESHOLD:-60}
 
 JPS=${JPS:-"${JAVA_HOME}/bin/jps -l"}
+USE_JPS=${USE_JPS:-"true"}
 JAVA=${JAVA:-"${JAVA_HOME}/bin/java"}
+CHECK_JAVA=${CHECK_JAVA:-"true"}
 PSJAVA=${PSJAVA:-"ps aux | grep [j]ava"} 
 PSCMD="$JPS | grep -i jmxtrans | awk '{ print \$1 };'"
 JAVA_OPTS=${JAVA_OPTS:-"-Djava.awt.headless=true -Djava.net.preferIPv4Stack=true"}
@@ -43,16 +45,22 @@ JMXTRANS_OPTS="$JMXTRANS_OPTS -Djmxtrans.log.level=${LOG_LEVEL} -Djmxtrans.log.d
 MONITOR_OPTS=${MONITOR_OPTS:-"-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=${JMX_PORT}"}
 GC_OPTS=${GC_OPTS:-"-Xms${HEAP_SIZE}M -Xmx${HEAP_SIZE}M -XX:+UseConcMarkSweepGC -XX:NewRatio=${NEW_RATIO} -XX:NewSize=${NEW_SIZE}m -XX:MaxNewSize=${NEW_SIZE}m -XX:MaxTenuringThreshold=16 -XX:GCTimeRatio=9 -XX:PermSize=${PERM_SIZE}m -XX:MaxPermSize=${MAX_PERM_SIZE}m -XX:+UseTLAB -XX:CMSInitiatingOccupancyFraction=${IO_FRACTION} -XX:+CMSIncrementalMode -XX:+CMSIncrementalPacing -XX:ParallelGCThreads=${CPU_CORES} -Dsun.rmi.dgc.server.gcInterval=28800000 -Dsun.rmi.dgc.client.gcInterval=28800000"}
 
-JPS_RUNNABLE=`$JPS 2>&1`
-if [ $? != 0 ]; then
+if [ "$USE_JPS" == "true" ]; then
+  JPS_RUNNABLE=`$JPS 2>&1`
+  if [ $? != 0 ]; then
     echo "Cannot execute $JPS!, switching to stock ps"
     PSCMD="$PSJAVA | grep -i jmxtrans | awk '{ print \$2 };'"
+  fi
+else
+  PSCMD="$PSJAVA | grep -i jmxtrans | awk '{ print \$2 };'"
 fi
 
-JAVA_VERSION=`$JAVA -version 2>&1`
-if [ $? != 0 ]; then
-    echo "Cannot execute $JAVA!"
-    exit 1
+if [ "$CHECK_JAVA" == "true" ]; then
+    JAVA_VERSION=`$JAVA -version 2>&1`
+    if [ $? != 0 ]; then
+        echo "Cannot execute $JAVA!"
+        exit 1
+    fi
 fi
 
 start() {


### PR DESCRIPTION
Add variables in jmstrans.sh to use directly ps command and bypass java -version.
This pull request is backward compatibility.
- USE_JPS if true (default value) jmstrans.sh use JPS (as the actual behaviour). If not true, jmxstrans.sh use directly ps command (#89)
- CHECK_JAVA if true (default value) the java version is printed (as the actual behaviour). If not true, java is bypassed.

Bonus, if I set USE_JPS and CHECK_JAVA with false, /etc/init.d/status is faster :)

``` bash
# before
time /etc/init.d/jmxtrans status
[....] Status jmxtrans: jmxtransjmxtrans is not running.
. ok 
/etc/init.d/jmxtrans status  0.37s user 0.08s system 85% cpu 0.521 total

# after
time /etc/init.d/jmxtrans status
[....] Status jmxtrans: jmxtransjmxtrans is not running.
. ok 
/etc/init.d/jmxtrans status  0.00s user 0.02s system 36% cpu 0.066 total
```

**0.066** s instead of **0.521** s.
