### PR TITLE
Use typeNames when provided in config for StackdriverWriter

### DIFF
--- a/src/com/googlecode/jmxtrans/model/output/StackdriverWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/StackdriverWriter.java
@@ -201,6 +201,8 @@ public class StackdriverWriter extends BaseOutputWriter {
 		g.writeNumberField("proto_version", STACKDRIVER_PROTOCOL_VERSION);
 		g.writeArrayFieldStart("data");
 
+		List<String> typeNames = this.getTypeNames();
+		
 		for (Result metric : results) {
 			Map<String, Object> values = metric.getValues();
 			if (values != null) {
@@ -222,6 +224,13 @@ public class StackdriverWriter extends BaseOutputWriter {
 							
 						} else {
 							nameBuilder.append(metric.getClassName());	
+						}
+						
+						// Wildcard "typeNames" substitution
+						String typeName = JmxUtils.cleanupStr(JmxUtils.getConcatedTypeNameValues(typeNames, metric.getTypeName()));
+						if (typeName != null && typeName.length() > 0) {
+							nameBuilder.append(".");
+							nameBuilder.append(typeName);
 						}
 						
 						// add the attribute name


### PR DESCRIPTION
This is common practice on the output writers, and was overlooked when writing the StackdriverWriter.  When typeNames is supplied in the writer configuration, this will expand out the wildcard values into the middle of the posted value strings.  The methodology was done specifically to match the other writers, and use the helper functions from JmxUtils as appropriate.
