### PR TITLE
Fixed debian init script

### DIFF
--- a/debian/init
+++ b/debian/init
@@ -26,7 +26,7 @@ RETVAL=0
 do_start() {
     start-stop-daemon --start -b --pidfile $PIDFILE --oknodo \
         --chuid jmxtrans:jmxtrans -u jmxtrans -g jmxtrans -v \
-        --exec $RUNCMD -- start
+        -d /usr/share/@PACKAGE@ --exec $RUNCMD -- start
     RETVAL=$?
 }
 


### PR DESCRIPTION
- Previously did not source /etc/defaults/jmxtrans correctly as the
  runcommand is a bash script and as such was not inheriting the sourced
  variables. Fixed it by making the source export with `set -a`
- Made $RUNCMD point directly to the script. Previously it was a line of
  bash which would also fail to source defaults and give the wrong exit
  code on failure to find the script (127 instead of 2)
