### PR TITLE
Enabled setting of debian package version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -91,6 +91,7 @@
 		<!--  A hack because svnant does not respect Ant's properties can't be overwritten rule. -->
 		<property name="version" value="${DATE_TIME}-${sVersionRevision}" />
 		<property name="version.rpm" value="${DATE_TIME2}.${sVersionRevision}" />
+		<property name="deb.version" value="1" />
 		<property name="build.version" value="${DATE_TIME}-${sVersionRevision}" />
 
 		<property name="build.dist.dir" location="${build.dir}/${ant.project.name}-${version}"/>
@@ -253,6 +254,7 @@
 		<filter token="YEAR" value="${YEAR}" />
 		<filter token="VERSION" value="${version}" />
 		<filter token="FULL_VERSION" value="${sVersion}" />
+		<filter token="DEB_VERSION" value="${deb.version}" />
 
 		<copy todir="${target.dir}/jmxtrans/debian" filtering="true">
 			<fileset dir="debian">

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-@PACKAGE@ (@VERSION@-1) stable; urgency=low
+@PACKAGE@ (@VERSION@-@DEB_VERSION@) stable; urgency=low
 
   * See http://jmxtrans.googlecode.com/ for more details.
 


### PR DESCRIPTION
- Means that package build can be iterated on and dpkg versions can be
  changed without modifying the upstream version number
- Version can be specified with -Ddeb.version
- Will still default to "1" to preserve old behaviour
