### PR TITLE
run java process with nohup to prevent zombie processes

### DIFF
--- a/jmxtrans.sh
+++ b/jmxtrans.sh
@@ -85,7 +85,7 @@ start() {
         EXEC=${EXEC:-"-jar $JAR_FILE -e -f $FILENAME -s $SECONDS_BETWEEN_RUNS -c $CONTINUE_ON_ERROR"}
     fi
 
-    $JAVA -server $JAVA_OPTS $JMXTRANS_OPTS $GC_OPTS $MONITOR_OPTS $EXEC >>$LOG_FILE 2>&1 &
+    nohup $JAVA -server $JAVA_OPTS $JMXTRANS_OPTS $GC_OPTS $MONITOR_OPTS $EXEC >>$LOG_FILE 2>&1 &
 
     if [ ! -z "$PIDFILE" ]; then
         echo $! > "$PIDFILE"


### PR DESCRIPTION
When using jmxtrans.sh in provisioning (like salt) it is executed by another forked command which results in the java process running but the parent process left behind as <defunct>.
