### PR TITLE
handle_no_jar_in_jmxtrans_init

### DIFF
--- a/jmxtrans.sh
+++ b/jmxtrans.sh
@@ -65,6 +65,11 @@ if [ "$CHECK_JAVA" == "true" ]; then
     fi
 fi
 
+if [ ! -f $JAR_FILE ]; then
+  echo "File not found - $JAR_FILE"
+  exit 1
+fi
+
 start() {
     if [ ! -z "$PIDFILE" ]; then
         if [ -r "$PIDFILE" ]; then


### PR DESCRIPTION
Handle the  not being found in terms of init not reporting success when 
the $JAR_FILE is not found.
Modified:
jmxtrans.sh
