### PR TITLE
Removed ant build from travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: java
 install: mvn dependency:go-offline -B -V
-before_script: sudo apt-get -y update && sudo apt-get -y install devscripts build-essential
-script:
-  - "ant debian"
-  - "mvn clean verify -B -V"
+script: "mvn clean verify -B -V"


### PR DESCRIPTION
Ant build is broken for the moment (need to update dependencies). It will be either completely removed in the future or fixed. At the moment, the feedback from Maven seems to be sufficient.
