### PR TITLE
fix rpm specs

### DIFF
--- a/rpm/SPECS/jmxtrans.spec
+++ b/rpm/SPECS/jmxtrans.spec
@@ -136,7 +136,7 @@ fi
 
 %files
 %defattr(-,root,root)
-%{_bindir}
+%{_bindir}/*
 %attr(0755, root,root)  %{_initrddir}/jmxtrans
 %attr(0644,root,root)   %{_systemdir}/jmxtrans.service
 #%config(noreplace)     %{_sysconfdir}/sysconfig/jmxtrans


### PR DESCRIPTION
Incorrect RPM specs lead to error while installing on CentOS 7:

`Transaction check error: file /usr/bin from install of jmxtrans-247-0.noarch conflicts with file from package filesystem-3.2-18.el7.x86_64`

This pull request solves the conflict by including contents of /usr/bin instead of the folder itself.
