### PR TITLE
Adding the ADDON_JARS option which is needed for weblogic client jars.

### DIFF
--- a/jmxtrans.conf
+++ b/jmxtrans.conf
@@ -1,0 +1,6 @@
+## Add configuration options here
+#
+# This is for Weblogic reporting it will use the WL_HOME environment variable 
+# which should be set and pointing to your Oracle WebLogic Server folder
+#
+#ADDON_JARS=$WL_HOME/server/lib/wljmxclient.jar

--- a/jmxtrans.sh
+++ b/jmxtrans.sh
@@ -20,6 +20,7 @@ LOG_DIR=${LOG_DIR:-"."}
 LOG_FILE=${LOG_FILE:-"/dev/null"}
 
 JAR_FILE=${JAR_FILE:-"jmxtrans-all.jar"}
+ADDON_JARS=${ADDON_JARS:-""}
 JSON_DIR=${JSON_DIR:-"."}
 SECONDS_BETWEEN_RUNS=${SECONDS_BETWEEN_RUNS:-"60"}
 HARDKILL_THRESHOLD=${HARDKILL_THRESHOLD:-60}
@@ -85,9 +86,9 @@ start() {
     fi
 
     if [ -z "$FILENAME" ]; then
-        EXEC=${EXEC:-"-jar $JAR_FILE -e -j $JSON_DIR -s $SECONDS_BETWEEN_RUNS -c $CONTINUE_ON_ERROR"}
+        EXEC=${EXEC:-"-classpath $JAR_FILE:$ADDON_JARS com.googlecode.jmxtrans.JmxTransformer -e -j $JSON_DIR -s $SECONDS_BETWEEN_RUNS -c $CONTINUE_ON_ERROR"}
     else
-        EXEC=${EXEC:-"-jar $JAR_FILE -e -f $FILENAME -s $SECONDS_BETWEEN_RUNS -c $CONTINUE_ON_ERROR"}
+        EXEC=${EXEC:-"-classpath $JAR_FILE:$ADDON_JARS com.googlecode.jmxtrans.JmxTransformer -e -f $FILENAME -s $SECONDS_BETWEEN_RUNS -c $CONTINUE_ON_ERROR"}
     fi
 
     nohup $JAVA -server $JAVA_OPTS $JMXTRANS_OPTS $GC_OPTS $MONITOR_OPTS $EXEC >>$LOG_FILE 2>&1 &


### PR DESCRIPTION
This is to support additional Jars that can be sent during execution of the jmxtrans. This is needed for weblogic connection as there is a proprietary jar that needs to be included for it to connect to a running weblogic server.

Sample weblogic connection
{  
   "servers":[  
      {  
    "host": "sfn.abc.com", 
        "port":7003, 
        "url": "service:jmx:t3://sfn.abc.com:7003/jndi/weblogic.management.mbeanservers.domainruntime", 
        "username": "weblogic",
        "password": "dummyPass", 
        "protocolProviderPackages": "weblogic.management.remote", 
 ...
