### PR TITLE
Remvoed live check on Sockets.

### DIFF
--- a/src/com/googlecode/jmxtrans/connections/SocketFactory.java
+++ b/src/com/googlecode/jmxtrans/connections/SocketFactory.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.SocketTimeoutException;
 
 /**
  * Allows us to pool socket connections.
@@ -61,16 +60,6 @@ public class SocketFactory extends BaseKeyedPoolableObjectFactory<InetSocketAddr
 		}
 		if (socket.isOutputShutdown()) {
 			log.error("Socket output is shutdown [{}]", address);
-			return false;
-		}
-		// This is a slow test, let's at least put it last. Should probably be removed anyway.
-		try {
-			socket.setSoTimeout(100);
-			if (socket.getInputStream().read() == -1) {
-				return false;
-			}
-		} catch (SocketTimeoutException e) {
-		} catch (Exception e) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
This check is problematic as it waits 100[ms] for a timeout, which is a very, very long time once you have some traffic.

This PR might fix #123 andfix #190. Note the emphasis on the _might_. I've had similar problems with JMXTrans that have been fixed by removing this check, but I have not enough information on those issue to ensure this is the same problem.
