### PR TITLE
Make JMXConnectionParams.hashCode() and equals() robust to array environment values.

### DIFF
--- a/src/com/googlecode/jmxtrans/connections/JMXConnectionParams.java
+++ b/src/com/googlecode/jmxtrans/connections/JMXConnectionParams.java
@@ -1,10 +1,16 @@
 package com.googlecode.jmxtrans.connections;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import javax.management.remote.JMXServiceURL;
+import java.lang.reflect.Array;
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.lang.reflect.Array.getLength;
 
 /*
  * TODO This class has been extracted as a simple holder to break the
@@ -15,9 +21,9 @@ public class JMXConnectionParams {
 	private final JMXServiceURL url;
 	private final ImmutableMap<String, ?> environment;
 
-	public JMXConnectionParams(JMXServiceURL url, ImmutableMap<String, ?> environment) {
+	public JMXConnectionParams(JMXServiceURL url, Map<String, ?> environment) {
 		this.url = url;
-		this.environment = environment;
+		this.environment = ImmutableMap.copyOf(environment);
 	}
 
 	public JMXServiceURL getUrl() {
@@ -47,16 +53,51 @@ public class JMXConnectionParams {
 		JMXConnectionParams that = (JMXConnectionParams) o;
 
 		return new EqualsBuilder()
-				.append(this.environment, that.environment)
+				.append(convertArraysToLists(this.environment), convertArraysToLists(that.environment))
 				.append(this.url, that.url)
 				.isEquals();
+	}
+
+	/**
+	 * Convert values in a map to ensure all arrays are transformed to lists.
+	 *
+	 * This is an ugly workaround for https://github.com/jmxtrans/jmxtrans/issues/190. We need to ensure that
+	 * environments containing arrays of same values are treated as equals for the purpose of hashCode() and equals().
+	 */
+	private ImmutableMap<String, ?> convertArraysToLists(ImmutableMap<String, ?> map) {
+		ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+		for (Map.Entry<String, ?> entry : map.entrySet()) {
+			if (entry.getValue().getClass().isArray()) {
+				builder.put(entry.getKey(), asList(entry.getValue()));
+			} else {
+				builder.put(entry.getKey(), entry.getValue());
+			}
+		}
+		return builder.build();
+	}
+
+	private ImmutableList<?> asList(Object array) {
+		ImmutableList.Builder<Object> builder = ImmutableList.builder();
+		for (int i = 0; i < getLength(array); i++) {
+			builder.add(Array.get(array, i));
+		}
+		return builder.build();
 	}
 
 	@Override
 	public int hashCode() {
 		return new HashCodeBuilder(135, 211)
-				.append(this.environment)
+				.append(convertArraysToLists(this.environment))
 				.append(this.url)
 				.toHashCode();
 	}
+
+	@Override
+	public String toString() {
+		return toStringHelper(getClass())
+				.add("url", url)
+				.add("environment", environment)
+				.toString();
+	}
+
 }

--- a/test/com/googlecode/jmxtrans/connections/JmxConnectionParamsTests.java
+++ b/test/com/googlecode/jmxtrans/connections/JmxConnectionParamsTests.java
@@ -1,5 +1,6 @@
 package com.googlecode.jmxtrans.connections;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
@@ -99,6 +100,50 @@ public class JmxConnectionParamsTests {
 		JMXConnectionParams p2 = new JMXConnectionParams(
 				new JMXServiceURL(JMX_URL_2),
 				ImmutableMap.<String, Object>of());
+		assertThat(p1).isNotEqualTo(p2);
+	}
+
+	@Test
+	public void connectionParamsWithArrayAsEnvironmentValueAreEquals() throws MalformedURLException {
+		JMXConnectionParams p1 = new JMXConnectionParams(
+				new JMXServiceURL(JMX_URL),
+				ImmutableMap.of("test", new String[]{ "value" }));
+		JMXConnectionParams p2 = new JMXConnectionParams(
+				new JMXServiceURL(JMX_URL),
+				ImmutableMap.of("test", new String[]{ "value" }));
+		assertThat(p1).isEqualTo(p2);
+	}
+
+	@Test
+	public void connectionParamsWithDifferentArrayAsEnvironmentValueAreNotEquals() throws MalformedURLException {
+		JMXConnectionParams p1 = new JMXConnectionParams(
+				new JMXServiceURL(JMX_URL),
+				ImmutableMap.of("test", new String[]{ "value1" }));
+		JMXConnectionParams p2 = new JMXConnectionParams(
+				new JMXServiceURL(JMX_URL),
+				ImmutableMap.of("test", new String[]{ "value2" }));
+		assertThat(p1).isNotEqualTo(p2);
+	}
+
+	@Test
+	public void connectionParamsWithListsAsEnvironmentValueAreEquals() throws MalformedURLException {
+		JMXConnectionParams p1 = new JMXConnectionParams(
+				new JMXServiceURL(JMX_URL),
+				ImmutableMap.of("test", ImmutableList.of("value")));
+		JMXConnectionParams p2 = new JMXConnectionParams(
+				new JMXServiceURL(JMX_URL),
+				ImmutableMap.of("test", ImmutableList.of("value")));
+		assertThat(p1).isEqualTo(p2);
+	}
+
+	@Test
+	public void connectionParamsWithDifferentListsAsEnvironmentValueAreNotEquals() throws MalformedURLException {
+		JMXConnectionParams p1 = new JMXConnectionParams(
+				new JMXServiceURL(JMX_URL),
+				ImmutableMap.of("test", ImmutableList.of("value1")));
+		JMXConnectionParams p2 = new JMXConnectionParams(
+				new JMXServiceURL(JMX_URL),
+				ImmutableMap.of("test", ImmutableList.of("value2")));
 		assertThat(p1).isNotEqualTo(p2);
 	}
 


### PR DESCRIPTION
This is a very ugly workaround which fixes #190. To make sure arrays with same parameters are treated as equals, we convert them to lists in the hashCode and equals methods. We could improve performance by caching the result (environment is immutable) but as environment is expected to be small, the gain is probably not worth the additional complexity.

Feel free to propose a better approach (I'm not really happy with this one, but cannot find a better idea at the moment).
