### PR TITLE
map support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -594,6 +594,12 @@
 						<configuration>
 							<filters>
 								<filter>
+						<!-- 
+							Signature files from other jars, if included, prevent the "all" jar from starting with:
+							"java.lang.SecurityException: Invalid signature file digest for Manifest main attributes"
+							This filter excludes signatures files from other signed jars.
+							Specifically avoid including ECLISPE_.* from org.eclipse.jgit.
+						-->
 										<artifact>*:*</artifact>
 										<excludes>
 											<exclude>META-INF/*.SF</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -592,6 +592,16 @@
 						</goals>
 						<phase>package</phase>
 						<configuration>
+							<filters>
+								<filter>
+										<artifact>*:*</artifact>
+										<excludes>
+											<exclude>META-INF/*.SF</exclude>
+											<exclude>META-INF/*.DSA</exclude>
+											<exclude>META-INF/*.RSA</exclude>
+										</excludes>
+								</filter>
+							</filters>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
 							<shadedClassifierName>all</shadedClassifierName>
 							<transformers>

--- a/src/com/googlecode/jmxtrans/cli/CliArgumentParser.java
+++ b/src/com/googlecode/jmxtrans/cli/CliArgumentParser.java
@@ -89,7 +89,7 @@ public class CliArgumentParser {
 				.hasArgs()
 				.withValueSeparator(',')
 				.withDescription("Coma delimited list of additional jars to add to the class path")
-				.create());
+				.create("a"));
 		options.addOption("h", false, "Help");
 		return options;
 	}

--- a/src/com/googlecode/jmxtrans/jmx/JmxResultProcessor.java
+++ b/src/com/googlecode/jmxtrans/jmx/JmxResultProcessor.java
@@ -79,6 +79,11 @@ public class JmxResultProcessor {
 			Result r = getNewResultObject(attribute.getName(), values);
 			processTabularDataSupport(accumulator, attribute.getName(), tds);
 			accumulator.add(r);
+		}  else if (value instanceof Map) {
+			// should probably check the Map type before casting
+			Map<String,Object> values = (Map<String, Object>) value;
+			Result r = getNewResultObject(attribute.getName(), values);
+			accumulator.add(r);
 		} else {
 			Map<String, Object> values = newHashMap();
 			values.put(attribute.getName(), value);

--- a/src/com/googlecode/jmxtrans/jmx/JmxResultProcessor.java
+++ b/src/com/googlecode/jmxtrans/jmx/JmxResultProcessor.java
@@ -1,6 +1,7 @@
 package com.googlecode.jmxtrans.jmx;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 
@@ -80,9 +81,7 @@ public class JmxResultProcessor {
 			processTabularDataSupport(accumulator, attribute.getName(), tds);
 			accumulator.add(r);
 		}  else if (value instanceof Map) {
-			// should probably check the Map type before casting
-			Map<String,Object> values = (Map<String, Object>) value;
-			Result r = getNewResultObject(attribute.getName(), values);
+			Result r = getNewResultObject(attribute.getName(), convertKeysToString((Map<Object, Object>) value));
 			accumulator.add(r);
 		} else {
 			Map<String, Object> values = newHashMap();
@@ -90,6 +89,14 @@ public class JmxResultProcessor {
 			Result r = getNewResultObject(attribute.getName(), values);
 			accumulator.add(r);
 		}
+	}
+
+	private <K, V> ImmutableMap<String, V> convertKeysToString(Map<K, V> value) {
+		ImmutableMap.Builder<String, V> values = ImmutableMap.builder();
+		for (Map.Entry<K, V> entry : value.entrySet()) {
+			values.put(entry.getKey().toString(), entry.getValue());
+		}
+		return values.build();
 	}
 
 	/**

--- a/test/com/googlecode/jmxtrans/jmx/JmxResultProcessorTest.java
+++ b/test/com/googlecode/jmxtrans/jmx/JmxResultProcessorTest.java
@@ -3,6 +3,9 @@ package com.googlecode.jmxtrans.jmx;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,9 +22,6 @@ import javax.management.ReflectionException;
 import java.lang.management.ManagementFactory;
 import java.util.List;
 import java.util.Map;
-
-import com.googlecode.jmxtrans.model.Query;
-import com.googlecode.jmxtrans.model.Result;
 
 import static com.google.common.collect.FluentIterable.from;
 import static java.lang.Boolean.TRUE;
@@ -164,6 +164,42 @@ public class JmxResultProcessorTest {
 
 		Object objectValue = result.getValues().get("init");
 		assertThat(objectValue).isInstanceOf(Long.class);
+	}
+
+	@Test
+	public void canReadMapData() throws MalformedObjectNameException {
+		Attribute mapAttribute = new Attribute("map", ImmutableMap.of("key1", "value1", "key2", "value2"));
+
+		List<Result> results = new JmxResultProcessor(
+				query,
+				new ObjectInstance("java.lang:type=Memory", "java.lang.SomeClass"),
+				ImmutableList.of(mapAttribute),
+				"java.lang.SomeClass"
+		).getResults();
+
+		assertThat(results).isNotNull();
+		assertThat(results).hasSize(1);
+		Result result = results.get(0);
+		assertThat(result.getValues()).hasSize(2);
+		assertThat(result.getValues()).isEqualTo(ImmutableMap.of("key1", "value1", "key2", "value2"));
+	}
+
+	@Test
+	public void canReadMapDataWithNonStringKeys() throws MalformedObjectNameException {
+		Attribute mapAttribute = new Attribute("map", ImmutableMap.of(1, "value1", 2, "value2"));
+
+		List<Result> results = new JmxResultProcessor(
+				query,
+				new ObjectInstance("java.lang:type=Memory", "java.lang.SomeClass"),
+				ImmutableList.of(mapAttribute),
+				"java.lang.SomeClass"
+		).getResults();
+
+		assertThat(results).isNotNull();
+		assertThat(results).hasSize(1);
+		Result result = results.get(0);
+		assertThat(result.getValues()).hasSize(2);
+		assertThat(result.getValues()).isEqualTo(ImmutableMap.of("1", "value1", "2", "value2"));
 	}
 
 	public ObjectInstance getRuntime() throws MalformedObjectNameException, InstanceNotFoundException {


### PR DESCRIPTION
I have a jmx enabled application that returns a Map object as the attribute value and the final commit here simply passes the Map object to the getNewResultObject method

The other two commits reflect changes I needed in order to run the jar:
compiled on Windows 7 Java jdk1.7.0_09 mvn  3.0.5 
and run on CentOS release 6.6 (Final) java-1.7.0-openjdk-devel-1.7.0.71-2.5.3.2.el6_6.x86_64