### PR TITLE
Fix rpm build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1006,6 +1006,14 @@
 									</sources>
 								</mapping>
 								<mapping>
+									<directory>${package.install.dir}/tools</directory>
+									<sources>
+										<source>
+											<location>${project.basedir}/tools</location>
+										</source>
+									</sources>
+								</mapping>
+								<mapping>
 									<directory>/usr/bin</directory>
 									<directoryIncluded>false</directoryIncluded>
 									<filemode>755</filemode>

--- a/pom.xml
+++ b/pom.xml
@@ -1007,6 +1007,7 @@
 								</mapping>
 								<mapping>
 									<directory>/usr/bin</directory>
+									<directoryIncluded>false</directoryIncluded>
 									<filemode>755</filemode>
 									<sources>
 										<source>


### PR DESCRIPTION
1. Do not attempt to create `/usr/bin` directory to avoid conflict with `filesystem` package on RHEL7 / CentOS7. See #176 (fixed the same problem for ant build).
2. Include `tools` directory with `yaml2jmxtrans.py` script.