### PR TITLE
Add allowDottedKeys option to config converter

### DIFF
--- a/tools/yaml2jmxtrans.py
+++ b/tools/yaml2jmxtrans.py
@@ -217,7 +217,7 @@ def usage():
 
 if __name__ == '__main__':
     # query attributes to copy
-    query_attributes = ["obj", "resultAlias", "attr", "typeName"]
+    query_attributes = ["obj", "resultAlias", "attr", "typeName", "allowDottedKeys"]
     outputWriters_attributes = ["settings", "@class"]
     
     if len(sys.argv) != 2:


### PR DESCRIPTION
This recent feature is missing from `yaml2jmxtrans.py` script.