### PR TITLE
Fix logging issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: java
-install: mvn compile -DskipTests=true -Dmaven.javadoc.skip=true -Dcobertura.skip=true -B -V
-before_script: "git clone -b travis `git config --get remote.origin.url` target/travis"
-script: mvn verify -B -V -PwithMutationTests
+before_install: "git clone -b travis `git config --get remote.origin.url` target/travis"
+install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y rpm
+  - mvn compile -DskipTests=true -Dmaven.javadoc.skip=true -Dcobertura.skip=true -B -V
+script: ./travis-script.sh
 after_success:
   - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && mvn site --settings target/travis/settings.xml -B -V
 branches:
@@ -11,3 +14,5 @@ branches:
 env:
   global:
     - secure: "J+lRFlE7ISkg362ROM7TeEg2+C8YGM0H4pimlEaf6g9e7QiT4zidpDxH6v9cOHl7B5hFiZ8K6CizfBpwq5AFrWfpPCO22VZMj4oX6tAKsD6AEeDt6x8dxcpx0aiRYrwnARKCucPnLCLWKSEor3BkO+v8LHAw9YMGOk770B64hIs="
+    - secure: "Z3Jt5wCnci0Tbd+9gf2upWgRcicaOEZKtZGRMz0ig6CwIhPJYvxizXfLPEW4UKTAtg52Vo+zl6zQmSiIOeEbzDlqd8QHWdkx9ViWiu5knOMVzn0K50UyZ0t71Jl2fwH+B/lm0tsH7Y0Z4KReQaWm1PfScVN84zsr3yMKFBxoflM="
+    - secure: "WLJ+rQHfCpRKNrK7ektVzxTk67cPJ3//9p7UVJhGQdcx1aTbIwcqiEUJCq84I+NIctx3Ks7madZbTIDJRX14uCOcFT2+9qjwc6S+ju3cxA+7t5R51fMk40DtQdOTyFtO9tHmX/jRKTLGMSigWObmChHyyvRUfMwXWQGdj/zr36s="

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
 		<version>9</version>
 	</parent>
 
-	<groupId>org.jmxtrans.jmxtrans</groupId>
+	<groupId>org.jmxtrans</groupId>
 	<artifactId>jmxtrans</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>247-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>jmxtrans</name>
 	<description>JMX metrics exporter</description>
@@ -60,6 +60,17 @@
 		<tag>HEAD</tag>
 		<url>https://github.com/jmxtrans/jmxtrans</url>
 	</scm>
+
+	<distributionManagement>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+		</repository>
+		<snapshotRepository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+	</distributionManagement>
 
 	<properties>
 		<!--
@@ -425,6 +436,20 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>1.6</version>
+					<executions>
+						<execution>
+							<id>sign-artifacts</id>
+							<goals>
+								<goal>sign</goal>
+							</goals>
+							<phase>verify</phase>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-install-plugin</artifactId>
 					<version>2.5.2</version>
 				</plugin>
@@ -437,6 +462,9 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
 					<version>2.5.1</version>
+					<configuration>
+						<releaseProfiles>gpg</releaseProfiles>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -452,6 +480,19 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-site-plugin</artifactId>
 					<version>3.4</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>2.2.1</version>
+					<executions>
+						<execution>
+							<id>attach-sources</id>
+							<goals>
+								<goal>jar-no-fork</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -483,6 +524,17 @@
 					<artifactId>pitest-maven</artifactId>
 					<version>1.1.2</version>
 				</plugin>
+				<plugin>
+					<groupId>org.sonatype.plugins</groupId>
+					<artifactId>nexus-staging-maven-plugin</artifactId>
+					<version>1.6.5</version>
+					<extensions>true</extensions>
+					<configuration>
+						<serverId>ossrh</serverId>
+						<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+						<autoReleaseAfterClose>true</autoReleaseAfterClose>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -492,8 +544,7 @@
 				<artifactId>site-maven-plugin</artifactId>
 				<configuration>
 					<message>Creating site for ${project.name}
-						${project.version}
-					</message>
+						${project.version}</message>
 				</configuration>
 				<executions>
 					<execution>
@@ -581,6 +632,24 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.10.1</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -594,18 +663,18 @@
 						<configuration>
 							<filters>
 								<filter>
-						<!-- 
-							Signature files from other jars, if included, prevent the "all" jar from starting with:
-							"java.lang.SecurityException: Invalid signature file digest for Manifest main attributes"
-							This filter excludes signatures files from other signed jars.
-							Specifically avoid including ECLISPE_.* from org.eclipse.jgit.
-						-->
-										<artifact>*:*</artifact>
-										<excludes>
-											<exclude>META-INF/*.SF</exclude>
-											<exclude>META-INF/*.DSA</exclude>
-											<exclude>META-INF/*.RSA</exclude>
-										</excludes>
+									<!--
+										Signature files from other jars, if included, prevent the "all" jar from starting with:
+										"java.lang.SecurityException: Invalid signature file digest for Manifest main attributes"
+										This filter excludes signatures files from other signed jars.
+										Specifically avoid including ECLISPE_.* from org.eclipse.jgit.
+									-->
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
 								</filter>
 							</filters>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
@@ -618,6 +687,10 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
 
 			<?SORTPOM IGNORE?>
@@ -774,7 +847,7 @@
 						<mutator>CONSTRUCTOR_CALLS</mutator>
 					</mutators>
 					<mutationThreshold>26</mutationThreshold>
-					<coverageThreshold>83</coverageThreshold>
+					<coverageThreshold>80</coverageThreshold>
 					<historyInputFile>${project.basedir}/pitest-history.xml</historyInputFile>
 					<historyOutputFile>${project.build.directory}/pitest-history.xml</historyOutputFile>
 					<jvmArgs>
@@ -785,6 +858,10 @@
 					</targetClasses>
 					<timestampedReports>false</timestampedReports>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
 
@@ -959,8 +1036,8 @@
 							</defineStatements>
 							<preinstallScriptlet>
 								<script>if [ $1 = 1 ]; then
-										/usr/sbin/useradd -c "${project.name}" -s /bin/sh -r -d \
-										${package.install.dir} -U ${package.user}
+									/usr/sbin/useradd -c "${project.name}" -s /bin/sh -r -d \
+									${package.install.dir} -U ${package.user}
 									fi</script>
 							</preinstallScriptlet>
 							<postinstallScriptlet>
@@ -968,9 +1045,9 @@
 							</postinstallScriptlet>
 							<preremoveScriptlet>
 								<script>if [ $1 = 0 ]; then
-										/sbin/service ${package.daemon.name} stop
-										/sbin/chkconfig --del ${package.daemon.name}
-										/usr/sbin/userdel ${package.user}
+									/sbin/service ${package.daemon.name} stop
+									/sbin/chkconfig --del ${package.daemon.name}
+									/usr/sbin/userdel ${package.user}
 									fi</script>
 							</preremoveScriptlet>
 							<requires>
@@ -1063,6 +1140,17 @@
 								</goals>
 							</execution>
 						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>gpg</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
 					</plugin>
 				</plugins>
 			</build>

--- a/src/com/googlecode/jmxtrans/model/output/LibratoWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/LibratoWriter.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.Base64Variants;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -82,6 +83,9 @@ public class LibratoWriter extends BaseOutputWriter {
 	private final String proxyHost;
 	private final Integer proxyPort;
 	private Proxy proxy;
+	
+	@VisibleForTesting
+	final String httpUserAgent;
 
 	@JsonCreator
 	public LibratoWriter(
@@ -120,6 +124,11 @@ public class LibratoWriter extends BaseOutputWriter {
 		} else {
 			this.proxy = null;
 		}
+		this.httpUserAgent =
+				"jmxtrans-standalone/1 " + "(" +
+						System.getProperty("java.vm.name") + "/" + System.getProperty("java.version") + "; " +
+						System.getProperty("os.name") + "-" + System.getProperty("os.arch") + "/" + System.getProperty("os.version")
+						+ ")";
 	}
 
 	public void validateSetup(Server server, Query query) throws ValidationException {
@@ -188,6 +197,7 @@ public class LibratoWriter extends BaseOutputWriter {
 			urlConnection.setReadTimeout(libratoApiTimeoutInMillis);
 			urlConnection.setRequestProperty("content-type", "application/json; charset=utf-8");
 			urlConnection.setRequestProperty("Authorization", "Basic " + basicAuthentication);
+			urlConnection.setRequestProperty("User-Agent", httpUserAgent);
 
 			serialize(server, query, results, urlConnection.getOutputStream());
 			int responseCode = urlConnection.getResponseCode();

--- a/test/com/googlecode/jmxtrans/model/output/LibratoWriterTest.java
+++ b/test/com/googlecode/jmxtrans/model/output/LibratoWriterTest.java
@@ -1,0 +1,39 @@
+package com.googlecode.jmxtrans.model.output;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LibratoWriterTest {
+
+	@Test
+	public void httpUserAgentContainsAppropriateInformation() throws MalformedURLException {
+		LibratoWriter writer = new LibratoWriter(
+				ImmutableList.<String>of(),
+				false,
+				false,
+				new URL(LibratoWriter.DEFAULT_LIBRATO_API_URL),
+				1000,
+				"username",
+				"token",
+				null,
+				null,
+				ImmutableMap.<String, Object>of()
+		);
+
+		assertThat(writer.httpUserAgent)
+				.startsWith("jmxtrans-standalone/")
+				.contains(System.getProperty("os.name"))
+				.contains(System.getProperty("os.arch"))
+				.contains(System.getProperty("os.version"))
+				.contains(System.getProperty("java.vm.name"))
+				.contains(System.getProperty("java.version"));
+	}
+	
+
+}

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ev
+
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  if [ "$TRAVIS_BRANCH" == "master" ]; then
+    echo "Building master"
+    mvn deploy --settings target/travis/settings.xml -B -V -PwithMutationTests,rpm
+  else
+    echo "Building feature branch"
+    mvn verify --settings target/travis/settings.xml -B -V -PwithMutationTests
+  fi
+else
+  echo "Building pull request"
+  mvn verify --settings target/travis/settings.xml -B -V -PwithMutationTests
+fi


### PR DESCRIPTION
This fixes, closes issue #221 . 
We have both log4j and logback jars and looks like slf4j is hitting logback jar first(as classloader seems to be loading those before log4j). In this case logback ignore log4j.xml and uses default configuration where it spits out everything to console. Default console logger is synchronous and hence it could be performance issue as well if we are logging too much.

Logback has really cool features like ability to change log level at runtime using JMX (which is available in log4j2 but not in log4j)

I have put together logback.xml to mimic intending log configuration we were trying to achieve using log4j.xml, with some more added features like automatically delete log file more than 15 days old.