### PR TITLE
Cleanup allow dotted

### DIFF
--- a/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
@@ -34,7 +34,7 @@ public final class KeyUtils {
 		addMBeanIdentifier(query, result, sb);
 		sb.append(".");
 		addTypeName(query, result, typeNames, sb);
-		addKeyString(result, values, sb);
+		addKeyString(query, result, values, sb);
 		return sb.toString();
 	}
 
@@ -52,25 +52,7 @@ public final class KeyUtils {
 		addMBeanIdentifier(query, result, sb);
 		sb.append(".");
 		addTypeName(query, result, typeNames, sb);
-		addKeyString(result, values, sb);
-		return sb.toString();
-	}
-
-	/**
-	 * Gets the key string, with dot allowed
-	 *
-	 * @param query     the query
-	 * @param result    the result
-	 * @param values    the values
-	 * @param typeNames the type names
-	 * @return the key string
-	 */
-	public static String getKeyStringWithDottedKeys(Query query, Result result, Map.Entry<String, Object> values, List<String> typeNames) {
-		StringBuilder sb = new StringBuilder();
-		addMBeanIdentifier(query, result, sb);
-		sb.append(".");
-		addTypeName(query, result, typeNames, sb);
-		addKeyStringDotted(result, values, query.isAllowDottedKeys(), sb);
+		addKeyString(query, result, values, sb);
 		return sb.toString();
 	}
 
@@ -124,14 +106,9 @@ public final class KeyUtils {
 		}
 	}
 
-	private static void addKeyString(Result result, Map.Entry<String, Object> values, StringBuilder sb) {
+	private static void addKeyString(Query query, Result result, Map.Entry<String, Object> values, StringBuilder sb) {
 		String keyStr = computeKey(result, values);
-		sb.append(StringUtils.cleanupStr(keyStr));
-	}
-
-	private static void addKeyStringDotted(Result result, Map.Entry<String, Object> values, boolean isAllowDottedKeys, StringBuilder sb) {
-		String keyStr = computeKey(result, values);
-		sb.append(StringUtils.cleanupStr(keyStr, isAllowDottedKeys));
+		sb.append(StringUtils.cleanupStr(keyStr, query.isAllowDottedKeys()));
 	}
 
 	private static String computeKey(Result result, Map.Entry<String, Object> values) {

--- a/src/com/googlecode/jmxtrans/model/output/LibratoWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/LibratoWriter.java
@@ -156,7 +156,7 @@ public class LibratoWriter extends BaseOutputWriter {
 				for (Map.Entry<String, Object> values : resultValues.entrySet()) {
 					if (NumberUtils.isNumeric(values.getValue())) {
 						g.writeStartObject();
-						g.writeStringField("name", KeyUtils.getKeyStringWithDottedKeys(query, result, values, typeNames));
+						g.writeStringField("name", KeyUtils.getKeyString(query, result, values, typeNames));
 						if (source != null && !source.isEmpty()) {
 							g.writeStringField("source", source);
 						}

--- a/test/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
+++ b/test/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
@@ -97,6 +97,23 @@ public class GraphiteWriterTests {
 		// check that Graphite format is respected
 		assertThat(out.toString()).startsWith("servers.host_123.objDomain.attributeName_key 1 ");
 	}
+	
+	@Test
+	public void allowDottedWorks() throws Exception {
+		Server server = Server.builder().setHost("host").setPort("123").setAlias("host").build();
+		Query query = Query.builder().setAllowDottedKeys(true).build();
+		Result result = new Result(System.currentTimeMillis(), "attributeName", "className", "objDomain", null, "typeName", ImmutableMap.of("key", (Object)1));
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		
+		// Set useObjDomain to true
+		GraphiteWriter writer = getGraphiteWriter(out);
+
+		writer.doWrite(server, query, of(result));
+		System.out.println(out.toString());
+		// check that Graphite format is respected
+		assertThat(out.toString()).startsWith("servers.host.className.attributeName.key 1 ");
+	}
 
 
 	@Test


### PR DESCRIPTION
I noticed that the AllowDotted property was not being used consistently. Made a change so it is always used by Output classes that use the KeyUtils class.

I think it helps clean up the code a bit but also it's nice to have the AllowDotted property working when outputting graphite data.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/lookfirst%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/266%23issuecomment-92475163%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-04-13T19%3A44%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/266%23issuecomment-92475163%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/lookfirst'><img src='https://avatars.githubusercontent.com/u/85355?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/266?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/266?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/266'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>