### PR TITLE
Debug Statement to address issue #269

### DIFF
--- a/src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
@@ -113,9 +113,11 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 	@Override
 	protected void sendOutput(String metricLine) throws IOException {
 		try {
-			if(isDebugEnabled() || log.isDebugEnabled()){
-				log.debug("Sending to server {}:{} line={}", host,port,metricLine);
+			
+			if (isDebugEnabled() || log.isDebugEnabled()) {
+				log.debug("Sending to server {}:{} line={}", host, port,metricLine);
 			}
+			
 			this.out.writeBytes("put " + metricLine + "\n");
 		} catch (IOException e) {
 			log.error("error writing result to the output stream", e);

--- a/src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
@@ -115,7 +115,7 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 		try {
 			
 			if (isDebugEnabled() || log.isDebugEnabled()) {
-				log.debug("Sending to server {}:{} line={}", host, port,metricLine);
+				log.debug("Sending to server {}:{} line={}", host, port, metricLine);
 			}
 			
 			this.out.writeBytes("put " + metricLine + "\n");

--- a/src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
@@ -113,6 +113,9 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 	@Override
 	protected void sendOutput(String metricLine) throws IOException {
 		try {
+			if(isDebugEnabled()){
+				log.debug("Sending to server {}:{} line={}", host,port,metricLine);
+			}
 			this.out.writeBytes("put " + metricLine + "\n");
 		} catch (IOException e) {
 			log.error("error writing result to the output stream", e);

--- a/src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
@@ -113,7 +113,7 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 	@Override
 	protected void sendOutput(String metricLine) throws IOException {
 		try {
-			if(isDebugEnabled()){
+			if(isDebugEnabled() || log.isDebugEnabled()){
 				log.debug("Sending to server {}:{} line={}", host,port,metricLine);
 			}
 			this.out.writeBytes("put " + metricLine + "\n");


### PR DESCRIPTION
Added debug statement.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23issuecomment-93022069%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23discussion_r28359583%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23discussion_r28359602%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23discussion_r28363676%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23issuecomment-93054183%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23discussion_r28372111%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23discussion_r28372288%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23discussion_r28374038%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23discussion_r28374552%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23issuecomment-93022069%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Also%2C%20can%20you%20guys%20please%20update%20doc%20that%20OpenTSDB%20Writer%20does%20indeed%20work%20as%20expected%20with%20Kairosdb%20out-of-box.%20%20%5Cr%5Cn%5Cr%5CnHere%20is%20line%20protocol%20and%20it%20same%20as%20OpenTSDB%20%3A%5Cr%5Cnhttps%3A//github.com/kairosdb/kairosdb-client/blob/master/src/main/java/org/kairosdb/client/TelnetClient.java%23L49%5Cr%5Cn%5Cr%5CnAlso%2C%20%20what%20is%20process%20of%20updating%20this%20doc%20which%20can%20state%20this%20writer%20works%20for%20KairosDB%20as%20well.%5Cr%5Cnhttps%3A//github.com/jmxtrans/jmxtrans/wiki/OpenTSDBWriter%5Cr%5Cn%5Cr%5CnThanks%2C%5Cr%5CnBhavesh%20%22%2C%20%22created_at%22%3A%20%222015-04-14T19%3A06%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9261969%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bmistry13%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%20the%20following%20build%20issue%20be%20ignore%20for%20this%20check-in%20%3F%20%20I%20only%20added%20debug%20statement.%20GraphiteWriterTests.booleanAsNumberWorks%3A147%20%22%2C%20%22created_at%22%3A%20%222015-04-14T20%3A44%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9261969%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bmistry13%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e8d22631c21872610a969561a8ab5a4e678462a8%20src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23discussion_r28359583%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22minor%20nit.%20formatting%20please.%20%60if%20%28isDebugEnabled%28%29%20%7C%7C%20log.isDebugEnabled%28%29%29%20%7B%60%22%2C%20%22created_at%22%3A%20%222015-04-14T19%3A10%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40lookfirst%20%2C%5Cr%5Cn%5Cr%5CnThanks%20for%20feedback.%20I%20have%20fixed%20the%20formatting%20issue.%20%5Cr%5Cn%5Cr%5CnThanks%2C%5Cr%5CnBhavesh%22%2C%20%22created_at%22%3A%20%222015-04-14T19%3A52%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9261969%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bmistry13%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java%3AL113-122%22%7D%2C%20%22Pull%20e8d22631c21872610a969561a8ab5a4e678462a8%20src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23discussion_r28359602%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60log.debug%28%5C%22Sending%20to%20server%20%7B%7D%3A%7B%7D%20line%3D%7B%7D%5C%22%2C%20host%2C%20port%2C%20metricLine%29%3B%60%22%2C%20%22created_at%22%3A%20%222015-04-14T19%3A10%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java%3AL113-122%22%7D%2C%20%22Pull%2004896de52c2c5761f3c67e3a26aeeb5fa61313d7%20src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/270%23discussion_r28372111%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60log.debug%28%5C%22Sending%20to%20server%20%7B%7D%3A%7B%7D%20line%3D%7B%7D%5C%22%2C%20host%2C%20port%2CmetricLine%29%3B%60%5Cr%5Cn%5Cr%5CnStill%20missing%20a%20space%20between%20%60port%2C%20metricLine%60%22%2C%20%22created_at%22%3A%20%222015-04-14T21%3A22%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%20to%20be%20pedantic%20about%20it%2C%20but%20what%20if%20you%20were%20reading%20a%20book%20and%20the%20spacing%20was%20off%3F%20%3Awink%3A%20%22%2C%20%22created_at%22%3A%20%222015-04-14T21%3A24%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20agreed%20with%20you.%20%20It%20is%20finally%20fixed%20%21%20%20Do%20you%20have%20any%20suggestion%20on%20how%20eclipse%20template%20that%20auto%20correct%20this%20kind%20of%20stuff%20%3F%20%20Just%20asking%20so%20cmd%20%2B%20f%20will%20auto%20fix%20this.%5Cr%5Cn%5Cr%5CnThanks%2C%5Cr%5CnBhavesh%20%22%2C%20%22created_at%22%3A%20%222015-04-14T21%3A45%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9261969%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bmistry13%22%7D%7D%2C%20%7B%22body%22%3A%20%22Stop%20using%20Eclipse%20immediately%20and%20switch%20to%20Intellij.%20It%20is%20a%20far%20better%20IDE.%20%3D%29%20I%20know%20that%20isn%27t%20what%20you%20want%20to%20hear%2C%20but%20trust%20me%20on%20this%20one...%20you%20won%27t%20look%20back.%22%2C%20%22created_at%22%3A%20%222015-04-14T21%3A51%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java%3AL113-124%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/270#issuecomment-93022069'>General Comment</a></b>
- <a href='https://github.com/bmistry13'><img border=0 src='https://avatars.githubusercontent.com/u/9261969?v=3' height=16 width=16'></a> Also, can you guys please update doc that OpenTSDB Writer does indeed work as expected with Kairosdb out-of-box.
Here is line protocol and it same as OpenTSDB :
https://github.com/kairosdb/kairosdb-client/blob/master/src/main/java/org/kairosdb/client/TelnetClient.java#L49
Also,  what is process of updating this doc which can state this writer works for KairosDB as well.
https://github.com/jmxtrans/jmxtrans/wiki/OpenTSDBWriter
Thanks,
Bhavesh
- <a href='https://github.com/bmistry13'><img border=0 src='https://avatars.githubusercontent.com/u/9261969?v=3' height=16 width=16'></a> Can the following build issue be ignore for this check-in ?  I only added debug statement. GraphiteWriterTests.booleanAsNumberWorks:147
- [x] <a href='#crh-comment-Pull e8d22631c21872610a969561a8ab5a4e678462a8 src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/270#discussion_r28359583'>File: src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java:L113-122</a></b>
- <a href='https://github.com/lookfirst'><img border=0 src='https://avatars.githubusercontent.com/u/85355?v=3' height=16 width=16'></a> minor nit. formatting please. `if (isDebugEnabled() || log.isDebugEnabled()) {`
- <a href='https://github.com/bmistry13'><img border=0 src='https://avatars.githubusercontent.com/u/9261969?v=3' height=16 width=16'></a> @lookfirst ,
Thanks for feedback. I have fixed the formatting issue.
Thanks,
Bhavesh
- [x] <a href='#crh-comment-Pull e8d22631c21872610a969561a8ab5a4e678462a8 src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/270#discussion_r28359602'>File: src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java:L113-122</a></b>
- <a href='https://github.com/lookfirst'><img border=0 src='https://avatars.githubusercontent.com/u/85355?v=3' height=16 width=16'></a> `log.debug("Sending to server {}:{} line={}", host, port, metricLine);`
- [ ] <a href='#crh-comment-Pull 04896de52c2c5761f3c67e3a26aeeb5fa61313d7 src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/270#discussion_r28372111'>File: src/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java:L113-124</a></b>
- <a href='https://github.com/lookfirst'><img border=0 src='https://avatars.githubusercontent.com/u/85355?v=3' height=16 width=16'></a> `log.debug("Sending to server {}:{} line={}", host, port,metricLine);`
Still missing a space between `port, metricLine`
- <a href='https://github.com/lookfirst'><img border=0 src='https://avatars.githubusercontent.com/u/85355?v=3' height=16 width=16'></a> Sorry to be pedantic about it, but what if you were reading a book and the spacing was off? :wink:
- <a href='https://github.com/bmistry13'><img border=0 src='https://avatars.githubusercontent.com/u/9261969?v=3' height=16 width=16'></a> I agreed with you.  It is finally fixed !  Do you have any suggestion on how eclipse template that auto correct this kind of stuff ?  Just asking so cmd + f will auto fix this.
Thanks,
Bhavesh
- <a href='https://github.com/lookfirst'><img border=0 src='https://avatars.githubusercontent.com/u/85355?v=3' height=16 width=16'></a> Stop using Eclipse immediately and switch to Intellij. It is a far better IDE. =) I know that isn't what you want to hear, but trust me on this one... you won't look back.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/270?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/270?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/270'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>