### PR TITLE
Stop empty strings appearing in output

### DIFF
--- a/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
@@ -81,7 +81,7 @@ public final class KeyUtils {
 	 * 
 	 * 1. resultAlias if that was specified as part of the query
 	 * 2. The domain portion of the ObjectName in the query if useObjDomainAsKey is set to true
-	 * 3. else, the Class Name of the MBean. I.e. ClassName will be used by default if the
+	 * 3. else, the Class Name of the MBean. I.e. ClassName will be used by default if the 
 	 * user doesn't specify anything special
 	 * 
 	 * @param result

--- a/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
@@ -13,255 +13,255 @@ import com.googlecode.jmxtrans.model.Server;
 import static com.google.common.collect.Maps.newHashMap;
 
 public final class KeyUtils {
-    private KeyUtils() {}
-    /**
-     * Gets the key string.
-     *
-     *
-     * @param server
-     * @param query      the query
-     * @param result     the result
-     * @param values     the values
-     * @param typeNames  the type names
-     * @param rootPrefix the root prefix
-     * @return the key string
-     */
-    public static String getKeyString(Server server, Query query, Result result, Map.Entry<String, Object> values, List<String> typeNames, String rootPrefix) {
-        StringBuilder sb = new StringBuilder();
-        addRootPrefix(rootPrefix, sb);
-        addAlias(server, sb);
-        sb.append(".");
-        addMBeanIdentifier(query, result, sb);
-        sb.append(".");
-        addTypeName(query, result, typeNames, sb);
-        addKeyString(query, result, values, sb);
-        return sb.toString();
-    }
+	private KeyUtils() {}
+	/**
+	 * Gets the key string.
+	 *
+	 *
+	 * @param server
+	 * @param query      the query
+	 * @param result     the result
+	 * @param values     the values
+	 * @param typeNames  the type names
+	 * @param rootPrefix the root prefix
+	 * @return the key string
+	 */
+	public static String getKeyString(Server server, Query query, Result result, Map.Entry<String, Object> values, List<String> typeNames, String rootPrefix) {
+		StringBuilder sb = new StringBuilder();
+		addRootPrefix(rootPrefix, sb);
+		addAlias(server, sb);
+		sb.append(".");
+		addMBeanIdentifier(query, result, sb);
+		sb.append(".");
+		addTypeName(query, result, typeNames, sb);
+		addKeyString(query, result, values, sb);
+		return sb.toString();
+	}
 
-    /**
-     * Gets the key string, without rootPrefix nor Alias
-     *
-     * @param query     the query
-     * @param result    the result
-     * @param values    the values
-     * @param typeNames the type names
-     * @return the key string
-     */
-    public static String getKeyString(Query query, Result result, Map.Entry<String, Object> values, List<String> typeNames) {
-        StringBuilder sb = new StringBuilder();
-        addMBeanIdentifier(query, result, sb);
-        sb.append(".");
-        addTypeName(query, result, typeNames, sb);
-        addKeyString(query, result, values, sb);
-        return sb.toString();
-    }
+	/**
+	 * Gets the key string, without rootPrefix nor Alias
+	 *
+	 * @param query     the query
+	 * @param result    the result
+	 * @param values    the values
+	 * @param typeNames the type names
+	 * @return the key string
+	 */
+	public static String getKeyString(Query query, Result result, Map.Entry<String, Object> values, List<String> typeNames) {
+		StringBuilder sb = new StringBuilder();
+		addMBeanIdentifier(query, result, sb);
+		sb.append(".");
+		addTypeName(query, result, typeNames, sb);
+		addKeyString(query, result, values, sb);
+		return sb.toString();
+	}
 
-    private static void addRootPrefix(String rootPrefix, StringBuilder sb) {
-        if (rootPrefix != null) {
-            sb.append(rootPrefix);
-            sb.append(".");
-        }
-    }
+	private static void addRootPrefix(String rootPrefix, StringBuilder sb) {
+		if (rootPrefix != null) {
+			sb.append(rootPrefix);
+			sb.append(".");
+		}
+	}
 
-    private static void addAlias(Server server, StringBuilder sb) {
-        String alias;
-        if (server.getAlias() != null) {
-            alias = server.getAlias();
-        } else {
-            alias = server.getHost() + "_" + server.getPort();
-            alias = StringUtils.cleanupStr(alias);
-        }
-        sb.append(alias);
-    }
+	private static void addAlias(Server server, StringBuilder sb) {
+		String alias;
+		if (server.getAlias() != null) {
+			alias = server.getAlias();
+		} else {
+			alias = server.getHost() + "_" + server.getPort();
+			alias = StringUtils.cleanupStr(alias);
+		}
+		sb.append(alias);
+	}
 
-    /**
-     * Adds a key to the StringBuilder
-     *
-     * It uses in order of preference:
-     *
-     * 1. resultAlias if that was specified as part of the query
-     * 2. The domain portion of the ObjectName in the query if useObjDomainAsKey is set to true
-     * 3. else, the Class Name of the MBean. I.e. ClassName will be used by default if the
-     * user doesn't specify anything special
-     *
-     * @param result
-     * @param sb
-     * @param useObjectDomain
-     */
-    private static void addMBeanIdentifier(Query query, Result result, StringBuilder sb) {
-        if (result.getKeyAlias() != null) {
-            sb.append(result.getKeyAlias());
-        } else if (query.isUseObjDomainAsKey()) {
-            sb.append(StringUtils.cleanupStr(result.getObjDomain(), query.isAllowDottedKeys()));
-        } else {
-            sb.append(StringUtils.cleanupStr(result.getClassName()));
-        }
-    }
+	/**
+	 * Adds a key to the StringBuilder
+	 *
+	 * It uses in order of preference:
+	 *
+	 * 1. resultAlias if that was specified as part of the query
+	 * 2. The domain portion of the ObjectName in the query if useObjDomainAsKey is set to true
+	 * 3. else, the Class Name of the MBean. I.e. ClassName will be used by default if the
+	 * user doesn't specify anything special
+	 *
+	 * @param result
+	 * @param sb
+	 * @param useObjectDomain
+	 */
+	private static void addMBeanIdentifier(Query query, Result result, StringBuilder sb) {
+		if (result.getKeyAlias() != null) {
+			sb.append(result.getKeyAlias());
+		} else if (query.isUseObjDomainAsKey()) {
+			sb.append(StringUtils.cleanupStr(result.getObjDomain(), query.isAllowDottedKeys()));
+		} else {
+			sb.append(StringUtils.cleanupStr(result.getClassName()));
+		}
+	}
 
-    private static void addTypeName(Query query, Result result, List<String> typeNames, StringBuilder sb) {
-        String typeName = StringUtils.cleanupStr(getConcatedTypeNameValues(query, typeNames, result.getTypeName()), query.isAllowDottedKeys());
-        if (typeName != null && typeName.length() > 0) {
-            sb.append(typeName);
-            sb.append(".");
-        }
-    }
+	private static void addTypeName(Query query, Result result, List<String> typeNames, StringBuilder sb) {
+		String typeName = StringUtils.cleanupStr(getConcatedTypeNameValues(query, typeNames, result.getTypeName()), query.isAllowDottedKeys());
+		if (typeName != null && typeName.length() > 0) {
+			sb.append(typeName);
+			sb.append(".");
+		}
+	}
 
-    private static void addKeyString(Query query, Result result, Map.Entry<String, Object> values, StringBuilder sb) {
-        String keyStr = computeKey(result, values);
-        sb.append(StringUtils.cleanupStr(keyStr, query.isAllowDottedKeys()));
-    }
+	private static void addKeyString(Query query, Result result, Map.Entry<String, Object> values, StringBuilder sb) {
+		String keyStr = computeKey(result, values);
+		sb.append(StringUtils.cleanupStr(keyStr, query.isAllowDottedKeys()));
+	}
 
-    private static String computeKey(Result result, Map.Entry<String, Object> values) {
-        String keyStr;
-        if (values.getKey().startsWith(result.getAttributeName())) {
-            keyStr = values.getKey();
-        } else {
-            keyStr = result.getAttributeName() + "." + values.getKey();
-        }
-        return keyStr;
-    }
+	private static String computeKey(Result result, Map.Entry<String, Object> values) {
+		String keyStr;
+		if (values.getKey().startsWith(result.getAttributeName())) {
+			keyStr = values.getKey();
+		} else {
+			keyStr = result.getAttributeName() + "." + values.getKey();
+		}
+		return keyStr;
+	}
 
-    /**
-     * Given a typeName string, get the first match from the typeNames setting.
-     * In other words, suppose you have:
-     * <p/>
-     * typeName=name=PS Eden Space,type=MemoryPool
-     * <p/>
-     * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
-     * string
-     *
-     * @param typeNames   the type names
-     * @param typeNameStr the type name str
-     * @return the concated type name values
-     */
-    public static String getConcatedTypeNameValues(List<String> typeNames, String typeNameStr) {
-        return getConcatedTypeNameValues(typeNames, typeNameStr, getTypeNameValuesSeparator(null));
-    }
+	/**
+	 * Given a typeName string, get the first match from the typeNames setting.
+	 * In other words, suppose you have:
+	 * <p/>
+	 * typeName=name=PS Eden Space,type=MemoryPool
+	 * <p/>
+	 * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
+	 * string
+	 *
+	 * @param typeNames   the type names
+	 * @param typeNameStr the type name str
+	 * @return the concated type name values
+	 */
+	public static String getConcatedTypeNameValues(List<String> typeNames, String typeNameStr) {
+		return getConcatedTypeNameValues(typeNames, typeNameStr, getTypeNameValuesSeparator(null));
+	}
 
-    /**
-     * Given a typeName string, get the first match from the typeNames setting.
-     * In other words, suppose you have:
-     * <p/>
-     * typeName=name=PS Eden Space,type=MemoryPool
-     * <p/>
-     * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
-     * string
-     *
-     * @param typeNames   the type names
-     * @param typeNameStr the type name str
-     * @param separator
-     * @return the concated type name values
-     */
-    public static String getConcatedTypeNameValues(List<String> typeNames, String typeNameStr, String separator) {
-        if ((typeNames == null) || (typeNames.size() == 0)) {
-            return null;
-        }
-        Map<String, String> typeNameValueMap = getTypeNameValueMap(typeNameStr);
-        StringBuilder sb = new StringBuilder();
-        for (String key : typeNames) {
-            String result = typeNameValueMap.get(key);
-            if (result != null) {
-                sb.append(result);
-                sb.append(separator);
-            }
-        }
-        return org.apache.commons.lang.StringUtils.chomp(sb.toString(), separator);
-    }
+	/**
+	 * Given a typeName string, get the first match from the typeNames setting.
+	 * In other words, suppose you have:
+	 * <p/>
+	 * typeName=name=PS Eden Space,type=MemoryPool
+	 * <p/>
+	 * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
+	 * string
+	 *
+	 * @param typeNames   the type names
+	 * @param typeNameStr the type name str
+	 * @param separator
+	 * @return the concated type name values
+	 */
+	public static String getConcatedTypeNameValues(List<String> typeNames, String typeNameStr, String separator) {
+		if ((typeNames == null) || (typeNames.size() == 0)) {
+			return null;
+		}
+		Map<String, String> typeNameValueMap = getTypeNameValueMap(typeNameStr);
+		StringBuilder sb = new StringBuilder();
+		for (String key : typeNames) {
+			String result = typeNameValueMap.get(key);
+			if (result != null) {
+				sb.append(result);
+				sb.append(separator);
+			}
+		}
+		return org.apache.commons.lang.StringUtils.chomp(sb.toString(), separator);
+	}
 
-    /**
-     * Given a typeName string, create a Map with every key and value in the typeName.
-     * For example:
-     * <p/>
-     * typeName=name=PS Eden Space,type=MemoryPool
-     * <p/>
-     * Returns a Map with the following key/value pairs (excluding the quotes):
-     * <p/>
-     * "name"  =>  "PS Eden Space"
-     * "type"  =>  "MemoryPool"
-     *
-     * @param typeNameStr the type name str
-     * @return Map<String, String> of type-name-key / value pairs.
-     */
-    public static Map<String, String> getTypeNameValueMap(String typeNameStr) {
-        if (typeNameStr == null) {
-            return Collections.emptyMap();
-        }
+	/**
+	 * Given a typeName string, create a Map with every key and value in the typeName.
+	 * For example:
+	 * <p/>
+	 * typeName=name=PS Eden Space,type=MemoryPool
+	 * <p/>
+	 * Returns a Map with the following key/value pairs (excluding the quotes):
+	 * <p/>
+	 * "name"  =>  "PS Eden Space"
+	 * "type"  =>  "MemoryPool"
+	 *
+	 * @param typeNameStr the type name str
+	 * @return Map<String, String> of type-name-key / value pairs.
+	 */
+	public static Map<String, String> getTypeNameValueMap(String typeNameStr) {
+		if (typeNameStr == null) {
+			return Collections.emptyMap();
+		}
 
-        Map<String, String> result = newHashMap();
-        String[] tokens = typeNameStr.split(",");
+		Map<String, String> result = newHashMap();
+		String[] tokens = typeNameStr.split(",");
 
-        for (String oneToken : tokens) {
-            if (oneToken.length() > 0) {
-                String[] keyValue = splitTypeNameValue(oneToken);
-                result.put(keyValue[0], keyValue[1]);
-            }
-        }
-        return result;
-    }
+		for (String oneToken : tokens) {
+			if (oneToken.length() > 0) {
+				String[] keyValue = splitTypeNameValue(oneToken);
+				result.put(keyValue[0], keyValue[1]);
+			}
+		}
+		return result;
+	}
 
-    /**
-     * Given a typeName string, get the first match from the typeNames setting.
-     * In other words, suppose you have:
-     * <p/>
-     * typeName=name=PS Eden Space,type=MemoryPool
-     * <p/>
-     * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
-     * string
-     *
-     * @param query     the query
-     * @param typeNames the type names
-     * @param typeName  the type name
-     * @return the concated type name values
-     */
-    public static String getConcatedTypeNameValues(Query query, List<String> typeNames, String typeName) {
-        Set<String> queryTypeNames = query.getTypeNames();
-        if (queryTypeNames != null && queryTypeNames.size() > 0) {
-            List<String> filteredTypeNames = new ArrayList<String>(queryTypeNames);
-            for (String name : typeNames) {
-                if (!filteredTypeNames.contains(name)) {
-                    filteredTypeNames.add(name);
-                }
-            }
-            return getConcatedTypeNameValues(filteredTypeNames, typeName, getTypeNameValuesSeparator(query));
-        } else {
-            return getConcatedTypeNameValues(typeNames, typeName, getTypeNameValuesSeparator(query));
-        }
-    }
+	/**
+	 * Given a typeName string, get the first match from the typeNames setting.
+	 * In other words, suppose you have:
+	 * <p/>
+	 * typeName=name=PS Eden Space,type=MemoryPool
+	 * <p/>
+	 * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
+	 * string
+	 *
+	 * @param query     the query
+	 * @param typeNames the type names
+	 * @param typeName  the type name
+	 * @return the concated type name values
+	 */
+	public static String getConcatedTypeNameValues(Query query, List<String> typeNames, String typeName) {
+		Set<String> queryTypeNames = query.getTypeNames();
+		if (queryTypeNames != null && queryTypeNames.size() > 0) {
+			List<String> filteredTypeNames = new ArrayList<String>(queryTypeNames);
+			for (String name : typeNames) {
+				if (!filteredTypeNames.contains(name)) {
+					filteredTypeNames.add(name);
+				}
+			}
+			return getConcatedTypeNameValues(filteredTypeNames, typeName, getTypeNameValuesSeparator(query));
+		} else {
+			return getConcatedTypeNameValues(typeNames, typeName, getTypeNameValuesSeparator(query));
+		}
+	}
 
-    /**
-     * Given a query, return a separator for type names based on its configuration.
-     * If query is null, return the default separator.
-     *
-     * @param query   the query
-     * @return the separator
-     */
-    private static String getTypeNameValuesSeparator(Query query) {
-        if (query != null && query.isAllowDottedKeys()) {
-            return ".";
-        }
-        return "_";
-    }
+	/**
+	 * Given a query, return a separator for type names based on its configuration.
+	 * If query is null, return the default separator.
+	 *
+	 * @param query   the query
+	 * @return the separator
+	 */
+	private static String getTypeNameValuesSeparator(Query query) {
+		if (query != null && query.isAllowDottedKeys()) {
+			return ".";
+		}
+		return "_";
+	}
 
-    /**
-     * Given a single type-name-key and value from a typename strig (e.g. "type=MemoryPool"), extract the key and
-     * the value and return both.
-     *
-     * @param typeNameToken - the string containing the pair.
-     * @return String[2] where String[0] = the key and String[1] = the value.  If the given string is not in the
-     * format "key=value" then String[0] = the original string and String[1] = "".
-     */
-    private static String[] splitTypeNameValue(String typeNameToken) {
-        String[] result;
-        String[] keys = typeNameToken.split("=", 2);
+	/**
+	 * Given a single type-name-key and value from a typename strig (e.g. "type=MemoryPool"), extract the key and
+	 * the value and return both.
+	 *
+	 * @param typeNameToken - the string containing the pair.
+	 * @return String[2] where String[0] = the key and String[1] = the value.  If the given string is not in the
+	 * format "key=value" then String[0] = the original string and String[1] = "".
+	 */
+	private static String[] splitTypeNameValue(String typeNameToken) {
+		String[] result;
+		String[] keys = typeNameToken.split("=", 2);
 
-        if (keys.length == 2) {
-            result = keys;
-        } else {
-            result = new String[2];
-            result[0] = keys[0];
-            result[1] = "";
-        }
+		if (keys.length == 2) {
+			result = keys;
+		} else {
+			result = new String[2];
+			result[0] = keys[0];
+			result[1] = "";
+		}
 
-        return result;
-    }
+		return result;
+	}
 }

--- a/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
@@ -193,9 +193,9 @@ public final class KeyUtils {
         for (String oneToken : tokens) {
             if (oneToken.length() > 0) {
                 String[] keyValue = splitTypeNameValue(oneToken);
-                    result.put(keyValue[0], keyValue[1]);
-                }
+                result.put(keyValue[0], keyValue[1]);
             }
+        }
         return result;
     }
 
@@ -253,9 +253,6 @@ public final class KeyUtils {
     private static String[] splitTypeNameValue(String typeNameToken) {
         String[] result;
         String[] keys = typeNameToken.split("=", 2);
-
-        for (int i=0; i<keys.length; i++) {
-        }
 
         if (keys.length == 2) {
             result = keys;

--- a/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
@@ -76,14 +76,14 @@ public final class KeyUtils {
 
 	/**
 	 * Adds a key to the StringBuilder
-	 * 
+	 *
 	 * It uses in order of preference:
-	 * 
+	 *
 	 * 1. resultAlias if that was specified as part of the query
 	 * 2. The domain portion of the ObjectName in the query if useObjDomainAsKey is set to true
-	 * 3. else, the Class Name of the MBean. I.e. ClassName will be used by default if the 
+	 * 3. else, the Class Name of the MBean. I.e. ClassName will be used by default if the
 	 * user doesn't specify anything special
-	 * 
+	 *
 	 * @param result
 	 * @param sb
 	 * @param useObjectDomain
@@ -160,7 +160,7 @@ public final class KeyUtils {
 		StringBuilder sb = new StringBuilder();
 		for (String key : typeNames) {
 			String result = typeNameValueMap.get(key);
-			if (result != null) {
+			if (result != null && !StringUtils.isBlank(result)) {
 				sb.append(result);
 				sb.append(separator);
 			}

--- a/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
@@ -160,7 +160,7 @@ public final class KeyUtils {
 		StringBuilder sb = new StringBuilder();
 		for (String key : typeNames) {
 			String result = typeNameValueMap.get(key);
-			if (result != null && !StringUtils.isBlank(result)) {
+			if (result != null && !result.isEmpty()) {
 				sb.append(result);
 				sb.append(separator);
 			}
@@ -193,9 +193,9 @@ public final class KeyUtils {
 		for (String oneToken : tokens) {
 			if (oneToken.length() > 0) {
 				String[] keyValue = splitTypeNameValue(oneToken);
-				result.put(keyValue[0], keyValue[1]);
+					result.put(keyValue[0], keyValue[1]);
+				}
 			}
-		}
 		return result;
 	}
 
@@ -254,7 +254,10 @@ public final class KeyUtils {
 		String[] result;
 		String[] keys = typeNameToken.split("=", 2);
 
-		if (keys.length == 2) {
+		for (int i=0; i<keys.length; i++) {
+		}
+
+		if (keys.length == 2 && !StringUtils.isBlankOrEmptyString(keys[1])) {
 			result = keys;
 		} else {
 			result = new String[2];

--- a/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
@@ -76,14 +76,14 @@ public final class KeyUtils {
 
 	/**
 	 * Adds a key to the StringBuilder
-	 *
+	 * 
 	 * It uses in order of preference:
-	 *
+	 * 
 	 * 1. resultAlias if that was specified as part of the query
 	 * 2. The domain portion of the ObjectName in the query if useObjDomainAsKey is set to true
 	 * 3. else, the Class Name of the MBean. I.e. ClassName will be used by default if the
 	 * user doesn't specify anything special
-	 *
+	 * 
 	 * @param result
 	 * @param sb
 	 * @param useObjectDomain

--- a/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/KeyUtils.java
@@ -13,258 +13,258 @@ import com.googlecode.jmxtrans.model.Server;
 import static com.google.common.collect.Maps.newHashMap;
 
 public final class KeyUtils {
-	private KeyUtils() {}
-	/**
-	 * Gets the key string.
-	 *
-	 *
-	 * @param server
-	 * @param query      the query
-	 * @param result     the result
-	 * @param values     the values
-	 * @param typeNames  the type names
-	 * @param rootPrefix the root prefix
-	 * @return the key string
-	 */
-	public static String getKeyString(Server server, Query query, Result result, Map.Entry<String, Object> values, List<String> typeNames, String rootPrefix) {
-		StringBuilder sb = new StringBuilder();
-		addRootPrefix(rootPrefix, sb);
-		addAlias(server, sb);
-		sb.append(".");
-		addMBeanIdentifier(query, result, sb);
-		sb.append(".");
-		addTypeName(query, result, typeNames, sb);
-		addKeyString(query, result, values, sb);
-		return sb.toString();
-	}
+    private KeyUtils() {}
+    /**
+     * Gets the key string.
+     *
+     *
+     * @param server
+     * @param query      the query
+     * @param result     the result
+     * @param values     the values
+     * @param typeNames  the type names
+     * @param rootPrefix the root prefix
+     * @return the key string
+     */
+    public static String getKeyString(Server server, Query query, Result result, Map.Entry<String, Object> values, List<String> typeNames, String rootPrefix) {
+        StringBuilder sb = new StringBuilder();
+        addRootPrefix(rootPrefix, sb);
+        addAlias(server, sb);
+        sb.append(".");
+        addMBeanIdentifier(query, result, sb);
+        sb.append(".");
+        addTypeName(query, result, typeNames, sb);
+        addKeyString(query, result, values, sb);
+        return sb.toString();
+    }
 
-	/**
-	 * Gets the key string, without rootPrefix nor Alias
-	 *
-	 * @param query     the query
-	 * @param result    the result
-	 * @param values    the values
-	 * @param typeNames the type names
-	 * @return the key string
-	 */
-	public static String getKeyString(Query query, Result result, Map.Entry<String, Object> values, List<String> typeNames) {
-		StringBuilder sb = new StringBuilder();
-		addMBeanIdentifier(query, result, sb);
-		sb.append(".");
-		addTypeName(query, result, typeNames, sb);
-		addKeyString(query, result, values, sb);
-		return sb.toString();
-	}
+    /**
+     * Gets the key string, without rootPrefix nor Alias
+     *
+     * @param query     the query
+     * @param result    the result
+     * @param values    the values
+     * @param typeNames the type names
+     * @return the key string
+     */
+    public static String getKeyString(Query query, Result result, Map.Entry<String, Object> values, List<String> typeNames) {
+        StringBuilder sb = new StringBuilder();
+        addMBeanIdentifier(query, result, sb);
+        sb.append(".");
+        addTypeName(query, result, typeNames, sb);
+        addKeyString(query, result, values, sb);
+        return sb.toString();
+    }
 
-	private static void addRootPrefix(String rootPrefix, StringBuilder sb) {
-		if (rootPrefix != null) {
-			sb.append(rootPrefix);
-			sb.append(".");
-		}
-	}
+    private static void addRootPrefix(String rootPrefix, StringBuilder sb) {
+        if (rootPrefix != null) {
+            sb.append(rootPrefix);
+            sb.append(".");
+        }
+    }
 
-	private static void addAlias(Server server, StringBuilder sb) {
-		String alias;
-		if (server.getAlias() != null) {
-			alias = server.getAlias();
-		} else {
-			alias = server.getHost() + "_" + server.getPort();
-			alias = StringUtils.cleanupStr(alias);
-		}
-		sb.append(alias);
-	}
+    private static void addAlias(Server server, StringBuilder sb) {
+        String alias;
+        if (server.getAlias() != null) {
+            alias = server.getAlias();
+        } else {
+            alias = server.getHost() + "_" + server.getPort();
+            alias = StringUtils.cleanupStr(alias);
+        }
+        sb.append(alias);
+    }
 
-	/**
-	 * Adds a key to the StringBuilder
-	 *
-	 * It uses in order of preference:
-	 *
-	 * 1. resultAlias if that was specified as part of the query
-	 * 2. The domain portion of the ObjectName in the query if useObjDomainAsKey is set to true
-	 * 3. else, the Class Name of the MBean. I.e. ClassName will be used by default if the
-	 * user doesn't specify anything special
-	 *
-	 * @param result
-	 * @param sb
-	 * @param useObjectDomain
-	 */
-	private static void addMBeanIdentifier(Query query, Result result, StringBuilder sb) {
-		if (result.getKeyAlias() != null) {
-			sb.append(result.getKeyAlias());
-		} else if (query.isUseObjDomainAsKey()) {
-			sb.append(StringUtils.cleanupStr(result.getObjDomain(), query.isAllowDottedKeys()));
-		} else {
-			sb.append(StringUtils.cleanupStr(result.getClassName()));
-		}
-	}
+    /**
+     * Adds a key to the StringBuilder
+     *
+     * It uses in order of preference:
+     *
+     * 1. resultAlias if that was specified as part of the query
+     * 2. The domain portion of the ObjectName in the query if useObjDomainAsKey is set to true
+     * 3. else, the Class Name of the MBean. I.e. ClassName will be used by default if the
+     * user doesn't specify anything special
+     *
+     * @param result
+     * @param sb
+     * @param useObjectDomain
+     */
+    private static void addMBeanIdentifier(Query query, Result result, StringBuilder sb) {
+        if (result.getKeyAlias() != null) {
+            sb.append(result.getKeyAlias());
+        } else if (query.isUseObjDomainAsKey()) {
+            sb.append(StringUtils.cleanupStr(result.getObjDomain(), query.isAllowDottedKeys()));
+        } else {
+            sb.append(StringUtils.cleanupStr(result.getClassName()));
+        }
+    }
 
-	private static void addTypeName(Query query, Result result, List<String> typeNames, StringBuilder sb) {
-		String typeName = StringUtils.cleanupStr(getConcatedTypeNameValues(query, typeNames, result.getTypeName()), query.isAllowDottedKeys());
-		if (typeName != null && typeName.length() > 0) {
-			sb.append(typeName);
-			sb.append(".");
-		}
-	}
+    private static void addTypeName(Query query, Result result, List<String> typeNames, StringBuilder sb) {
+        String typeName = StringUtils.cleanupStr(getConcatedTypeNameValues(query, typeNames, result.getTypeName()), query.isAllowDottedKeys());
+        if (typeName != null && typeName.length() > 0) {
+            sb.append(typeName);
+            sb.append(".");
+        }
+    }
 
-	private static void addKeyString(Query query, Result result, Map.Entry<String, Object> values, StringBuilder sb) {
-		String keyStr = computeKey(result, values);
-		sb.append(StringUtils.cleanupStr(keyStr, query.isAllowDottedKeys()));
-	}
+    private static void addKeyString(Query query, Result result, Map.Entry<String, Object> values, StringBuilder sb) {
+        String keyStr = computeKey(result, values);
+        sb.append(StringUtils.cleanupStr(keyStr, query.isAllowDottedKeys()));
+    }
 
-	private static String computeKey(Result result, Map.Entry<String, Object> values) {
-		String keyStr;
-		if (values.getKey().startsWith(result.getAttributeName())) {
-			keyStr = values.getKey();
-		} else {
-			keyStr = result.getAttributeName() + "." + values.getKey();
-		}
-		return keyStr;
-	}
+    private static String computeKey(Result result, Map.Entry<String, Object> values) {
+        String keyStr;
+        if (values.getKey().startsWith(result.getAttributeName())) {
+            keyStr = values.getKey();
+        } else {
+            keyStr = result.getAttributeName() + "." + values.getKey();
+        }
+        return keyStr;
+    }
 
-	/**
-	 * Given a typeName string, get the first match from the typeNames setting.
-	 * In other words, suppose you have:
-	 * <p/>
-	 * typeName=name=PS Eden Space,type=MemoryPool
-	 * <p/>
-	 * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
-	 * string
-	 *
-	 * @param typeNames   the type names
-	 * @param typeNameStr the type name str
-	 * @return the concated type name values
-	 */
-	public static String getConcatedTypeNameValues(List<String> typeNames, String typeNameStr) {
-		return getConcatedTypeNameValues(typeNames, typeNameStr, getTypeNameValuesSeparator(null));
-	}
+    /**
+     * Given a typeName string, get the first match from the typeNames setting.
+     * In other words, suppose you have:
+     * <p/>
+     * typeName=name=PS Eden Space,type=MemoryPool
+     * <p/>
+     * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
+     * string
+     *
+     * @param typeNames   the type names
+     * @param typeNameStr the type name str
+     * @return the concated type name values
+     */
+    public static String getConcatedTypeNameValues(List<String> typeNames, String typeNameStr) {
+        return getConcatedTypeNameValues(typeNames, typeNameStr, getTypeNameValuesSeparator(null));
+    }
 
-	/**
-	 * Given a typeName string, get the first match from the typeNames setting.
-	 * In other words, suppose you have:
-	 * <p/>
-	 * typeName=name=PS Eden Space,type=MemoryPool
-	 * <p/>
-	 * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
-	 * string
-	 *
-	 * @param typeNames   the type names
-	 * @param typeNameStr the type name str
-	 * @param separator
-	 * @return the concated type name values
-	 */
-	public static String getConcatedTypeNameValues(List<String> typeNames, String typeNameStr, String separator) {
-		if ((typeNames == null) || (typeNames.size() == 0)) {
-			return null;
-		}
-		Map<String, String> typeNameValueMap = getTypeNameValueMap(typeNameStr);
-		StringBuilder sb = new StringBuilder();
-		for (String key : typeNames) {
-			String result = typeNameValueMap.get(key);
-			if (result != null && !result.isEmpty()) {
-				sb.append(result);
-				sb.append(separator);
-			}
-		}
-		return org.apache.commons.lang.StringUtils.chomp(sb.toString(), separator);
-	}
+    /**
+     * Given a typeName string, get the first match from the typeNames setting.
+     * In other words, suppose you have:
+     * <p/>
+     * typeName=name=PS Eden Space,type=MemoryPool
+     * <p/>
+     * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
+     * string
+     *
+     * @param typeNames   the type names
+     * @param typeNameStr the type name str
+     * @param separator
+     * @return the concated type name values
+     */
+    public static String getConcatedTypeNameValues(List<String> typeNames, String typeNameStr, String separator) {
+        if ((typeNames == null) || (typeNames.size() == 0)) {
+            return null;
+        }
+        Map<String, String> typeNameValueMap = getTypeNameValueMap(typeNameStr);
+        StringBuilder sb = new StringBuilder();
+        for (String key : typeNames) {
+            String result = typeNameValueMap.get(key);
+            if (result != null) {
+                sb.append(result);
+                sb.append(separator);
+            }
+        }
+        return org.apache.commons.lang.StringUtils.chomp(sb.toString(), separator);
+    }
 
-	/**
-	 * Given a typeName string, create a Map with every key and value in the typeName.
-	 * For example:
-	 * <p/>
-	 * typeName=name=PS Eden Space,type=MemoryPool
-	 * <p/>
-	 * Returns a Map with the following key/value pairs (excluding the quotes):
-	 * <p/>
-	 * "name"  =>  "PS Eden Space"
-	 * "type"  =>  "MemoryPool"
-	 *
-	 * @param typeNameStr the type name str
-	 * @return Map<String, String> of type-name-key / value pairs.
-	 */
-	public static Map<String, String> getTypeNameValueMap(String typeNameStr) {
-		if (typeNameStr == null) {
-			return Collections.emptyMap();
-		}
+    /**
+     * Given a typeName string, create a Map with every key and value in the typeName.
+     * For example:
+     * <p/>
+     * typeName=name=PS Eden Space,type=MemoryPool
+     * <p/>
+     * Returns a Map with the following key/value pairs (excluding the quotes):
+     * <p/>
+     * "name"  =>  "PS Eden Space"
+     * "type"  =>  "MemoryPool"
+     *
+     * @param typeNameStr the type name str
+     * @return Map<String, String> of type-name-key / value pairs.
+     */
+    public static Map<String, String> getTypeNameValueMap(String typeNameStr) {
+        if (typeNameStr == null) {
+            return Collections.emptyMap();
+        }
 
-		Map<String, String> result = newHashMap();
-		String[] tokens = typeNameStr.split(",");
+        Map<String, String> result = newHashMap();
+        String[] tokens = typeNameStr.split(",");
 
-		for (String oneToken : tokens) {
-			if (oneToken.length() > 0) {
-				String[] keyValue = splitTypeNameValue(oneToken);
-					result.put(keyValue[0], keyValue[1]);
-				}
-			}
-		return result;
-	}
+        for (String oneToken : tokens) {
+            if (oneToken.length() > 0) {
+                String[] keyValue = splitTypeNameValue(oneToken);
+                    result.put(keyValue[0], keyValue[1]);
+                }
+            }
+        return result;
+    }
 
-	/**
-	 * Given a typeName string, get the first match from the typeNames setting.
-	 * In other words, suppose you have:
-	 * <p/>
-	 * typeName=name=PS Eden Space,type=MemoryPool
-	 * <p/>
-	 * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
-	 * string
-	 *
-	 * @param query     the query
-	 * @param typeNames the type names
-	 * @param typeName  the type name
-	 * @return the concated type name values
-	 */
-	public static String getConcatedTypeNameValues(Query query, List<String> typeNames, String typeName) {
-		Set<String> queryTypeNames = query.getTypeNames();
-		if (queryTypeNames != null && queryTypeNames.size() > 0) {
-			List<String> filteredTypeNames = new ArrayList<String>(queryTypeNames);
-			for (String name : typeNames) {
-				if (!filteredTypeNames.contains(name)) {
-					filteredTypeNames.add(name);
-				}
-			}
-			return getConcatedTypeNameValues(filteredTypeNames, typeName, getTypeNameValuesSeparator(query));
-		} else {
-			return getConcatedTypeNameValues(typeNames, typeName, getTypeNameValuesSeparator(query));
-		}
-	}
+    /**
+     * Given a typeName string, get the first match from the typeNames setting.
+     * In other words, suppose you have:
+     * <p/>
+     * typeName=name=PS Eden Space,type=MemoryPool
+     * <p/>
+     * If you addTypeName("name"), then it'll retrieve 'PS Eden Space' from the
+     * string
+     *
+     * @param query     the query
+     * @param typeNames the type names
+     * @param typeName  the type name
+     * @return the concated type name values
+     */
+    public static String getConcatedTypeNameValues(Query query, List<String> typeNames, String typeName) {
+        Set<String> queryTypeNames = query.getTypeNames();
+        if (queryTypeNames != null && queryTypeNames.size() > 0) {
+            List<String> filteredTypeNames = new ArrayList<String>(queryTypeNames);
+            for (String name : typeNames) {
+                if (!filteredTypeNames.contains(name)) {
+                    filteredTypeNames.add(name);
+                }
+            }
+            return getConcatedTypeNameValues(filteredTypeNames, typeName, getTypeNameValuesSeparator(query));
+        } else {
+            return getConcatedTypeNameValues(typeNames, typeName, getTypeNameValuesSeparator(query));
+        }
+    }
 
-	/**
-	 * Given a query, return a separator for type names based on its configuration.
-	 * If query is null, return the default separator.
-	 *
-	 * @param query   the query
-	 * @return the separator
-	 */
-	private static String getTypeNameValuesSeparator(Query query) {
-		if (query != null && query.isAllowDottedKeys()) {
-			return ".";
-		}
-		return "_";
-	}
+    /**
+     * Given a query, return a separator for type names based on its configuration.
+     * If query is null, return the default separator.
+     *
+     * @param query   the query
+     * @return the separator
+     */
+    private static String getTypeNameValuesSeparator(Query query) {
+        if (query != null && query.isAllowDottedKeys()) {
+            return ".";
+        }
+        return "_";
+    }
 
-	/**
-	 * Given a single type-name-key and value from a typename strig (e.g. "type=MemoryPool"), extract the key and
-	 * the value and return both.
-	 *
-	 * @param typeNameToken - the string containing the pair.
-	 * @return String[2] where String[0] = the key and String[1] = the value.  If the given string is not in the
-	 * format "key=value" then String[0] = the original string and String[1] = "".
-	 */
-	private static String[] splitTypeNameValue(String typeNameToken) {
-		String[] result;
-		String[] keys = typeNameToken.split("=", 2);
+    /**
+     * Given a single type-name-key and value from a typename strig (e.g. "type=MemoryPool"), extract the key and
+     * the value and return both.
+     *
+     * @param typeNameToken - the string containing the pair.
+     * @return String[2] where String[0] = the key and String[1] = the value.  If the given string is not in the
+     * format "key=value" then String[0] = the original string and String[1] = "".
+     */
+    private static String[] splitTypeNameValue(String typeNameToken) {
+        String[] result;
+        String[] keys = typeNameToken.split("=", 2);
 
-		for (int i=0; i<keys.length; i++) {
-		}
+        for (int i=0; i<keys.length; i++) {
+        }
 
-		if (keys.length == 2 && !StringUtils.isBlankOrEmptyString(keys[1])) {
-			result = keys;
-		} else {
-			result = new String[2];
-			result[0] = keys[0];
-			result[1] = "";
-		}
+        if (keys.length == 2) {
+            result = keys;
+        } else {
+            result = new String[2];
+            result[0] = keys[0];
+            result[1] = "";
+        }
 
-		return result;
-	}
+        return result;
+    }
 }

--- a/src/com/googlecode/jmxtrans/model/naming/StringUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/StringUtils.java
@@ -40,4 +40,23 @@ public final class StringUtils {
 		clean = SPACE_PAT.matcher(clean).replaceAll("");
 		return clean;
 	}
+
+	/**
+	 * Checks if a String is whitespace, empty (""), equals empty String ("\"\"") or null.
+	 *
+	 * <pre>
+	 * StringUtils.isBlank(null)      = true
+	 * StringUtils.isBlank("")        = true
+	 * StringUtils.isBlank(" ")       = true
+	 * StringUtils.isBlank("\"\"")    = true
+	 * StringUtils.isBlank("bob")     = false
+	 * StringUtils.isBlank("  bob  ") = false
+	 * </pre>
+	 *
+	 * @param name  the String to check, may be null
+	 * @return <code>true</code> if the String is null, empty, equals the empty string or whitespace
+	 */
+	public static boolean isBlank(String name) {
+		return org.apache.commons.lang.StringUtils.isBlank(name) || "\"\"".equals(name);
+	}
 }

--- a/src/com/googlecode/jmxtrans/model/naming/StringUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/StringUtils.java
@@ -24,7 +24,7 @@ public final class StringUtils {
 	 * Chomps trailing . when allowDottedKeys is true.
 	 * Chomps trailing _ when allowDottedKeys is false.
 	 *
-	 * @param name			  the name
+	 * @param name            the name
 	 * @param allowDottedKeys whether we remove the dots or not.
 	 * @return
 	 */

--- a/src/com/googlecode/jmxtrans/model/naming/StringUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/StringUtils.java
@@ -56,7 +56,7 @@ public final class StringUtils {
 	 * @param name  the String to check, may be null
 	 * @return <code>true</code> if the String is null, empty, equals the empty string or whitespace
 	 */
-	public static boolean isBlank(String name) {
+	public static boolean isBlankOrEmptyString(String name) {
 		return org.apache.commons.lang.StringUtils.isBlank(name) || "\"\"".equals(name);
 	}
 }

--- a/src/com/googlecode/jmxtrans/model/naming/StringUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/StringUtils.java
@@ -3,60 +3,46 @@ package com.googlecode.jmxtrans.model.naming;
 import java.util.regex.Pattern;
 
 public final class StringUtils {
-	private static final Pattern DOT_SLASH_UNDERSCORE_PAT = Pattern.compile("[./]");
-	private static final Pattern SLASH_UNDERSCORE_PAT = Pattern.compile("/", Pattern.LITERAL);
-	private static final Pattern SPACE_PAT = Pattern.compile("[ \"']+");
+    private static final Pattern DOT_SLASH_UNDERSCORE_PAT = Pattern.compile("[./]");
+    private static final Pattern SLASH_UNDERSCORE_PAT = Pattern.compile("/", Pattern.LITERAL);
+    private static final Pattern SPACE_PAT = Pattern.compile("[ \"']+");
 
-	private StringUtils() {}
+    private StringUtils() {}
 
-	/**
-	 * Replaces all . and / with _ and removes all spaces and double/single quotes.
-	 *
-	 * @param name the name
-	 * @return the string
-	 */
-	public static String cleanupStr(String name) {
-		return cleanupStr(name, false);
-	}
+    /**
+     * Replaces all . and / with _ and removes all spaces and double/single quotes.
+     *
+     * @param name the name
+     * @return the string
+     */
+    public static String cleanupStr(String name) {
+        return cleanupStr(name, false);
+    }
 
-	/**
-	 * Replaces all . and / with _ and removes all spaces and double/single quotes.
-	 *
-	 * @param name            the name
-	 * @param allowDottedKeys whether we remove the dots or not.
-	 * @return
-	 */
-	public static String cleanupStr(String name, boolean allowDottedKeys) {
-		if (name == null) {
-			return null;
-		}
-		Pattern pattern;
-		if (!allowDottedKeys) {
-			pattern = DOT_SLASH_UNDERSCORE_PAT;
-		} else {
-			pattern = SLASH_UNDERSCORE_PAT;
-		}
-		String clean = pattern.matcher(name).replaceAll("_");
-		clean = SPACE_PAT.matcher(clean).replaceAll("");
-		return clean;
-	}
-
-	/**
-	 * Checks if a String is whitespace, empty (""), equals empty String ("\"\"") or null.
-	 *
-	 * <pre>
-	 * StringUtils.isBlank(null)      = true
-	 * StringUtils.isBlank("")        = true
-	 * StringUtils.isBlank(" ")       = true
-	 * StringUtils.isBlank("\"\"")    = true
-	 * StringUtils.isBlank("bob")     = false
-	 * StringUtils.isBlank("  bob  ") = false
-	 * </pre>
-	 *
-	 * @param name  the String to check, may be null
-	 * @return <code>true</code> if the String is null, empty, equals the empty string or whitespace
-	 */
-	public static boolean isBlankOrEmptyString(String name) {
-		return org.apache.commons.lang.StringUtils.isBlank(name) || "\"\"".equals(name);
-	}
+    /**
+     * Replaces all . and / with _ and removes all spaces and double/single quotes.
+     * Chomps trailing . when allowDottedKeys is true.
+     * Chomps trailing _ when allowDottedKeys is false.
+     *
+     * @param name            the name
+     * @param allowDottedKeys whether we remove the dots or not.
+     * @return
+     */
+    public static String cleanupStr(String name, boolean allowDottedKeys) {
+        if (name == null) {
+            return null;
+        }
+        Pattern pattern;
+        String separator;
+        if (!allowDottedKeys) {
+            pattern = DOT_SLASH_UNDERSCORE_PAT;
+            separator = "_";
+        } else {
+            pattern = SLASH_UNDERSCORE_PAT;
+            separator = ".";
+        }
+        String clean = pattern.matcher(name).replaceAll("_");
+        clean = SPACE_PAT.matcher(clean).replaceAll("");
+        return org.apache.commons.lang.StringUtils.chomp(clean, separator);
+    }
 }

--- a/src/com/googlecode/jmxtrans/model/naming/StringUtils.java
+++ b/src/com/googlecode/jmxtrans/model/naming/StringUtils.java
@@ -3,46 +3,46 @@ package com.googlecode.jmxtrans.model.naming;
 import java.util.regex.Pattern;
 
 public final class StringUtils {
-    private static final Pattern DOT_SLASH_UNDERSCORE_PAT = Pattern.compile("[./]");
-    private static final Pattern SLASH_UNDERSCORE_PAT = Pattern.compile("/", Pattern.LITERAL);
-    private static final Pattern SPACE_PAT = Pattern.compile("[ \"']+");
+	private static final Pattern DOT_SLASH_UNDERSCORE_PAT = Pattern.compile("[./]");
+	private static final Pattern SLASH_UNDERSCORE_PAT = Pattern.compile("/", Pattern.LITERAL);
+	private static final Pattern SPACE_PAT = Pattern.compile("[ \"']+");
 
-    private StringUtils() {}
+	private StringUtils() {}
 
-    /**
-     * Replaces all . and / with _ and removes all spaces and double/single quotes.
-     *
-     * @param name the name
-     * @return the string
-     */
-    public static String cleanupStr(String name) {
-        return cleanupStr(name, false);
-    }
+	/**
+	 * Replaces all . and / with _ and removes all spaces and double/single quotes.
+	 *
+	 * @param name the name
+	 * @return the string
+	 */
+	public static String cleanupStr(String name) {
+		return cleanupStr(name, false);
+	}
 
-    /**
-     * Replaces all . and / with _ and removes all spaces and double/single quotes.
-     * Chomps trailing . when allowDottedKeys is true.
-     * Chomps trailing _ when allowDottedKeys is false.
-     *
-     * @param name            the name
-     * @param allowDottedKeys whether we remove the dots or not.
-     * @return
-     */
-    public static String cleanupStr(String name, boolean allowDottedKeys) {
-        if (name == null) {
-            return null;
-        }
-        Pattern pattern;
-        String separator;
-        if (!allowDottedKeys) {
-            pattern = DOT_SLASH_UNDERSCORE_PAT;
-            separator = "_";
-        } else {
-            pattern = SLASH_UNDERSCORE_PAT;
-            separator = ".";
-        }
-        String clean = pattern.matcher(name).replaceAll("_");
-        clean = SPACE_PAT.matcher(clean).replaceAll("");
-        return org.apache.commons.lang.StringUtils.chomp(clean, separator);
-    }
+	/**
+	 * Replaces all . and / with _ and removes all spaces and double/single quotes.
+	 * Chomps trailing . when allowDottedKeys is true.
+	 * Chomps trailing _ when allowDottedKeys is false.
+	 *
+	 * @param name			  the name
+	 * @param allowDottedKeys whether we remove the dots or not.
+	 * @return
+	 */
+	public static String cleanupStr(String name, boolean allowDottedKeys) {
+		if (name == null) {
+			return null;
+		}
+		Pattern pattern;
+		String separator;
+		if (!allowDottedKeys) {
+			pattern = DOT_SLASH_UNDERSCORE_PAT;
+			separator = "_";
+		} else {
+			pattern = SLASH_UNDERSCORE_PAT;
+			separator = ".";
+		}
+		String clean = pattern.matcher(name).replaceAll("_");
+		clean = SPACE_PAT.matcher(clean).replaceAll("");
+		return org.apache.commons.lang.StringUtils.chomp(clean, separator);
+	}
 }

--- a/test/com/googlecode/jmxtrans/model/naming/StringUtilsTest.java
+++ b/test/com/googlecode/jmxtrans/model/naming/StringUtilsTest.java
@@ -10,10 +10,10 @@ public class StringUtilsTest {
 	public void testCleanupStr() {
 		assertEquals("addfber1241qdw!èé$", StringUtils.cleanupStr("addfber1241qdw!èé$"));
 		assertEquals("abcd_abcd", StringUtils.cleanupStr("abcd.abcd"));
-		assertEquals("abcd_abcd_", StringUtils.cleanupStr("abcd.abcd."));
+		assertEquals("abcd_abcd", StringUtils.cleanupStr("abcd.abcd."));
 		assertEquals("_abcd_abcd", StringUtils.cleanupStr(".abcd_abcd"));
 		assertEquals("abcd_abcd", StringUtils.cleanupStr("abcd/abcd"));
-		assertEquals("abcd_abcd_", StringUtils.cleanupStr("abcd/abcd/"));
+		assertEquals("abcd_abcd", StringUtils.cleanupStr("abcd/abcd/"));
 		assertEquals("_abcd_abcd", StringUtils.cleanupStr("/abcd_abcd"));
 		assertEquals("abcd_abcd", StringUtils.cleanupStr("abcd'_abcd'"));
 		assertEquals("_abcd_abcd", StringUtils.cleanupStr("/abcd\"_abcd\""));
@@ -26,7 +26,7 @@ public class StringUtilsTest {
 	public void testCleanupStrDottedKeysKept() {
 		assertEquals("addfber1241qdw!èé$", StringUtils.cleanupStr("addfber1241qdw!èé$", true));
 		assertEquals("abcd.abcd", StringUtils.cleanupStr("abcd.abcd", true));
-		assertEquals("abcd.abcd.", StringUtils.cleanupStr("abcd.abcd.", true));
+		assertEquals("abcd.abcd", StringUtils.cleanupStr("abcd.abcd.", true));
 		assertEquals(".abcd_abcd", StringUtils.cleanupStr(".abcd_abcd", true));
 		assertEquals("abcd_abcd", StringUtils.cleanupStr("abcd/abcd", true));
 		assertEquals("abcd_abcd_", StringUtils.cleanupStr("abcd/abcd/", true));

--- a/test/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
+++ b/test/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
@@ -154,7 +154,7 @@ public class GraphiteWriterTests {
 		assertThat(out.toString()).startsWith("servers.host_123.objDomain.attributeName.key 1");
 	}
 	
-		@Test
+	@Test
 	public void checkEmptyTypeNamesAreIgnored() throws Exception {
 		Server server = Server.builder().setHost("host").setPort("123").build();
 		// Set useObjDomain to true

--- a/test/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
+++ b/test/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
@@ -180,9 +180,21 @@ public class GraphiteWriterTests {
 
         writer.doWrite(server, query, of(result));
 
-        // check that the empty type "type" is ignored
+        // check that the empty type "type" is ignored when allowDottedKeys is true
         assertThat(out.toString()).startsWith("servers.host_123.yammer.metrics.uniqueName.Attribute 0 ");
-    }
+        
+        // check that the empty type "type" is ignored when allowDottedKeys is false
+		query = Query.builder()
+				.setUseObjDomainAsKey(true)
+		        .setAllowDottedKeys(false)
+		        .setObj("\"yammer.metrics\":name=\"uniqueName\",type=\"\"").build();
+		
+		out = new ByteArrayOutputStream();
+		writer = getGraphiteWriter(out, typeNames);
+		
+		writer.doWrite(server, query, of(result));
+		assertThat(out.toString()).startsWith("servers.host_123.yammer_metrics.uniqueName.Attribute 0 ");
+	}
 
 	@Test
 	public void socketInvalidatedWhenError() throws Exception {

--- a/test/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
+++ b/test/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
@@ -154,40 +154,40 @@ public class GraphiteWriterTests {
 		assertThat(out.toString()).startsWith("servers.host_123.objDomain.attributeName.key 1");
 	}
 	
-	    @Test
-    public void checkEmptyTypeNamesAreIgnored() throws Exception {
-        Server server = Server.builder().setHost("host").setPort("123").build();
-        // Set useObjDomain to true
-        Query query = Query.builder()
-                .setUseObjDomainAsKey(true)
-                .setAllowDottedKeys(true)
-                .setObj("\"yammer.metrics\":name=\"uniqueName\",type=\"\"").build();
+		@Test
+	public void checkEmptyTypeNamesAreIgnored() throws Exception {
+		Server server = Server.builder().setHost("host").setPort("123").build();
+		// Set useObjDomain to true
+		Query query = Query.builder()
+				.setUseObjDomainAsKey(true)
+				.setAllowDottedKeys(true)
+				.setObj("\"yammer.metrics\":name=\"uniqueName\",type=\"\"").build();
 
-        Result result = new Result(System.currentTimeMillis(),
-                "Attribute",
-                "com.yammer.metrics.reporting.JmxReporter$Counter",
-                "yammer.metrics",
-                null,
-                "name=\"uniqueName\",type=\"\"",
-                ImmutableMap.of("Attribute", (Object)0));
+		Result result = new Result(System.currentTimeMillis(),
+				"Attribute",
+				"com.yammer.metrics.reporting.JmxReporter$Counter",
+				"yammer.metrics",
+				null,
+				"name=\"uniqueName\",type=\"\"",
+				ImmutableMap.of("Attribute", (Object)0));
 
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        ArrayList<String> typeNames = new ArrayList<String>();
-        typeNames.add("name");
-        typeNames.add("type");
-        GraphiteWriter writer = getGraphiteWriter(out, typeNames);
+		ArrayList<String> typeNames = new ArrayList<String>();
+		typeNames.add("name");
+		typeNames.add("type");
+		GraphiteWriter writer = getGraphiteWriter(out, typeNames);
 
-        writer.doWrite(server, query, of(result));
+		writer.doWrite(server, query, of(result));
 
-        // check that the empty type "type" is ignored when allowDottedKeys is true
-        assertThat(out.toString()).startsWith("servers.host_123.yammer.metrics.uniqueName.Attribute 0 ");
-        
-        // check that the empty type "type" is ignored when allowDottedKeys is false
+		// check that the empty type "type" is ignored when allowDottedKeys is true
+		assertThat(out.toString()).startsWith("servers.host_123.yammer.metrics.uniqueName.Attribute 0 ");
+		
+		// check that the empty type "type" is ignored when allowDottedKeys is false
 		query = Query.builder()
 				.setUseObjDomainAsKey(true)
-		        .setAllowDottedKeys(false)
-		        .setObj("\"yammer.metrics\":name=\"uniqueName\",type=\"\"").build();
+				.setAllowDottedKeys(false)
+				.setObj("\"yammer.metrics\":name=\"uniqueName\",type=\"\"").build();
 		
 		out = new ByteArrayOutputStream();
 		writer = getGraphiteWriter(out, typeNames);

--- a/test/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
+++ b/test/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
@@ -17,6 +17,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.google.common.collect.ImmutableList.of;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,8 +54,12 @@ public class GraphiteWriterTests {
 			throw npe;
 		}
 	}
-
+	
 	private static GraphiteWriter getGraphiteWriter(OutputStream out) throws Exception {
+		return getGraphiteWriter(out, new ArrayList<String>());
+	}
+
+	private static GraphiteWriter getGraphiteWriter(OutputStream out, List<String> typeNames) throws Exception {
 		GenericKeyedObjectPool<InetSocketAddress, Socket> pool = mock(GenericKeyedObjectPool.class);
 		Socket socket = mock(Socket.class);
 		when(pool.borrowObject(any(InetSocketAddress.class))).thenReturn(socket);
@@ -63,6 +69,7 @@ public class GraphiteWriterTests {
 		GraphiteWriter writer = GraphiteWriter.builder()
 				.setHost("localhost")
 				.setPort(2003)
+				.addTypeNames(typeNames)
 				.build();
 		writer.setPool(pool);
 
@@ -146,7 +153,36 @@ public class GraphiteWriterTests {
 		// check that the booleanAsNumber property was picked up from the JSON
 		assertThat(out.toString()).startsWith("servers.host_123.objDomain.attributeName.key 1");
 	}
+	
+	    @Test
+    public void checkEmptyTypeNamesAreIgnored() throws Exception {
+        Server server = Server.builder().setHost("host").setPort("123").build();
+        // Set useObjDomain to true
+        Query query = Query.builder()
+                .setUseObjDomainAsKey(true)
+                .setAllowDottedKeys(true)
+                .setObj("\"yammer.metrics\":name=\"uniqueName\",type=\"\"").build();
 
+        Result result = new Result(System.currentTimeMillis(),
+                "Attribute",
+                "com.yammer.metrics.reporting.JmxReporter$Counter",
+                "yammer.metrics",
+                null,
+                "name=\"uniqueName\",type=\"\"",
+                ImmutableMap.of("Attribute", (Object)0));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ArrayList<String> typeNames = new ArrayList<String>();
+        typeNames.add("name");
+        typeNames.add("type");
+        GraphiteWriter writer = getGraphiteWriter(out, typeNames);
+
+        writer.doWrite(server, query, of(result));
+
+        // check that the empty type "type" is ignored
+        assertThat(out.toString()).startsWith("servers.host_123.yammer.metrics.uniqueName.Attribute 0 ");
+    }
 
 	@Test
 	public void socketInvalidatedWhenError() throws Exception {


### PR DESCRIPTION
Sometimes ObjectName key properties can be empty Strings. If they are specified by JMXTrans configuration as typeNames then currently the empty string will appear in the JMXTrans output. In this case the literal string "\"\"" can appear! This issue has been seen to occur when using Yammer Metrics.

Added a failing test to GraphiteWriterTests
Added the fix with minimal changes to KeyUtils and StringUtils classes.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28438619%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28438724%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28439138%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28439228%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23issuecomment-93598364%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28475243%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23issuecomment-93603863%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28538071%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28538521%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28538628%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28538690%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28546638%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28546886%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28547795%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28550949%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28552049%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23issuecomment-94112084%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%202d30b813151618f8d87a98ecbd1c4f3e8469c842%20src/com/googlecode/jmxtrans/model/naming/StringUtils.java%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28438724%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Yea%2C%20I%20don%27t%20like%20this%20because%20it%20hides%20behavior%20of%20isBlank.%20I%27d%20rather%20have%20separate%20functions%20for%20these%20things.%22%2C%20%22created_at%22%3A%20%222015-04-15T16%3A52%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%2C%20%7B%22body%22%3A%20%22Agreed.%20I%20will%20try%20to%20fix%20another%20way%20but%20as%20a%20last%20resort%20I%20can%20rename%20this%20method%20if%20nothing%20else.%22%2C%20%22created_at%22%3A%20%222015-04-15T16%3A58%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/997809%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/conorbev%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/naming/StringUtils.java%3AL40-63%22%7D%2C%20%22Pull%20228ff0b6b0cb4f55e408ec2583008521a9438534%20src/com/googlecode/jmxtrans/model/naming/KeyUtils.java%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28538521%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22That%20could%20be%20replaced%20by%20%60Strings.isNullOrEmpty%28%29%60%2C%20which%20I%20find%20more%20readable.%20Or%20the%20equivalent%20from%20apache%20common-lang%22%2C%20%22created_at%22%3A%20%222015-04-16T18%3A51%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%20it%20seem%20to%20me%20that%20this%20whole%20block%20could%20be%20written%20in%20a%20much%20simpler%20way%20by%20using%20the%20functional%20idioms%20of%20Guava.%22%2C%20%22created_at%22%3A%20%222015-04-16T18%3A52%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/naming/KeyUtils.java%3AL160-167%22%7D%2C%20%22Pull%20228ff0b6b0cb4f55e408ec2583008521a9438534%20src/com/googlecode/jmxtrans/model/naming/KeyUtils.java%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28538690%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20is%20an%20indentation%20problem%20here.%22%2C%20%22created_at%22%3A%20%222015-04-16T18%3A53%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/naming/KeyUtils.java%3AL193-202%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23issuecomment-93598364%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20do%20you%20think%20of%20this%20change%3F%5Cr%5Cn%5Cr%5CnI%20would%20prefer%20the%20empty%20string%20to%20never%20get%20into%20the%20typeNameValueMap%20at%20all%2C%20but%2C%20if%20I%20do%20that%2C%20an%20existing%20test%20in%20KeyUtilsTests%20fails.%20Specifically%20the%20line%20%60assertThat%28getTypeNameValueMap%28%5C%22x-key1-x%5C%22%29%29.isEqualTo%28makeMap%28%5C%22x-key1-x%5C%22%2C%20%5C%22%5C%22%29%29%3B%60%5Cr%5Cn%5Cr%5CnWhile%20I%27m%20not%20sure%20that%20that%20particular%20test%20case%20is%20valid/needed%20this%20whole%20section%20of%20code%20is%20somewhat%20hairy%20and%20I%27m%20loathe%20to%20change%20any%20existing%20behavior%20that%20someone%20might%20be%20relying%20on.%22%2C%20%22created_at%22%3A%20%222015-04-15T23%3A37%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/997809%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/conorbev%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20sounds%20like%20the%20test%20is%20broken.%20I%27d%20fix%20the%20test.%22%2C%20%22created_at%22%3A%20%222015-04-16T00%3A13%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20as%20%40gehel%20suggested%20this%20is%20now%20cleaned%20up%20in%20cleanupStr%20and%20avoids%20doing%20anything%20strange%20like%20comparing%20a%20String%20to%20%5C%22%5C%5C%5C%22%5C%5C%5C%22%5C%22%5Cr%5Cn%5Cr%5CnMy%20editor%20got%20a%20bit%20screwy%20with%20tabs%20vs%20spaces%20leading%20to%20a%20messy%20commit%20history.%20Let%20me%20know%20if%20you%20want%20me%20to%20close%20this%20pull%20and%20just%20do%20again%20on%20a%20fresh%20branch%20or%20something%20like%20that.%22%2C%20%22created_at%22%3A%20%222015-04-18T01%3A29%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/997809%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/conorbev%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20228ff0b6b0cb4f55e408ec2583008521a9438534%20src/com/googlecode/jmxtrans/model/naming/StringUtils.java%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28538071%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20looks%20suspicious.%20Having%20a%20need%20to%20treat%20an%20empty%20string%20%60%5C%22%5C%22%60%20or%20the%20string%20representation%20of%20the%20empty%20string%20%60%5C%22%5C%5C%5C%22%5C%5C%5C%22%5C%22%60%20is%20really%20strange.%20It%20lets%20me%20think%20that%20the%20problem%20you%20are%20trying%20to%20solve%20is%20that%20we%20do%20not%20interpret%20the%20string%20correctly%20at%20some%20point.%22%2C%20%22created_at%22%3A%20%222015-04-16T18%3A46%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20underlying%20issue%20is%20actually%20that%20Yammer%20metrics%20itself%20is%20putting%20%5C%22%20characters%20into%20the%20Java%20ObjectName%20inside%20JMX.%20So%20I%27m%20seeing%20things%20like%3A%20ObjectName%3D%5C%22metric%5C%22%3Atype%3D%5C%22%5C%22%2Cname%3D%5C%22runtime%5C%22%5Cr%5Cn%5Cr%5CnYou%20are%20right%20though%20that%20we%20might%20be%20able%20to%20clean%20it%20out%20earlier%20in%20the%20code..%20I%20am%20not%20sure%20if%20this%20is%20a%20common%20issue%20with%20Yammer%20metrics%20%28which%20appears%20to%20be%20pretty%20popular%29%20or%20just%20the%20ones%20I%27m%20looking%20at%20but%20in%20any%20case%20this%20is%20an%20edge%20case%20I%27d%20like%20to%20fix%20without%20impacting%20anything%20else.%5Cr%5Cn%5Cr%5CnThere%20is%20an%20existing%20StringUtils.cleanupStr%20method%20that%20runs%20pretty%20late%20in%20this%20whole%20process.%20Initially%20I%20thought%20the%20best%20thing%20would%20be%20for%20it%20to%20just%20strip%20trailing%20dots%2C%20but%2C%20if%20I%20do%20that%20it%20breaks%20this%20test%20in%20StringUtilsTests%3A%5Cr%5Cn%5Cr%5CnassertEquals%28%5C%22abcd.abcd.%5C%22%2C%20StringUtils.cleanupStr%28%5C%22abcd.abcd.%5C%22%2C%20true%29%29%3B%5Cr%5Cn%5Cr%5CnJust%20like%20KeyUtilsTests%20that%20%40lookfirst%20commented%20on%20I%27m%20not%20convinced%20that%20test%20case%20is%20valid%2C%20but%2C%20I%20don%27t%20really%20like%20breaking%20existing%20tests%20when%20I%27m%20not%20sure%20if%20there%20was%20a%20good%20reason%20for%20them%21%20%3A-%29%5Cr%5Cn%5Cr%5CnI%20find%20this%20whole%20area%20inside%20KeyUtils%20to%20be%20fairly%20convoluted%20and%20probably%20needing%20a%20more%20major%20cleanup.%20As%20this%20is%20probably%20just%20an%20edge%20case%20though%2C%20I%27m%20not%20sure%20if%20it%20is%20worth%20changing%20too%20much.%22%2C%20%22created_at%22%3A%20%222015-04-16T21%3A19%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/997809%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/conorbev%22%7D%7D%2C%20%7B%22body%22%3A%20%22Strange%2C%20we%20use%20Yammer%20metrics%20and%20I%20have%20not%20seen%20this%20issue.%20In%20any%20case%2C%20we%20should%20escape%20those%20%60%5C%5C%5C%22%60%2C%20not%20make%20them%20disappear.%20If%20a%20lib%20want%20to%20add%20quotes%20in%20objects%20name%2C%20why%20not%2C%20we%20should%20respect%20this%20choice.%20We%20should%20just%20make%20sure%20we%20do%20not%20send%20garbage%20to%20the%20backends.%20Which%20means%20that%20we%20probably%20want%20to%20address%20this%20in%20%60StringUtils.cleanupStr%28%29%60.%22%2C%20%22created_at%22%3A%20%222015-04-16T21%3A33%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/naming/StringUtils.java%3AL40-63%22%7D%2C%20%22Pull%202d30b813151618f8d87a98ecbd1c4f3e8469c842%20src/com/googlecode/jmxtrans/model/naming/KeyUtils.java%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28438619%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20wonder%20more%20how%20the%20value%20gets%20put%20into%20typeNameValueMap%20as%20null.%20I%27d%20rather%20fix%20it%20there.%22%2C%20%22created_at%22%3A%20%222015-04-15T16%3A51%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20will%20take%20a%20look%20later%20today%20or%20tomorrow.%22%2C%20%22created_at%22%3A%20%222015-04-15T16%3A57%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/997809%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/conorbev%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/naming/KeyUtils.java%3AL160-167%22%7D%2C%20%22Pull%20228ff0b6b0cb4f55e408ec2583008521a9438534%20src/com/googlecode/jmxtrans/model/naming/KeyUtils.java%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/271%23discussion_r28475243%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22WAT%3F%20%3Awink%3A%20%22%2C%20%22created_at%22%3A%20%222015-04-16T00%3A12%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%2C%20%7B%22body%22%3A%20%22How%20embarrassing..%20I%20needed%20to%20do%20more%20than%20just%20delete%20all%20printlns%20/me%20promises%20not%20to%20commit%20while%20sitting%20in%20Starbucks%20in%20future%21%22%2C%20%22created_at%22%3A%20%222015-04-16T20%3A29%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/997809%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/conorbev%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20worries...%20we%20have%20all%20done%20it%20a%20bazillion%20times.%20%3Asmile%3A%20%22%2C%20%22created_at%22%3A%20%222015-04-16T20%3A31%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/85355%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lookfirst%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20do%20not%20commit%20from%20Starbucks.%20Go%20to%20a%20place%20where%20thy%20have%20good%20coffee%20...%20%3B-%29%22%2C%20%22created_at%22%3A%20%222015-04-16T20%3A42%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/naming/KeyUtils.java%3AL254-264%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 2d30b813151618f8d87a98ecbd1c4f3e8469c842 src/com/googlecode/jmxtrans/model/naming/KeyUtils.java 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/271#discussion_r28438619'>File: src/com/googlecode/jmxtrans/model/naming/KeyUtils.java:L160-167</a></b>
- <a href='https://github.com/lookfirst'><img border=0 src='https://avatars.githubusercontent.com/u/85355?v=3' height=16 width=16'></a> I wonder more how the value gets put into typeNameValueMap as null. I'd rather fix it there.
- <a href='https://github.com/conorbev'><img border=0 src='https://avatars.githubusercontent.com/u/997809?v=3' height=16 width=16'></a> OK, will take a look later today or tomorrow.
- [ ] <a href='#crh-comment-Pull 2d30b813151618f8d87a98ecbd1c4f3e8469c842 src/com/googlecode/jmxtrans/model/naming/StringUtils.java 22'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/271#discussion_r28438724'>File: src/com/googlecode/jmxtrans/model/naming/StringUtils.java:L40-63</a></b>
- <a href='https://github.com/lookfirst'><img border=0 src='https://avatars.githubusercontent.com/u/85355?v=3' height=16 width=16'></a> Yea, I don't like this because it hides behavior of isBlank. I'd rather have separate functions for these things.
- <a href='https://github.com/conorbev'><img border=0 src='https://avatars.githubusercontent.com/u/997809?v=3' height=16 width=16'></a> Agreed. I will try to fix another way but as a last resort I can rename this method if nothing else.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/271#issuecomment-93598364'>General Comment</a></b>
- <a href='https://github.com/conorbev'><img border=0 src='https://avatars.githubusercontent.com/u/997809?v=3' height=16 width=16'></a> What do you think of this change?
I would prefer the empty string to never get into the typeNameValueMap at all, but, if I do that, an existing test in KeyUtilsTests fails. Specifically the line `assertThat(getTypeNameValueMap("x-key1-x")).isEqualTo(makeMap("x-key1-x", ""));`
While I'm not sure that that particular test case is valid/needed this whole section of code is somewhat hairy and I'm loathe to change any existing behavior that someone might be relying on.
- <a href='https://github.com/lookfirst'><img border=0 src='https://avatars.githubusercontent.com/u/85355?v=3' height=16 width=16'></a> It sounds like the test is broken. I'd fix the test.
- <a href='https://github.com/conorbev'><img border=0 src='https://avatars.githubusercontent.com/u/997809?v=3' height=16 width=16'></a> OK, as @gehel suggested this is now cleaned up in cleanupStr and avoids doing anything strange like comparing a String to "\"\""
My editor got a bit screwy with tabs vs spaces leading to a messy commit history. Let me know if you want me to close this pull and just do again on a fresh branch or something like that.
- [ ] <a href='#crh-comment-Pull 228ff0b6b0cb4f55e408ec2583008521a9438534 src/com/googlecode/jmxtrans/model/naming/KeyUtils.java 46'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/271#discussion_r28475243'>File: src/com/googlecode/jmxtrans/model/naming/KeyUtils.java:L254-264</a></b>
- <a href='https://github.com/lookfirst'><img border=0 src='https://avatars.githubusercontent.com/u/85355?v=3' height=16 width=16'></a> WAT? :wink:
- <a href='https://github.com/conorbev'><img border=0 src='https://avatars.githubusercontent.com/u/997809?v=3' height=16 width=16'></a> How embarrassing.. I needed to do more than just delete all printlns /me promises not to commit while sitting in Starbucks in future!
- <a href='https://github.com/lookfirst'><img border=0 src='https://avatars.githubusercontent.com/u/85355?v=3' height=16 width=16'></a> No worries... we have all done it a bazillion times. :smile:
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Yeah, do not commit from Starbucks. Go to a place where thy have good coffee ... ;-)
- [ ] <a href='#crh-comment-Pull 228ff0b6b0cb4f55e408ec2583008521a9438534 src/com/googlecode/jmxtrans/model/naming/StringUtils.java 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/271#discussion_r28538071'>File: src/com/googlecode/jmxtrans/model/naming/StringUtils.java:L40-63</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This looks suspicious. Having a need to treat an empty string `""` or the string representation of the empty string `"\"\""` is really strange. It lets me think that the problem you are trying to solve is that we do not interpret the string correctly at some point.
- <a href='https://github.com/conorbev'><img border=0 src='https://avatars.githubusercontent.com/u/997809?v=3' height=16 width=16'></a> The underlying issue is actually that Yammer metrics itself is putting " characters into the Java ObjectName inside JMX. So I'm seeing things like: ObjectName="metric":type="",name="runtime"
You are right though that we might be able to clean it out earlier in the code.. I am not sure if this is a common issue with Yammer metrics (which appears to be pretty popular) or just the ones I'm looking at but in any case this is an edge case I'd like to fix without impacting anything else.
There is an existing StringUtils.cleanupStr method that runs pretty late in this whole process. Initially I thought the best thing would be for it to just strip trailing dots, but, if I do that it breaks this test in StringUtilsTests:
assertEquals("abcd.abcd.", StringUtils.cleanupStr("abcd.abcd.", true));
Just like KeyUtilsTests that @lookfirst commented on I'm not convinced that test case is valid, but, I don't really like breaking existing tests when I'm not sure if there was a good reason for them! :-)
I find this whole area inside KeyUtils to be fairly convoluted and probably needing a more major cleanup. As this is probably just an edge case though, I'm not sure if it is worth changing too much.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Strange, we use Yammer metrics and I have not seen this issue. In any case, we should escape those `\"`, not make them disappear. If a lib want to add quotes in objects name, why not, we should respect this choice. We should just make sure we do not send garbage to the backends. Which means that we probably want to address this in `StringUtils.cleanupStr()`.
- [ ] <a href='#crh-comment-Pull 228ff0b6b0cb4f55e408ec2583008521a9438534 src/com/googlecode/jmxtrans/model/naming/KeyUtils.java 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/271#discussion_r28538521'>File: src/com/googlecode/jmxtrans/model/naming/KeyUtils.java:L160-167</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> That could be replaced by `Strings.isNullOrEmpty()`, which I find more readable. Or the equivalent from apache common-lang
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Also it seem to me that this whole block could be written in a much simpler way by using the functional idioms of Guava.
- [ ] <a href='#crh-comment-Pull 228ff0b6b0cb4f55e408ec2583008521a9438534 src/com/googlecode/jmxtrans/model/naming/KeyUtils.java 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/271#discussion_r28538690'>File: src/com/googlecode/jmxtrans/model/naming/KeyUtils.java:L193-202</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> There is an indentation problem here.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/271?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/271?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/271'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>