### PR TITLE
Hotfix/Double underflow error in Ganglia

### DIFF
--- a/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java
@@ -166,7 +166,10 @@ public class GangliaWriter extends BaseOutputWriter {
 			if (result.getValues() != null) {
 				for (final Map.Entry<String, Object> resultValue : result.getValues().entrySet()) {
 					final String name = KeyUtils.getKeyString(query, result, resultValue, getTypeNames());
-					final String value = resultValue.getValue().toString();
+					String value = resultValue.getValue().toString();
+					BigDecimal bd = new BigDecimal(value);
+					if (bd.compareTo(new BigDecimal("1E-308”)) <= 0)
+						value = "0";
 					GMetricType dataType = getType(resultValue.getValue());
 					log.debug("Sending Ganglia metric {}={} [type={}]", name, value, dataType);
 					new GMetric(host, port, addressingMode, ttl, v31, null, spoofedHostName)

--- a/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import java.math.BigDecimal;
+
 import static info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode;
 
 /**

--- a/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java
@@ -64,6 +64,7 @@ public class GangliaWriter extends BaseOutputWriter {
 	public static final int DEFAULT_DMAX = 0;
 	public static final int DEFAULT_TMAX = 60;
 	public static final String DEFAULT_GROUP_NAME = "JMX";
+	public static final BigDecimal GANGLIA_MIN_DOUBLE = new BigDecimal("1E-308");
 
 	/* Settings run-time values. */
 	private final String host;
@@ -168,14 +169,14 @@ public class GangliaWriter extends BaseOutputWriter {
 			if (result.getValues() != null) {
 				for (final Map.Entry<String, Object> resultValue : result.getValues().entrySet()) {
 					final String name = KeyUtils.getKeyString(query, result, resultValue, getTypeNames());
-					String value = resultValue.getValue().toString();
-					BigDecimal bd = new BigDecimal(value);
-					if (bd.compareTo(new BigDecimal("1E-308")) <= 0)
-						value = "0";
+					
+					BigDecimal value = new BigDecimal(resultValue.getValue().toString());
+					String strValue = value.compareTo(GANGLIA_MIN_DOUBLE) <= 0 ? "0" : value.toString();
+
 					GMetricType dataType = getType(resultValue.getValue());
-					log.debug("Sending Ganglia metric {}={} [type={}]", name, value, dataType);
+					log.debug("Sending Ganglia metric {}={} [type={}]", name, strValue, dataType);
 					new GMetric(host, port, addressingMode, ttl, v31, null, spoofedHostName)
-							.announce(name, value, dataType, units, slope, tmax, dmax, groupName);
+							.announce(name, strValue, dataType, units, slope, tmax, dmax, groupName);
 				}
 			}
 		}

--- a/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java
+++ b/src/com/googlecode/jmxtrans/model/output/GangliaWriter.java
@@ -170,7 +170,7 @@ public class GangliaWriter extends BaseOutputWriter {
 					final String name = KeyUtils.getKeyString(query, result, resultValue, getTypeNames());
 					String value = resultValue.getValue().toString();
 					BigDecimal bd = new BigDecimal(value);
-					if (bd.compareTo(new BigDecimal("1E-308”)) <= 0)
+					if (bd.compareTo(new BigDecimal("1E-308")) <= 0)
 						value = "0";
 					GMetricType dataType = getType(resultValue.getValue());
 					log.debug("Sending Ganglia metric {}={} [type={}]", name, value, dataType);


### PR DESCRIPTION
Possible solution for issue #272, error with conversion of types between JAVA and C.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/273%23discussion_r28532613%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/273%23discussion_r28532672%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/273%23discussion_r28532735%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/273%23discussion_r28548475%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/273%23discussion_r28631392%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20f38b4aec1c0d1569a790056e5512a710af26b02a%20src/com/googlecode/jmxtrans/model/output/GangliaWriter.java%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/273%23discussion_r28532735%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20you%20are%20adding%20a%20branch%20in%20the%20execution%20flow%2C%20it%20make%20sense%20to%20add%20a%20test%20for%20it%20as%20well.%22%2C%20%22created_at%22%3A%20%222015-04-16T17%3A47%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/output/GangliaWriter.java%3AL169-183%22%7D%2C%20%22Pull%20f38b4aec1c0d1569a790056e5512a710af26b02a%20src/com/googlecode/jmxtrans/model/output/GangliaWriter.java%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/273%23discussion_r28532672%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20case%20where%20we%20are%20modifying%20the%20data%20being%20sent%2C%20I%20think%20we%20should%20at%20least%20log%20an%20%60info%60%2C%20maybe%20a%20%60warning%60.%22%2C%20%22created_at%22%3A%20%222015-04-16T17%3A47%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/output/GangliaWriter.java%3AL169-183%22%7D%2C%20%22Pull%20f38b4aec1c0d1569a790056e5512a710af26b02a%20src/com/googlecode/jmxtrans/model/output/GangliaWriter.java%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/273%23discussion_r28631392%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%601E-308%60%20is%20actually%20%3E%200.%20Which%20means%20that%20with%20the%20test%20you%20are%20doing%20below%2C%20any%20negative%20value%20will%20be%20modified%20to%200.%20This%20is%20probably%20not%20what%20you%20want%20to%20do.%22%2C%20%22created_at%22%3A%20%222015-04-17T21%3A24%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/output/GangliaWriter.java%3AL64-71%22%7D%2C%20%22Pull%20f38b4aec1c0d1569a790056e5512a710af26b02a%20src/com/googlecode/jmxtrans/model/output/GangliaWriter.java%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/273%23discussion_r28532613%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20that%20when%20value%20is%20too%20small%20for%20Ganglia%2C%20you%20replace%20it%20with%200.%20What%20you%20probably%20want%20is%20to%20replace%20it%20with%20%60GANGLIA_MIN_DOUBLE%60.%20This%20should%20probably%20be%20implemented%20as%20%60Math.max%28resultValue.getValue%28%29%2C%20GANGLIA_MIN_DOUBLE%29%60.%20Note%20that%20there%20is%20no%20garantee%20that%20%60resultValue.getValue%28%29%60%20is%20a%20number%2C%20so%20some%20type%20checking%20should%20probably%20be%20done.%22%2C%20%22created_at%22%3A%20%222015-04-16T17%3A46%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22As%20what%20we%20are%20doing%20here%20is%20transforming%20values%2C%20we%20should%20probably%20reuse%20the%20concept%20of%20%5BValueTransformer%5D%28https%3A//github.com/jmxtrans/jmxtrans/blob/master/src/com/googlecode/jmxtrans/model/results/ValueTransformer.java%29.%20We%20will%20probably%20have%20the%20same%20problematic%20with%20other%20output%20writers.%20It%20also%20makes%20it%20much%20easier%20to%20test.%22%2C%20%22created_at%22%3A%20%222015-04-16T20%3A48%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/com/googlecode/jmxtrans/model/output/GangliaWriter.java%3AL169-183%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull f38b4aec1c0d1569a790056e5512a710af26b02a src/com/googlecode/jmxtrans/model/output/GangliaWriter.java 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/273#discussion_r28532613'>File: src/com/googlecode/jmxtrans/model/output/GangliaWriter.java:L169-183</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Seems that when value is too small for Ganglia, you replace it with 0. What you probably want is to replace it with `GANGLIA_MIN_DOUBLE`. This should probably be implemented as `Math.max(resultValue.getValue(), GANGLIA_MIN_DOUBLE)`. Note that there is no garantee that `resultValue.getValue()` is a number, so some type checking should probably be done.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> As what we are doing here is transforming values, we should probably reuse the concept of [ValueTransformer](https://github.com/jmxtrans/jmxtrans/blob/master/src/com/googlecode/jmxtrans/model/results/ValueTransformer.java). We will probably have the same problematic with other output writers. It also makes it much easier to test.
- [ ] <a href='#crh-comment-Pull f38b4aec1c0d1569a790056e5512a710af26b02a src/com/googlecode/jmxtrans/model/output/GangliaWriter.java 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/273#discussion_r28532672'>File: src/com/googlecode/jmxtrans/model/output/GangliaWriter.java:L169-183</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> In case where we are modifying the data being sent, I think we should at least log an `info`, maybe a `warning`.
- [ ] <a href='#crh-comment-Pull f38b4aec1c0d1569a790056e5512a710af26b02a src/com/googlecode/jmxtrans/model/output/GangliaWriter.java 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/273#discussion_r28532735'>File: src/com/googlecode/jmxtrans/model/output/GangliaWriter.java:L169-183</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> As you are adding a branch in the execution flow, it make sense to add a test for it as well.
- [ ] <a href='#crh-comment-Pull f38b4aec1c0d1569a790056e5512a710af26b02a src/com/googlecode/jmxtrans/model/output/GangliaWriter.java 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/273#discussion_r28631392'>File: src/com/googlecode/jmxtrans/model/output/GangliaWriter.java:L64-71</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> `1E-308` is actually > 0. Which means that with the test you are doing below, any negative value will be modified to 0. This is probably not what you want to do.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/273?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/273?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/273'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>