### PR TITLE
Pr scmsite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - mvn compile -DskipTests=true -Dmaven.javadoc.skip=true -Dcobertura.skip=true -B -V
 script: ./travis-script.sh
 after_success:
-  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "$SITE_BRANCH_NAME" && mvn site --settings ${HOME}/travis/settings.xml -B -V && mvn site:stage scm-publish:publish-scm --settings ${HOME}/travis/settings.xml -B -V
+  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "$SITE_BRANCH_NAME" && mvn site-deploy --settings ${HOME}/travis/settings.xml -B -V && mvn site:stage scm-publish:publish-scm --settings ${HOME}/travis/settings.xml -B -V
 branches:
   except:
     - travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - mvn compile -DskipTests=true -Dmaven.javadoc.skip=true -Dcobertura.skip=true -B -V
 script: ./travis-script.sh
 after_success:
-  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && mvn site --settings ${HOME}/travis/settings.xml -B -V
+  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "$SITE_BRANCH_NAME" && mvn site --settings ${HOME}/travis/settings.xml -B -V && mvn site:stage scm-publish:publish-scm --settings ${HOME}/travis/settings.xml -B -V
 branches:
   except:
     - travis

--- a/jmxtrans-core/pom.xml
+++ b/jmxtrans-core/pom.xml
@@ -116,16 +116,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-examples/pom.xml
+++ b/jmxtrans-examples/pom.xml
@@ -71,16 +71,6 @@
 
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-cloudwatch/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/pom.xml
@@ -82,16 +82,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-core/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-core/pom.xml
@@ -41,6 +41,10 @@
 			<artifactId>commons-lang</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>commons-pool</groupId>
 			<artifactId>commons-pool</artifactId>
 		</dependency>
@@ -118,16 +122,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>

--- a/jmxtrans-output/jmxtrans-output-ganglia/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-ganglia/pom.xml
@@ -59,16 +59,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-jrobin/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-jrobin/pom.xml
@@ -71,16 +71,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-log4j/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-log4j/pom.xml
@@ -66,16 +66,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-velocity/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-velocity/pom.xml
@@ -55,16 +55,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/pom.xml
+++ b/jmxtrans-output/pom.xml
@@ -33,19 +33,4 @@
 		<module>jmxtrans-output-velocity</module>
 	</modules>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/jmxtrans-utils/pom.xml
+++ b/jmxtrans-utils/pom.xml
@@ -66,16 +66,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -132,16 +132,6 @@
 
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>
@@ -204,17 +194,6 @@
 				</executions>
 			</plugin>
 			<?SORTPOM RESUME?>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<systemPropertyVariables>
-						<jmxtrans.log.dir>${project.build.directory}</jmxtrans.log.dir>
-						<myhost>w2</myhost>
-						<myport>1099</myport>
-					</systemPropertyVariables>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>appassembler-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -655,8 +655,6 @@
 					<artifactId>maven-scm-publish-plugin</artifactId>
 					<version>1.1</version>
 					<configuration>
-						<!-- try to reduce the number of files sent in one git add command -->
-						<addUniqueDirectory>true</addUniqueDirectory>
 						<scmBranch>gh-pages</scmBranch>
 						<tryUpdate>true</tryUpdate>
 						<serverId>github</serverId>
@@ -680,6 +678,15 @@
 								travis -->
 						</dependency>
 					</dependencies>
+					<executions>
+						<execution>
+						<id>sitestage</id>
+						<goals>
+							<goal>publish-scm</goal>
+						<goals>
+						<phase>site-deploy</phase>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -693,6 +700,15 @@
 					<configuration>
 						<skipDeploy>true</skipDeploy>
 					</configuration>
+					<executions>
+						<execution>
+							<id>stage-for-scm-publish</id>
+							<goals>
+								<goal>stage</goal>
+							</goals>
+							<phase>post-site</phase>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -655,6 +655,8 @@
 					<artifactId>maven-scm-publish-plugin</artifactId>
 					<version>1.1</version>
 					<configuration>
+						<!-- try to reduce the number of files sent in one git add command -->
+						<addUniqueDirectory>true</addUniqueDirectory>
 						<scmBranch>gh-pages</scmBranch>
 						<tryUpdate>true</tryUpdate>
 						<serverId>github</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
 			<id>ossrh</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
+		<site>
+			<id>github</id>
+			<url>scm:git:https://github.com/jmxtrans/jmxtrans</url>
+		</site>
 	</distributionManagement>
 
 	<properties>
@@ -92,9 +96,10 @@
 			dogmatic, but to provide consistency in the code.
 		-->
 		<checkstyle.max.allowed.violations>0</checkstyle.max.allowed.violations>
-		<github.global.server>github</github.global.server>
 		<!-- some versions used by multiple dependencies -->
 		<jackson.version>2.5.1</jackson.version>
+		<jmxtrans.stagingDirectory>${jmxtrans.targetDirectory}/staging</jmxtrans.stagingDirectory>
+		<jmxtrans.targetDirectory>${session.executionRootDirectory}/target</jmxtrans.targetDirectory>
 		<jsw.dir>${project.build.directory}/generated-resources/appassembler/jsw/${package.daemon.name}</jsw.dir>
 		<main.class>com.googlecode.jmxtrans.JmxTransformer</main.class>
 		<maven.build.timestamp.format>yyMMdd_HHmm</maven.build.timestamp.format>
@@ -103,7 +108,12 @@
 		<package.install.dir>/usr/share/${project.artifactId}</package.install.dir>
 		<package.user>${project.artifactId}</package.user>
 		<packageBuildTimeStamp>${maven.build.timestamp}</packageBuildTimeStamp>
+		<pitest.verbose>false</pitest.verbose>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<scmpublish.checkoutDirectory>${jmxtrans.targetDirectory}/scmpublish-checkout</scmpublish.checkoutDirectory>
+		<scmpublish.content>${jmxtrans.stagingDirectory}</scmpublish.content>
+		<stagingDirectory>${jmxtrans.stagingDirectory}/${project.version}</stagingDirectory>
+		<verify.haltOnFailure>true</verify.haltOnFailure>
 		<verify.mutationThreshold>100</verify.mutationThreshold>
 		<verify.totalBranchRate>100</verify.totalBranchRate>
 		<verify.totalLineRate>100</verify.totalLineRate>
@@ -186,6 +196,11 @@
 				<groupId>commons-lang</groupId>
 				<artifactId>commons-lang</artifactId>
 				<version>2.6</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-logging</groupId>
+				<artifactId>commons-logging</artifactId>
+				<version>1.1.3</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-pool</groupId>
@@ -425,26 +440,6 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>com.github.github</groupId>
-					<artifactId>site-maven-plugin</artifactId>
-					<!--
-						version 0.11 seem to have some problem to publish, let's wait until 0.12 to upgrade
-					-->
-					<version>0.10</version>
-					<configuration>
-						<message>Creating site for ${project.name}
-							${project.version}</message>
-					</configuration>
-					<executions>
-						<execution>
-							<goals>
-								<goal>site</goal>
-							</goals>
-							<phase>site</phase>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
 					<groupId>com.google.code.sortpom</groupId>
 					<artifactId>maven-sortpom-plugin</artifactId>
 					<version>2.3.0</version>
@@ -539,6 +534,14 @@
 							<id>checkstyle-check</id>
 							<goals>
 								<goal>check</goal>
+							</goals>
+							<phase>package</phase>
+						</execution>
+						<execution>
+							<id>checkstyle-report</id>
+							<goals>
+								<goal>checkstyle</goal>
+								<goal>checkstyle-aggregate</goal>
 							</goals>
 							<phase>verify</phase>
 						</execution>
@@ -649,6 +652,35 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-scm-publish-plugin</artifactId>
+					<version>1.1</version>
+					<configuration>
+						<scmBranch>gh-pages</scmBranch>
+						<tryUpdate>true</tryUpdate>
+						<serverId>github</serverId>
+						<skipDeletedFiles>true</skipDeletedFiles>
+						<!-- try to shortcut the delete process since we are not doing it anyway -->
+						<ignorePathsToDelete>
+							<ignorePathsToDelete>%regex[.*]</ignorePathsToDelete>
+						</ignorePathsToDelete>
+					</configuration>
+					<dependencies>
+						<dependency>
+							<groupId>org.apache.maven.scm</groupId>
+							<artifactId>maven-scm-api</artifactId>
+							<version>[1.9.4]</version>
+						</dependency>
+						<dependency>
+							<groupId>org.apache.maven.scm</groupId>
+							<artifactId>maven-scm-provider-gitexe</artifactId>
+							<version>[1.9.4]</version>
+							<!-- required in order to hide password value in command logging on 
+								travis -->
+						</dependency>
+					</dependencies>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
 					<version>2.3</version>
 				</plugin>
@@ -656,6 +688,9 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-site-plugin</artifactId>
 					<version>3.4</version>
+					<configuration>
+						<skipDeploy>true</skipDeploy>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -681,6 +716,19 @@
 							<include>**/*TestCase.java</include>
 							<include>**/*Tests.java</include>
 						</includes>
+						<systemPropertyVariables>
+							<jmxtrans.log.dir>${project.build.directory}</jmxtrans.log.dir>
+							<myhost>w2</myhost>
+							<myport>1099</myport>
+						</systemPropertyVariables>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-report-plugin</artifactId>
+					<version>2.18.1</version>
+					<configuration>
+						<aggregate>true</aggregate>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -714,23 +762,25 @@
 					<artifactId>cobertura-maven-plugin</artifactId>
 					<version>2.7</version>
 					<configuration>
+						<aggregate>true</aggregate>
 						<check>
 							<branchRate>0</branchRate>
+							<haltOnFailure>${verify.haltOnFailure}</haltOnFailure>
 							<lineRate>0</lineRate>
 							<packageBranchRate>0</packageBranchRate>
 							<packageLineRate>0</packageLineRate>
 							<totalBranchRate>${verify.totalBranchRate}</totalBranchRate>
 							<totalLineRate>${verify.totalLineRate}</totalLineRate>
 						</check>
+						<instrumentation>
+							<excludes>
+								<exclude>**/Test*.java</exclude>
+								<exclude>**/*Test.java</exclude>
+								<exclude>**/*TestCase.java</exclude>
+								<exclude>**/*Tests.java</exclude>
+							</excludes>
+						</instrumentation>
 					</configuration>
-					<executions>
-						<execution>
-							<goals>
-								<goal>clean</goal>
-								<goal>check</goal>
-							</goals>
-						</execution>
-					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -739,12 +789,15 @@
 					<configuration>
 						<effort>Max</effort>
 						<threshold>Default</threshold>
+						<!-- http://jira.codehaus.org/browse/MCOBERTURA-203 -->
+						<classFilesDirectory>${project.build.outputDirectory}</classFilesDirectory>
 					</configuration>
 					<executions>
 						<execution>
 							<goals>
 								<goal>check</goal>
 							</goals>
+							<phase>test</phase>
 						</execution>
 					</executions>
 				</plugin>
@@ -770,6 +823,7 @@
 						<historyInputFile>${project.basedir}/pitest-history.xml</historyInputFile>
 						<historyOutputFile>${project.build.directory}/pitest-history.xml</historyOutputFile>
 						<reportsDirectory>${project.build.directory}/site/pit-reports</reportsDirectory>
+						<verbose>${pitest.verbose}</verbose>
 						<threads>4</threads>
 						<targetClasses>
 							<param>com.googlecode.jmxtrans.*</param>
@@ -793,10 +847,6 @@
 
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
 				<groupId>com.google.code.sortpom</groupId>
 				<artifactId>maven-sortpom-plugin</artifactId>
 			</plugin>
@@ -818,6 +868,14 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-scm-publish-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-site-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
 			<plugin>
@@ -831,6 +889,22 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>clean</id>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+						<phase>clean</phase>
+					</execution>
+					<execution>
+						<id>check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<phase>verify</phase>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -901,6 +975,11 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-site-plugin</artifactId>
+				<version>3.4</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
 				<version>2.18.1</version>
 			</plugin>
@@ -908,6 +987,15 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
 				<version>2.7</version>
+				<inherited>true</inherited>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<!-- only run cobertura -->
+							<report>cobertura</report>
+						</reports>
+					</reportSet>
+				</reportSets>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
@@ -960,6 +1048,10 @@
 				<artifactId>versions-maven-plugin</artifactId>
 				<version>2.1</version>
 			</plugin>
+			<plugin>
+				<groupId>org.pitest</groupId>
+				<artifactId>pitest-maven</artifactId>
+			</plugin>
 		</plugins>
 	</reporting>
 
@@ -971,6 +1063,9 @@
 					<plugin>
 						<groupId>org.pitest</groupId>
 						<artifactId>pitest-maven</artifactId>
+						<configuration>
+							<exportLineCoverage>true</exportLineCoverage>
+						</configuration>
 						<executions>
 							<execution>
 								<id>pitest</id>
@@ -1049,6 +1144,15 @@
 					</plugins>
 				</pluginManagement>
 			</build>
+		</profile>
+		<profile>
+			<id>withPitVerbose</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<properties>
+				<pitest.verbose>true</pitest.verbose>
+			</properties>
 		</profile>
 	</profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -683,7 +683,7 @@
 						<id>sitestage</id>
 						<goals>
 							<goal>publish-scm</goal>
-						<goals>
+						</goals>
 						<phase>site-deploy</phase>
 						</execution>
 					</executions>

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -40,7 +40,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     fi
   else
     echo "Building feature branch"
-    mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb
+    mvn install --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb
   fi
 else
   echo "Building pull request"


### PR DESCRIPTION
This pull request switches from using the github site plugin to maven-scm-publish-plugin as there was no current way to upload the whole site without triggering the abuse mechanisms

The scm-publish strategy relies on git scm provider which also has a problem for large changes as it tries to "git add" all changed files in one command line and this is way too big. 

The end result is to use site-stage to push each individual projects site to one "global" directory (currently found using session.executionRootDirectory) and scm-publish immediately after each site is staged. This minimises the number of files changed on each operation. A final site stage and scm-publish is called in order to pickup any aggregate reports that would only have been completed at the end of the site build (cobertura aggregate)

As I was interested in how the cobertura coverage was change (and why), Ive made the site upload to a folder called ${project.version} and disabled any deletion of file through scm-publish. This should mean you can maintain a site at gh-pages without the maven site overwriting it.

The use of the git provider, means authentication is still done with the github token but it is recommended to add the following environment variables to travis:
GIT_AUTHOR_NAME
GIT_COMMITTER_NAME
and these with secure settings applied so they dont show in the logs:
GIT_AUTHOR_EMAIL
GIT_COMMITTER_EMAIL

The email settings are used by github to determine what is displayed on github.

Git provider versions before 1.9.4 showed the whole token in the logs, so the version is set as a dependency with a fixed version

Ive added a required environment variable (SITE_BRANCH_NAME) that designates which branch should initiate the site build - this was a convenience method for me to test outside the main project. It should also mean no site will be built until you set this in travis to the appropriate branch

Ive also added a profile to turn on verbose logging on pitest (off by default)

There is an example of the complete build including site deploy with this branch at:
https://travis-ci.org/abcops/jmxtrans/builds/64401278
and the built site can be seen at:
http://abcops.github.io/jmxtrans/251-SNAPSHOT/

Im not sure what will be produced when a non-feature branch is built.
