### PR TITLE
Switch OpenTSDB telnet writer to use GenericKeyedObjectPool

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
@@ -4,20 +4,27 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.DataOutputStream;
+import javax.inject.Inject;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.net.Socket;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.net.ConnectException;
 import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Charsets.UTF_8;
+import static com.googlecode.jmxtrans.model.PropertyResolver.resolveProps;
 
 /**
  * OpenTSDBWriter which directly sends
@@ -28,8 +35,8 @@ import static com.google.common.base.Charsets.UTF_8;
 public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 	private static final Logger log = LoggerFactory.getLogger(OpenTSDBWriter.class);
 
-	protected Socket socket;
-	protected DataOutputStream out;
+	private GenericKeyedObjectPool<InetSocketAddress, Socket> pool;
+	private final InetSocketAddress address;
 
 	@JsonCreator
 	public OpenTSDBWriter(
@@ -46,6 +53,21 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 			@JsonProperty("settings") Map<String, Object> settings) throws LifecycleException, UnknownHostException {
 		super(typeNames, booleanAsNumber, debugEnabled, host, port, tags, tagName, mergeTypeNamesTags, metricNamingExpression,
 				addHostnameTag, settings);
+		host = resolveProps(host);
+		if (host == null) {
+			host = (String) getSettings().get(HOST);
+		}
+		if (host == null) {
+			throw new NullPointerException("Host cannot be null.");
+		}
+		if (port == null) {
+			port = Settings.getIntegerSetting(getSettings(), PORT, null);
+		}
+		if (port == null) {
+			throw new NullPointerException("Port cannot be null.");
+		}
+		this.address = new InetSocketAddress(host, port);
+
 	}
 
 	/**
@@ -57,94 +79,45 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 		return true;
 	}
 
-	/**
-	 * Prepare for sending metrics.
-	 */
-	@Override
-	protected void prepareSender() throws LifecycleException {
-
-		if (host == null || port == null) {
-			throw new LifecycleException("Host and port for " + this.getClass().getSimpleName() + " output can't be null");
-		}
-
-		try {
-			socket = new Socket(host, port);
-		} catch (UnknownHostException e) {
-			log.error("error opening socket to OpenTSDB", e);
-			throw new LifecycleException(e);
-		} catch (IOException e) {
-			log.error("error opening socket to OpenTSDB", e);
-			throw new LifecycleException(e);
-		}
-	}
-
-	/**
-	 * Shutdown the sender as it will no longer be used to send metrics.
-	 */
-	@Override
-	protected void shutdownSender() throws LifecycleException {
-		try {
-			socket.close();
-		} catch (IOException e) {
-			log.error("error closing socket to OpenTSDB", e);
-			throw new LifecycleException(e);
-		}
-	}
-
-	/**
-	 * Start the output for the results of a Query to OpenTSDB.
-	 */
-	@Override
-	protected void startOutput() throws IOException {
-		try {
-			this.out = new DataOutputStream(socket.getOutputStream());
-		} catch (IOException e) {
-			log.error("error getting the output stream", e);
-			throw e;
-		}
-	}
-
-	/**
-	 * Send a single metric to the server.
-	 *
-	 * @param metricLine - the line containing the metric name, value, and tags for a single metric; excludes the
-	 *                   "put" keyword expected by OpenTSDB and the trailing newline character.
-	 */
 	@Override
 	protected void sendOutput(String metricLine) throws IOException {
-		try {
-			
-			if (isDebugEnabled() || log.isDebugEnabled()) {
-				log.debug("Sending to server {}:{} line={}", host, port, metricLine);
-			}
-			
-			this.out.writeBytes("put " + metricLine + "\n");
-		} catch (IOException e) {
-			log.error("error writing result to the output stream", e);
-			throw e;
-		}
 	}
 
-	/**
-	 * Finish the output for a single Query, flushing all data to the server and logging the server's response.
-	 */
 	@Override
-	protected void finishOutput() throws IOException {
-		try {
-			this.out.flush();
-		} catch (IOException e) {
-			log.error("flush failed", e);
-			throw e;
+	public void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
+	Socket socket = null;
+	PrintWriter writer = null;
+
+	try {
+		socket = pool.borrowObject(address);
+		writer = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), UTF_8), true);
+
+		for (Result result : results) {
+			log.debug("Query result: {}", result);
+			Map<String, Object> resultValues = result.getValues();
+			if (resultValues != null) {
+				for (String resultString : resultParser(result)) {
+					log.debug("OpenTSDB Message: {}", resultString);
+					writer.write("put " + resultString + "\n");
+				}
+			}
 		}
 
-		// Read and log the response from the server for diagnostic purposes.
-
-		InputStreamReader socketInputStream = new InputStreamReader(socket.getInputStream(), UTF_8);
-		BufferedReader bufferedSocketInputStream = new BufferedReader(socketInputStream);
-		String line;
-		while (socketInputStream.ready() && (line = bufferedSocketInputStream.readLine()) != null) {
-			log.warn("OpenTSDB says: " + line);
+	} catch (ConnectException e) {
+		log.error("Error while connecting to OpenTSDB");
+	} finally {
+		if (writer != null && writer.checkError()) {
+			log.error("Error writing to OpenTSDB, clearing OpenTSDB socket pool");
+			pool.invalidateObject(address, socket);
+		} else {
+			pool.returnObject(address, socket);
 		}
+	}
+	}
+
+	@Inject
+	public void setPool(GenericKeyedObjectPool<InetSocketAddress, Socket> pool) {
+		this.pool = pool;
 	}
 
 	public static Builder builder() {

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java
@@ -2,6 +2,9 @@ package com.googlecode.jmxtrans.model.output;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
@@ -56,6 +59,25 @@ public class TCollectorUDPWriter extends OpenTSDBGenericWriter {
 	@Override
 	protected boolean getAddHostnameTagDefault() {
 		return false;
+	}
+	/**
+	* Write the results of the query.
+	 *
+	 * @param server
+	 * @param query   - the query and its results.
+	 * @param results
+	*/
+	@Override
+	public void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
+		this.startOutput();
+		for (Result result : results) {
+			for (String resultString : resultParser(result)) {
+				if (isDebugEnabled())
+				log.debug("TCollectorUDP Message: {}", resultString);
+				this.sendOutput(resultString);
+			}
+		}
+		this.finishOutput();
 	}
 
 	/**

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
@@ -2,39 +2,38 @@ package com.googlecode.jmxtrans.model.output;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
-import org.hamcrest.Matchers;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ValidationException;
+import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
+import org.mockito.Matchers;
 import org.slf4j.Logger;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
-import java.net.UnknownHostException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
 
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.contains;
-import static org.mockito.Matchers.eq;
-
+import static com.google.common.collect.ImmutableList.of;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link OpenTSDBWriter}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ OpenTSDBWriter.class })
+
 public class OpenTSDBWriterTests {
 	protected OpenTSDBWriter writer;
 	protected Query mockQuery;
@@ -45,236 +44,6 @@ public class OpenTSDBWriterTests {
 	protected BufferedReader mockBufRdr;
 	protected Logger mockLog;
 	protected ImmutableMap<String, Object> testValues;
-
-	/**
-	 * Prepare the test with standard mocks and mock interactions.  Also perform the base configuration of the
-	 * object under test.
-	 */
-	@Before
-	public void	setupTest () throws Exception {
-		// Prepare Mock Objects
-		this.mockQuery = Mockito.mock(Query.class);
-		this.mockResult = Mockito.mock(Result.class);
-		this.mockSocket = Mockito.mock(Socket.class);
-		this.mockInStreamRdr = Mockito.mock(InputStreamReader.class);
-		this.mockBufRdr = Mockito.mock(BufferedReader.class);
-		this.mockLog = Mockito.mock(Logger.class);
-
-		// PowerMockito mocks for those final/static classes and methods:
-		this.mockOut = PowerMockito.mock(DataOutputStream.class);
-
-
-		// Setup common mock interactions.
-		PowerMockito.whenNew(Socket.class).withParameterTypes(String.class, int.class).
-			withArguments("localhost", 4242).thenReturn(this.mockSocket);
-		PowerMockito.whenNew(DataOutputStream.class).withAnyArguments().thenReturn(this.mockOut);
-		PowerMockito.whenNew(InputStreamReader.class).withAnyArguments().thenReturn(this.mockInStreamRdr);
-		PowerMockito.whenNew(BufferedReader.class).withAnyArguments().thenReturn(this.mockBufRdr);
-
-
-		// When results are needed.
-		testValues = ImmutableMap.<String, Object>of("x-att1-x", "120021");
-		Mockito.when(this.mockResult.getValues()).thenReturn(testValues);
-		Mockito.when(this.mockResult.getAttributeName()).thenReturn("X-ATT-X");
-		Mockito.when(this.mockResult.getClassName()).thenReturn("X-DOMAIN.PKG.CLASS-X");
-		Mockito.when(this.mockResult.getTypeName()).thenReturn("Type=x-type-x");
-		Mockito.when(this.mockInStreamRdr.ready()).thenReturn(false);
-
-
-		// Prepare the object under test and test data.
-		this.writer = OpenTSDBWriter.builder()
-				.setDebugEnabled(false)
-				.setHost("localhost")
-				.setPort(4242)
-				.build();
-
-		// Inject the mock logger
-		Whitebox.setInternalState(OpenTSDBWriter.class, Logger.class, this.mockLog);
-	}
-
-	/**
-	 * Test a successful send without any response from OpenTSDB.
-	 */
-	@Test
-	public void	testSuccessfulSendNoOpenTSDBResponse () throws Exception {
-		ArgumentCaptor<String>	lineCapture = ArgumentCaptor.forClass(String.class);
-
-		// Execute.
-		this.writer.start();
-		this.writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
-		this.writer.stop();
-
-		// Verify.
-		Mockito.verify(this.mockOut).writeBytes(lineCapture.capture());
-
-		Assert.assertThat(lineCapture.getValue(), Matchers.startsWith("put X-DOMAIN.PKG.CLASS-X.X-ATT-X 0 120021"));
-		Assert.assertThat(lineCapture.getValue(), Matchers.containsString(" host="));
-	}
-
-	/**
-	 * Verify a successful send with a response from OpenTSDB with the second ready() on the InputStream returning
-	 * false.
-	 */
-	@Test
-	public void	testSuccessfulSendOpenTSDBResponse1 () throws Exception {
-		// Prepare.
-		Mockito.when(this.mockInStreamRdr.ready()).thenReturn(true).thenReturn(false);
-		Mockito.when(this.mockBufRdr.readLine()).thenReturn("X-OPENTSDB-MSG-X");
-
-		// Execute.
-		this.writer.start();
-		this.writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
-		this.writer.stop();
-
-
-		// Verify.
-		Mockito.verify(this.mockOut).writeBytes(Mockito.startsWith("put X-DOMAIN.PKG.CLASS-X.X-ATT-X 0 120021"));
-		Mockito.verify(this.mockLog).warn("OpenTSDB says: X-OPENTSDB-MSG-X");
-	}
-
-	/**
-	 * Verify a successful send with a response from OpenTSDB with the second readLine returning null.
-	 */
-	@Test
-	public void	testSuccessfulSendOpenTSDBResponse2 () throws Exception {
-		// Prepare.
-		Mockito.when(this.mockInStreamRdr.ready()).thenReturn(true);
-		Mockito.when(this.mockBufRdr.readLine()).thenReturn("X-OPENTSDB-MSG-X").thenReturn(null);
-
-		// Execute.
-		this.writer.start();
-		this.writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
-		this.writer.stop();
-
-
-		// Verify.
-		Mockito.verify(this.mockOut).writeBytes(Mockito.startsWith("put X-DOMAIN.PKG.CLASS-X.X-ATT-X 0 120021"));
-		Mockito.verify(this.mockLog).warn("OpenTSDB says: X-OPENTSDB-MSG-X");
-	}
-
-	/**
-	 * Test throwing of UnknownHostException when creating the socket.
-	 */
-	@Test
-	public void	testUnknownHostException () throws Exception {
-		// Prepare.
-		UnknownHostException uhExc = new UnknownHostException("X-TEST-UHE-X");
-		PowerMockito.whenNew(Socket.class).withParameterTypes(String.class, int.class).
-			withArguments("localhost", 4242).thenThrow(uhExc);
-
-		try {
-			// Execute.
-			this.writer.start();
-
-			Assert.fail("LifecycleException missing");
-		} catch ( LifecycleException lcExc ) {
-			// Verify.
-			Assert.assertSame(uhExc, lcExc.getCause());
-			Mockito.verify(this.mockLog).error(contains("opening socket"), eq(uhExc));
-		}
-	}
-
-	/**
-	 * Test throwing of IOException when creating the socket.
-	 */
-	@Test
-	public void	testSocketCreationIOException () throws Exception {
-		// Prepare.
-		IOException	ioExc = new IOException("X-TEST-IO-EXC-X");
-		PowerMockito.whenNew(Socket.class).withParameterTypes(String.class, int.class).
-			withArguments("localhost", 4242).thenThrow(ioExc);
-
-		try {
-			// Execute.
-			this.writer.start();
-			Assert.fail("LifecycleException missing");
-		} catch ( LifecycleException lcExc ) {
-			// Verify.
-			Assert.assertSame(ioExc, lcExc.getCause());
-			Mockito.verify(this.mockLog).error(contains("opening socket"), eq(ioExc));
-		}
-	}
-
-	/**
-	 * Test throwing of IOException when closing the socket.
-	 */
-	@Test
-	public void	testSocketCloseIOException () throws Exception {
-		// Prepare.
-		IOException	ioExc = new IOException("X-TEST-IO-EXC-X");
-		Mockito.doThrow(ioExc).when(this.mockSocket).close();
-
-		// Execute.
-		this.writer.start();
-		try {
-			this.writer.stop();
-			Assert.fail("LifecycleException missing");
-		} catch ( LifecycleException lcExc ) {
-			// Verify.
-			Assert.assertSame(ioExc, lcExc.getCause());
-			Mockito.verify(this.mockLog).error(contains("closing socket"), eq(ioExc));
-		}
-	}
-
-	/**
-	 * Test throwing of IOException when starting output.
-	 */
-	@Test
-	public void	testStartOutputIOException () throws Exception {
-		// Prepare.
-		IOException	ioExc = new IOException("X-TEST-IO-EXC-X");
-		Mockito.when(this.mockSocket.getOutputStream()).thenThrow(ioExc);
-
-		// Execute.
-		this.writer.start();
-		try {
-			this.writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
-			Assert.fail("IOException missing");
-		} catch ( IOException ioCaught ) {
-			// Verify.
-			Assert.assertSame(ioExc, ioCaught);
-			Mockito.verify(this.mockLog).error(contains("output stream"), eq(ioExc));
-		}
-	}
-
-	/**
-	 * Test IOException thrown on SendOutput.
-	 */
-	@Test
-	public void	testSendOutputIOException () throws Exception {
-		// Prepare.
-		IOException	ioExc = new IOException("X-TEST-IO-EXC-X");
-		Mockito.doThrow(ioExc).when(this.mockOut).writeBytes(anyString());
-
-		// Execute.
-		this.writer.start();
-		try {
-			this.writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
-			Assert.fail("IOException missing");
-		} catch ( IOException ioCaught ) {
-			// Verify.
-			Assert.assertSame(ioExc, ioCaught);
-			Mockito.verify(this.mockLog).error(contains("writing result"), eq(ioExc));
-		}
-	}
-
-	@Test
-	public void	testFinishOutputIOException () throws Exception {
-		// Prepare.
-		IOException	ioExc = new IOException("X-TEST-IO-EXC-X");
-		Mockito.doThrow(ioExc).when(this.mockOut).flush();
-
-		// Execute.
-		this.writer.start();
-		try {
-			this.writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
-			Assert.fail("exception on flush was not thrown");
-		} catch ( IOException ioCaught ) {
-			// Verify.
-			Assert.assertSame(ioExc, ioCaught);
-			Mockito.verify(this.mockLog).error(contains("flush failed"), eq(ioExc));
-		}
-	}
 
 	@Test(expected = NullPointerException.class)
 	public void	exceptionThrownIfHostIsNotDefined() throws Exception {
@@ -289,4 +58,75 @@ public class OpenTSDBWriterTests {
 				.setHost("localhost")
 				.build();
 	}
+	@Test
+	public void socketInvalidatedWhenError() throws Exception {
+		// a lot of setup for not much of a test ...
+		Server server = Server.builder().setHost("host").setPort("123").build();
+		Query query = Query.builder().build();
+		Result result = new Result(System.currentTimeMillis(), "attributeName", "className", "objDomain", "classNameAlias", "typeName", ImmutableMap.of("key", (Object)1));
+
+		GenericKeyedObjectPool<InetSocketAddress, Socket> pool = Mockito.mock(GenericKeyedObjectPool.class);
+		Socket socket = Mockito.mock(Socket.class);
+		Mockito.when(pool.borrowObject(Matchers.any(InetSocketAddress.class))).thenReturn(socket);
+		UnflushableByteArrayOutputStream out = new UnflushableByteArrayOutputStream();
+		Mockito.when(socket.getOutputStream()).thenReturn(out);
+
+		OpenTSDBWriter writer = OpenTSDBWriter.builder()
+				.setHost("localhost")
+				.setPort(4243)
+				.build();
+		writer.setPool(pool);
+
+		writer.doWrite(server, query, of(result));
+		Mockito.verify(pool).invalidateObject(Matchers.any(InetSocketAddress.class), Matchers.eq(socket));
+		Mockito.verify(pool, Mockito.never()).returnObject(Matchers.any(InetSocketAddress.class), Matchers.eq(socket));
+	}
+
+	
+	private static OpenTSDBWriter getOpenTSDBWriter(OutputStream out) throws Exception {
+		return getOpenTSDBWriter(out, new ArrayList<String>());
+	}
+
+	private static OpenTSDBWriter getOpenTSDBWriter(OutputStream out, List<String> typeNames) throws Exception {
+		GenericKeyedObjectPool<InetSocketAddress, Socket> pool = Mockito.mock(GenericKeyedObjectPool.class);
+		Socket socket = Mockito.mock(Socket.class);
+		Mockito.when(pool.borrowObject(Matchers.any(InetSocketAddress.class))).thenReturn(socket);
+
+		Mockito.when(socket.getOutputStream()).thenReturn(out);
+
+		OpenTSDBWriter writer = OpenTSDBWriter.builder()
+				.setHost("localhost")
+				.setPort(4243)
+				.addTypeNames(typeNames)
+				.build();
+		writer.setPool(pool);
+
+		return writer;
+	}
+
+	@Test
+	public void writeSingleResult() throws Exception {
+		Server server = Server.builder().build();
+		Query query = Query.builder().build();
+		Result result = new Result(System.currentTimeMillis(), "attributeName", "className", "objDomain", "classNameAlias", "typeName", ImmutableMap.of("key", (Object)1));
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		OpenTSDBWriter writer = getOpenTSDBWriter(out);
+
+		writer.doWrite(server, query, of(result));
+
+		// check that OpenTSDB format is respected
+		assertThat(out.toString()).startsWith("put classNameAlias.attributeName ")
+			.contains("type=key")
+			.contains("host=")  // hostname is added by default
+			.endsWith("\n");
+	}
+
+	private static class UnflushableByteArrayOutputStream extends ByteArrayOutputStream {
+		@Override
+		public void flush() throws IOException {
+			throw new IOException();
+		}
+	}
+
 }


### PR DESCRIPTION
And eliminate LifecycleExceptions where possible.
Most of the code and tests is borrowed from GraphiteWriter that trust connection handling to GenericKeyedObjectPool. Prior implementation was throwing LifecycleExceptions on innocent things like refused connections.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23issuecomment-107332031%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23issuecomment-107678333%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23discussion_r31403460%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23discussion_r31403569%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23discussion_r31403607%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23discussion_r31460670%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23discussion_r31460672%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23discussion_r31460673%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23issuecomment-107680750%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23issuecomment-107681053%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23issuecomment-107682098%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23issuecomment-107682576%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23issuecomment-107332031%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20a%20lo%20for%20the%20help%20%21%20That%20something%20I%20wanted%20to%20clean%20up.%20I%27ll%20have%20a%20closer%20look%20this%20evening.%22%2C%20%22created_at%22%3A%20%222015-06-01T07%3A06%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-01T19%3A28%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3947391%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ivan-gusev%22%7D%7D%2C%20%7B%22body%22%3A%20%22Just%20a%20side%20note%20for%20next%20time%3A%20rebasing%20or%20squashing%20should%20probably%20be%20done%20at%20the%20end%20of%20code%20review%2C%20so%20that%20we%20can%20keep%20track%20of%20the%20discussion.%20Here%2C%20we%20have%20lost%20some%20of%20the%20context%20of%20the%20comments.%22%2C%20%22created_at%22%3A%20%222015-06-01T19%3A40%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20going%20to%20take%20this%20opportunity%20to%20do%20some%20additional%20clean%20up%20of%20the%20tests%20...%20and%20merge%20all%20this%20...%22%2C%20%22created_at%22%3A%20%222015-06-01T19%3A41%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%20about%20rebasing.%20I%27m%20not%20a%20frequent%20contributor%20on%20github%20so%20might%20be%20missing%20on%20some%20best%20practices.%22%2C%20%22created_at%22%3A%20%222015-06-01T19%3A44%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3947391%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ivan-gusev%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20problem%21%20And%20each%20project%20has%20its%20own%20rules%20/%20preferences%2C%20so%20it%20is%20hard%20to%20find%20your%20way%20...%22%2C%20%22created_at%22%3A%20%222015-06-01T19%3A45%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e98b27e72b952dec651cf853c837387adf2bed47%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23discussion_r31403569%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Now%20that%20the%20pool%20is%20injected%20into%20%60OpenTSDBWriter%60%20we%20could%20probably%20remove%20the%20use%20of%20PowerMock.%20While%20it%20is%20not%20directly%20related%20to%20your%20change%2C%20this%20additional%20improvement%20would%20be%20very%20welcomed%20%21%22%2C%20%22created_at%22%3A%20%222015-06-01T07%3A02%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-01T19%3A28%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3947391%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ivan-gusev%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java%3AL2-39%22%7D%2C%20%22Pull%20e98b27e72b952dec651cf853c837387adf2bed47%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23discussion_r31403460%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22That%20should%20probably%20be%20a%20logger%20call%20and%20not%20a%20call%20to%20%60System.out%60.%22%2C%20%22created_at%22%3A%20%222015-06-01T06%3A59%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-01T19%3A28%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3947391%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ivan-gusev%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java%3AL60-85%22%7D%2C%20%22Pull%20e98b27e72b952dec651cf853c837387adf2bed47%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java%20266%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/300%23discussion_r31403607%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Static%20import%20of%20%60Assertions.assertThat%28%29%60%20would%20be%20more%20readable%20%28if%20there%20is%20no%20conflict%20with%20another%20assertion%20framework%29.%22%2C%20%22created_at%22%3A%20%222015-06-01T07%3A03%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-01T19%3A28%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3947391%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ivan-gusev%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java%3AL96-185%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/300#issuecomment-107332031'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Thanks a lo for the help ! That something I wanted to clean up. I'll have a closer look this evening.
- <a href='https://github.com/ivan-gusev'><img border=0 src='https://avatars.githubusercontent.com/u/3947391?v=3' height=16 width=16'></a> :+1:<a href='#crh-update-none'></a>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Just a side note for next time: rebasing or squashing should probably be done at the end of code review, so that we can keep track of the discussion. Here, we have lost some of the context of the comments.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I'm going to take this opportunity to do some additional clean up of the tests ... and merge all this ...
- <a href='https://github.com/ivan-gusev'><img border=0 src='https://avatars.githubusercontent.com/u/3947391?v=3' height=16 width=16'></a> Sorry about rebasing. I'm not a frequent contributor on github so might be missing on some best practices.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> No problem! And each project has its own rules / preferences, so it is hard to find your way ...
- [x] <a href='#crh-comment-Pull e98b27e72b952dec651cf853c837387adf2bed47 jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java 27'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/300#discussion_r31403460'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java:L60-85</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> That should probably be a logger call and not a call to `System.out`.
- [x] <a href='#crh-comment-Pull e98b27e72b952dec651cf853c837387adf2bed47 jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java 39'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/300#discussion_r31403569'>File: jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java:L2-39</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Now that the pool is injected into `OpenTSDBWriter` we could probably remove the use of PowerMock. While it is not directly related to your change, this additional improvement would be very welcomed !
- [x] <a href='#crh-comment-Pull e98b27e72b952dec651cf853c837387adf2bed47 jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java 266'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/300#discussion_r31403607'>File: jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java:L96-185</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Static import of `Assertions.assertThat()` would be more readable (if there is no conflict with another assertion framework).


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/300?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/300?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/300'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>