### PR TITLE
fixed issue with variable resolvement in json file for port field.

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -86,7 +86,7 @@ public class Server {
 			@JsonProperty("queries") List<Query> queries) {
 		this.alias = resolveProps(alias);
 		this.host = resolveProps(host);
-		this.port = port;
+		this.port = resolveProps(port);
 		this.username = resolveProps(username);
 		this.password = resolveProps(password);
 		this.protocolProviderPackages = protocolProviderPackages;

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
@@ -85,6 +85,50 @@ public class ServerTests {
 	}
 
 	@Test
+	public void testServerVariableHandling() {
+		// we add some variables to the System.properties list 
+		String alias = "somealias";
+		String port = "1234";
+		String host = "localhost.local";
+		String username = "acme";
+		String password = "password";
+		String url = "service:jmx:remoting-jms://amce.local:1234";
+		
+		System.setProperty("myalias", alias);
+		System.setProperty("myport", port);
+		System.setProperty("myhost", host);
+		System.setProperty("myusername",username);
+		System.setProperty("mypassword", password);
+		System.setProperty("myurl", url);
+		
+		Server s1 = Server.builder()
+					.setAlias("${myalias}")
+					.setPort("${myport}")
+					.setHost("${myhost}")
+					.setUsername("${myusername}")
+					.setPassword("${mypassword}")
+					.setUrl("${myurl}")
+					.build();
+		Server s2 = Server.builder()
+					.setAlias(alias)
+					.setPort(port)
+					.setHost(host)
+					.setUsername(username)
+					.setPassword(password)
+					.setUrl(url)
+					.build();
+		assertEquals(s1.hashCode(), s2.hashCode());
+		
+		
+		System.clearProperty("myalias");
+		System.clearProperty("myport");
+		System.clearProperty("myhost");
+		System.clearProperty("myusername");
+		System.clearProperty("myusername");
+		System.clearProperty("myurl");
+	}
+	
+	@Test
 	public void testHashCode() {
 		Server s1 = Server.builder()
 				.setUrl("service:jmx:remoting-jmx://mysys.mydomain:8004")

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
@@ -86,46 +86,49 @@ public class ServerTests {
 
 	@Test
 	public void testServerVariableHandling() {
-		// we add some variables to the System.properties list 
-		String alias = "somealias";
-		String port = "1234";
-		String host = "localhost.local";
-		String username = "acme";
-		String password = "password";
-		String url = "service:jmx:remoting-jms://amce.local:1234";
+		try{
+			// we add some variables to the System.properties list 
 		
-		System.setProperty("myalias", alias);
-		System.setProperty("myport", port);
-		System.setProperty("myhost", host);
-		System.setProperty("myusername",username);
-		System.setProperty("mypassword", password);
-		System.setProperty("myurl", url);
-		
-		Server s1 = Server.builder()
-					.setAlias("${myalias}")
-					.setPort("${myport}")
-					.setHost("${myhost}")
-					.setUsername("${myusername}")
-					.setPassword("${mypassword}")
-					.setUrl("${myurl}")
-					.build();
-		Server s2 = Server.builder()
-					.setAlias(alias)
-					.setPort(port)
-					.setHost(host)
-					.setUsername(username)
-					.setPassword(password)
-					.setUrl(url)
-					.build();
-		assertEquals(s1.hashCode(), s2.hashCode());
-		
-		
-		System.clearProperty("myalias");
-		System.clearProperty("myport");
-		System.clearProperty("myhost");
-		System.clearProperty("myusername");
-		System.clearProperty("myusername");
-		System.clearProperty("myurl");
+			String alias = "somealias";
+			String port = "1234";
+			String host = "localhost.local";
+			String username = "acme";
+			String password = "password";
+			String url = "service:jmx:remoting-jms://amce.local:1234";
+			
+			System.setProperty("myalias", alias);
+			System.setProperty("myport", port);
+			System.setProperty("myhost", host);
+			System.setProperty("myusername",username);
+			System.setProperty("mypassword", password);
+			System.setProperty("myurl", url);
+			
+			Server serverFromSystemProperties = Server.builder()
+						.setAlias("${myalias}")
+						.setPort("${myport}")
+						.setHost("${myhost}")
+						.setUsername("${myusername}")
+						.setPassword("${mypassword}")
+						.setUrl("${myurl}")
+						.build();
+			Server serverFromDirectParameters = Server.builder()
+						.setAlias(alias)
+						.setPort(port)
+						.setHost(host)
+						.setUsername(username)
+						.setPassword(password)
+						.setUrl(url)
+						.build();
+			assertEquals(serverFromSystemProperties.hashCode(), serverFromDirectParameters.hashCode());
+			
+		}finally{
+			System.clearProperty("myalias");
+			System.clearProperty("myport");
+			System.clearProperty("myhost");
+			System.clearProperty("myusername");
+			System.clearProperty("myusername");
+			System.clearProperty("myurl");
+		}
 	}
 	
 	@Test


### PR DESCRIPTION
fix issue where the port field in the json file was never resolved if a variable was used. (like ${myportnumber}).
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23issuecomment-107375893%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23issuecomment-107375958%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23discussion_r31409701%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23discussion_r31413048%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23discussion_r31426970%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23discussion_r31427079%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23discussion_r31427130%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23issuecomment-107375893%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20seems%20to%20fix%20%23298.%22%2C%20%22created_at%22%3A%20%222015-06-01T09%3A04%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-06-01T09%3A05%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204b6ddfcf4e3678fb1d53d783aae427e21eb8dacc%20jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23discussion_r31427079%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22To%20improve%20readability%2C%20we%20could%20call%20this%20%60Server%60%20%5C%22serverFromSystemProperties%5C%22%20and%20%60s2%60%20could%20be%20called%20%5C%22serverFromDirectParameters%5C%22%2C%20or%20something%20similar.%22%2C%20%22created_at%22%3A%20%222015-06-01T13%3A56%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java%3AL85-135%22%7D%2C%20%22Pull%20e53f60a9018c99ca4f5d8957769e2793bc56da10%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23discussion_r31409701%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20please%20add%20a%20test%20case%20to%20validate%20the%20change%20%3F%20And%20to%20make%20sure%20we%20do%20not%20re-introduce%20this%20bug%20again%20%3F%22%2C%20%22created_at%22%3A%20%222015-06-01T09%3A06%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22sure..%20I%20added%20a%20unit%20test%20to%20the%20ServerTests%20which%20compares%20a%20server%20created%20with%20system%20variables%20and%20one%20created%20with%20plain%20variables.%20It%20failes%20if%20they%20don%27t%20match.%20%22%2C%20%22created_at%22%3A%20%222015-06-01T10%3A03%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12645639%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/yuk1974%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-01T13%3A57%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java%3AL86-93%22%7D%2C%20%22Pull%204b6ddfcf4e3678fb1d53d783aae427e21eb8dacc%20jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/301%23discussion_r31426970%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20probably%20want%20to%20clear%20those%20properties%20in%20a%20finally%20block.%20So%20even%20if%20this%20test%20fails%2C%20the%20environment%20is%20clean%20for%20the%20next%20test.%22%2C%20%22created_at%22%3A%20%222015-06-01T13%3A55%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java%3AL85-135%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 4b6ddfcf4e3678fb1d53d783aae427e21eb8dacc jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/301#discussion_r31426970'>File: jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java:L85-135</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> We probably want to clear those properties in a finally block. So even if this test fails, the environment is clean for the next test.
- [ ] <a href='#crh-comment-Pull 4b6ddfcf4e3678fb1d53d783aae427e21eb8dacc jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/301#discussion_r31427079'>File: jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java:L85-135</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> To improve readability, we could call this `Server` "serverFromSystemProperties" and `s2` could be called "serverFromDirectParameters", or something similar.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/301#issuecomment-107375893'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This seems to fix #298.
- [x] <a href='#crh-comment-Pull e53f60a9018c99ca4f5d8957769e2793bc56da10 jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/301#discussion_r31409701'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java:L86-93</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Could you please add a test case to validate the change ? And to make sure we do not re-introduce this bug again ?
- <a href='https://github.com/yuk1974'><img border=0 src='https://avatars.githubusercontent.com/u/12645639?v=3' height=16 width=16'></a> sure.. I added a unit test to the ServerTests which compares a server created with system variables and one created with plain variables. It failes if they don't match.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/301?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/301?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/301'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>