### PR TITLE
Adding KafkaWriter

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-core/pom.xml
@@ -53,12 +53,22 @@
 			<artifactId>commons-jexl</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka_2.10</artifactId>
+			<version>0.8.2.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.jmxtrans</groupId>
 			<artifactId>jmxtrans-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jmxtrans</groupId>
 			<artifactId>jmxtrans-utils</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20140107</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java
@@ -1,0 +1,133 @@
+package com.googlecode.jmxtrans.model.output;
+
+import static com.googlecode.jmxtrans.model.PropertyResolver.resolveProps;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ValidationException;
+import com.googlecode.jmxtrans.model.naming.KeyUtils;
+import com.googlecode.jmxtrans.util.NumberUtils;
+
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Map.Entry;
+
+import kafka.javaapi.producer.Producer;
+import kafka.producer.KeyedMessage;
+import kafka.producer.ProducerConfig;
+
+/**
+ * This low latency and thread safe output writer sends data to a kafka topics in JSON format.
+ * Kafka Topics can be passed as separated by commas such as kafka01,kafka02.
+ *
+ * @author utkarsh bhatnagar
+ */
+
+@NotThreadSafe
+public class KafkaWriter extends BaseOutputWriter {
+	
+	private static final Logger log = LoggerFactory.getLogger(KafkaWriter.class);
+	
+	private static final String DEFAULT_ROOT_PREFIX = "servers";
+	
+	private Producer<String,String> producer;
+	private String[] topics;
+	private boolean isTest;
+	private final String rootPrefix;
+
+	@JsonCreator
+	public KafkaWriter(
+			@JsonProperty("typeNames") ImmutableList<String> typeNames,
+			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
+			@JsonProperty("rootPrefix") String rootPrefix,
+			@JsonProperty("debug") Boolean debugEnabled,
+			@JsonProperty("settings") Map<String, Object> settings) {
+		super(typeNames, booleanAsNumber, debugEnabled, settings);
+		this.rootPrefix = resolveProps(
+				firstNonNull(
+						rootPrefix,
+						(String) getSettings().get("rootPrefix"),
+						DEFAULT_ROOT_PREFIX));		
+		// Setting all the required Kafka Properties
+		Properties kafkaProperties =  new Properties();
+		kafkaProperties.setProperty("metadata.broker.list", Settings.getStringSetting(settings, "metadata.broker.list", null));
+		kafkaProperties.setProperty("zk.connect", Settings.getStringSetting(settings, "zk.connect", null));
+		kafkaProperties.setProperty("serializer.class", Settings.getStringSetting(settings, "serializer.class", null));
+		this.producer= new Producer<String,String>(new ProducerConfig(kafkaProperties));
+		this.topics = Settings.getStringSetting(settings, "topics", null).split(","); 
+	}
+	
+	public void validateSetup(Server server, Query query) throws ValidationException {
+	}
+
+	public void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
+
+		try {
+			ArrayList<KeyedMessage<String,String>> messages = new ArrayList<KeyedMessage<String,String>>();
+			List<String> typeNames = this.getTypeNames();
+
+			for (Result result : results) {
+				log.debug("Query result: {}", result);
+				Map<String, Object> resultValues = result.getValues();
+				if (resultValues != null) {
+					for (Entry<String, Object> values : resultValues.entrySet()) {
+						Object value = values.getValue();
+						if (NumberUtils.isNumeric(value)) {
+							JSONObject obj = new JSONObject();
+							obj.put("keyspace",KeyUtils.getKeyString(server, query, result, values, typeNames, this.rootPrefix).replaceAll("[()]", "_"));
+							obj.put("value", value.toString());
+							obj.put("timestamp", result.getEpoch() / 1000);
+							for(String topic : this.topics) {
+								log.debug("Topic: "+topic+" ; Kafka Message: {}", obj.toString());
+								messages.add(new KeyedMessage<String,String>(topic,obj.toString()));
+							}
+						} else {
+							log.warn("Unable to submit non-numeric value to Kafka: [{}] from result [{}]", value, result);
+						}
+					}
+				}
+			}
+			if (!this.isTest)
+				this.producer.send(messages);
+			else
+				log.debug("Topic: random Kafka Messages: {no messages for localhost}");
+		} catch (Exception e){
+			e.printStackTrace();
+			log.error("Unable to write to kafka. Please debug.");
+		}
+	}
+	
+	public Producer<String, String> getProducer() {
+		return producer;
+	}
+
+	public void setProducer(Producer<String, String> producer) {
+		this.producer = producer;
+	}
+
+	public static Logger getLog() {
+		return log;
+	}
+	
+	public boolean isTest() {
+		return isTest;
+	}
+
+	public void setTest(boolean isTest) {
+		this.isTest = isTest;
+	}
+
+	
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/KafkaWriterTests.java
@@ -1,0 +1,51 @@
+package com.googlecode.jmxtrans.model.output;
+
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert; 
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+
+public class KafkaWriterTests {
+	
+	@Test
+	public void KafkaWriterNotNull() throws Exception {
+		Assert.assertNotNull(getTestKafkaWriter());
+	}
+
+	@Test
+	public void LocalWriteShouldFail() throws Exception {
+			Server server = Server.builder().setHost("host").setPort("123").build();
+			Query query = Query.builder().build();
+			Result result = new Result(System.currentTimeMillis(), "attributeName", "className", "objDomain", "classNameAlias", "typeName", ImmutableMap.of("key", (Object)1));
+		
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
+			KafkaWriter writer = getTestKafkaWriter();
+			writer.setTest(true);
+			writer.doWrite(server, query, ImmutableList.of(result));
+			// This write should fail because there is no Kafka instance running locally
+			
+	}
+	
+	public static KafkaWriter getTestKafkaWriter() {
+		Server server = Server.builder().setHost("host").setPort("123").build();
+		ImmutableList typenames = ImmutableList.of();
+		Map<String,Object> settings = new HashMap<String,Object>();
+		settings.put("zk.connect", "host:2181");
+		settings.put("metadata.broker.list", "10.231.1.1:9180");
+		settings.put("serializer.class", "kafka.serializer.StringEncoder");
+		settings.put("debug", false);
+		settings.put("booleanAsNumber", true);
+		settings.put("topics", "cloudwatch_ec2");
+		KafkaWriter kw = new KafkaWriter(typenames,true,"rootPrefix",true,settings);
+		return kw;
+	}
+	
+}


### PR DESCRIPTION
KafkaWriter writes into more than one Kafka Topic. It needs the following settings:

1. metadata.broker.list
2. zk.connect
3. serializer.class
4. topics

For example:
"metadata.broker.list" : "10.0.0.1:9092",
"zk.connect" : "10.0.0.2:2181",
"serializer.class" : "kafka.serializer.StringEncoder",
"topics" : "topic1,topic2"
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23discussion_r31865907%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23discussion_r31865923%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23discussion_r31865930%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23discussion_r31865935%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23issuecomment-109550874%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23discussion_r31865952%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23issuecomment-109552991%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23issuecomment-109758520%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23issuecomment-109792310%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23issuecomment-109550874%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good%20%21%20A%20few%20minor%20corrections%20would%20be%20nice.%20I%20can%20do%20those%20corrections%20if%20you%20do%20not%20have%20the%20time%20/%20energy%20/%20...%20let%20me%20know%20...%22%2C%20%22created_at%22%3A%20%222015-06-06T08%3A13%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20I%20think%20you%20have%20a%20better%20idea%20about%20the%20project%20structure%20%2C%20so%20it%20might%20be%20far%20quicker%20for%20you%20to%20edit%20these%20things%20as%20compared%20to%20me.%20But%20the%20writer%20works%20and%20writes%20to%20Kafka%20as%20needed.%20I%20tested%20it%20thoroughly.%20Thanks%20for%20the%20quick%20review%20and%20hopefully%20I%20contribute%20more%20in%20the%20future%20on%20this%20project.%20%3A%2B1%3A%20%20%3A%29%20%22%2C%20%22created_at%22%3A%20%222015-06-06T08%3A31%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1019609%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/utkarshcmu%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20did%20some%20rework%20and%20created%20a%20new%20PR%20%28%23305%29.%20Your%20review%20of%20what%20I%20did%20would%20be%20welcomed%20%21%22%2C%20%22created_at%22%3A%20%222015-06-07T13%3A53%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Closed%20as%20this%20is%20replaced%20by%20%23305%22%2C%20%22created_at%22%3A%20%222015-06-07T19%3A41%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208cb6edaef1d92c28c1c3e74104a2f47c3487a739%20jmxtrans-output/jmxtrans-output-core/pom.xml%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23discussion_r31865952%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Version%20should%20be%20defined%20in%20the%20%60dependencyManagement%60%20section%20of%20the%20parent%20pom.%20That%20way%20we%20ensure%20that%20all%20modules%20are%20using%20the%20same%20version%20of%20each%20dependency.%22%2C%20%22created_at%22%3A%20%222015-06-06T08%3A14%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/pom.xml%3AL53-64%22%7D%2C%20%22Pull%208cb6edaef1d92c28c1c3e74104a2f47c3487a739%20jmxtrans-output/jmxtrans-output-core/pom.xml%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23discussion_r31865907%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20goal%20of%20the%20%60jmxtrans-output-core%60%20module%20is%20to%20have%20only%20core%20output%20writers%2C%20with%20minimal%20dependencies.%20Could%20you%20move%20the%20output%20writer%20to%20a%20new%20module%2C%20probably%20named%20%60jmxtrans-output-kafka%60%20%3F%22%2C%20%22created_at%22%3A%20%222015-06-06T08%3A07%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/pom.xml%3AL53-64%22%7D%2C%20%22Pull%208cb6edaef1d92c28c1c3e74104a2f47c3487a739%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java%20102%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23discussion_r31865935%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20%60isTest%60%20condition%20is%20dubious.%20If%20you%20want%20a%20way%20to%20unit%20test%20this%20class%2C%20you%20should%20provide%20a%20way%20to%20inject%20the%20%60producer%60%20and%20mock%20it.%22%2C%20%22created_at%22%3A%20%222015-06-06T08%3A12%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java%3AL1-134%22%7D%2C%20%22Pull%208cb6edaef1d92c28c1c3e74104a2f47c3487a739%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java%20116%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23discussion_r31865923%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20seems%20that%20all%20those%20getters%20/%20setters%20are%20exposing%20internal%20state.%20You%20could%20probably%20remove%20them.%22%2C%20%22created_at%22%3A%20%222015-06-06T08%3A09%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java%3AL1-134%22%7D%2C%20%22Pull%208cb6edaef1d92c28c1c3e74104a2f47c3487a739%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/304%23discussion_r31865930%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Complexity%20of%20this%20method%20is%20quite%20high.%20It%20seems%20we%20can%20at%20least%20extract%20a%20method%20%60writeSingleValue%28%29%60.%22%2C%20%22created_at%22%3A%20%222015-06-06T08%3A11%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java%3AL1-134%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 8cb6edaef1d92c28c1c3e74104a2f47c3487a739 jmxtrans-output/jmxtrans-output-core/pom.xml 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/304#discussion_r31865907'>File: jmxtrans-output/jmxtrans-output-core/pom.xml:L53-64</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> The goal of the `jmxtrans-output-core` module is to have only core output writers, with minimal dependencies. Could you move the output writer to a new module, probably named `jmxtrans-output-kafka` ?
- [ ] <a href='#crh-comment-Pull 8cb6edaef1d92c28c1c3e74104a2f47c3487a739 jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java 116'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/304#discussion_r31865923'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java:L1-134</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> It seems that all those getters / setters are exposing internal state. You could probably remove them.
- [ ] <a href='#crh-comment-Pull 8cb6edaef1d92c28c1c3e74104a2f47c3487a739 jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java 75'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/304#discussion_r31865930'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java:L1-134</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Complexity of this method is quite high. It seems we can at least extract a method `writeSingleValue()`.
- [ ] <a href='#crh-comment-Pull 8cb6edaef1d92c28c1c3e74104a2f47c3487a739 jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java 102'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/304#discussion_r31865935'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/KafkaWriter.java:L1-134</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This `isTest` condition is dubious. If you want a way to unit test this class, you should provide a way to inject the `producer` and mock it.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/304#issuecomment-109550874'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Looks good ! A few minor corrections would be nice. I can do those corrections if you do not have the time / energy / ... let me know ...
- <a href='https://github.com/utkarshcmu'><img border=0 src='https://avatars.githubusercontent.com/u/1019609?v=3' height=16 width=16'></a> Yes, I think you have a better idea about the project structure , so it might be far quicker for you to edit these things as compared to me. But the writer works and writes to Kafka as needed. I tested it thoroughly. Thanks for the quick review and hopefully I contribute more in the future on this project. :+1:  :)
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I did some rework and created a new PR (#305). Your review of what I did would be welcomed !
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Closed as this is replaced by #305
- [ ] <a href='#crh-comment-Pull 8cb6edaef1d92c28c1c3e74104a2f47c3487a739 jmxtrans-output/jmxtrans-output-core/pom.xml 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/304#discussion_r31865952'>File: jmxtrans-output/jmxtrans-output-core/pom.xml:L53-64</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Version should be defined in the `dependencyManagement` section of the parent pom. That way we ensure that all modules are using the same version of each dependency.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/304?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/304?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/304'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>