### PR TITLE
Fixed NullPointerException in KafkaWriter. Topics reading from Settings.

### DIFF
--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
@@ -77,7 +77,7 @@ public class KafkaWriter extends BaseOutputWriter {
 		kafkaProperties.setProperty("zk.connect", Settings.getStringSetting(settings, "zk.connect", null));
 		kafkaProperties.setProperty("serializer.class", Settings.getStringSetting(settings, "serializer.class", null));
 		this.producer= new Producer<String,String>(new ProducerConfig(kafkaProperties));
-		this.topics = asList(topics.split(","));
+		this.topics = asList(Settings.getStringSetting(settings, "topics", null).split(","));
 		jsonFactory = new JsonFactory();
 	}
 	

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
@@ -64,7 +64,7 @@ public class KafkaWriter extends BaseOutputWriter {
 			@JsonProperty("rootPrefix") String rootPrefix,
 			@JsonProperty("debug") Boolean debugEnabled,
 			@JsonProperty("topics") String topics,
-			@JsonProperty("settings") Map<String, Object> settings) {
+			@JsonProperty("settings") Map<String, Object> settings) throws Exception {
 		super(typeNames, booleanAsNumber, debugEnabled, settings);
 		this.rootPrefix = resolveProps(
 				firstNonNull(
@@ -86,7 +86,7 @@ public class KafkaWriter extends BaseOutputWriter {
 			throw new NullPointerException("serializer.class Kafka property cannot be null");
 		Iterator<String> iter = this.topics.iterator();
 		if(iter.next().length() == 0)
-			throw new NullPointerException("Kafka topics list cannot be null");
+			throw new Exception("Kafka topics list cannot be empty.");
 		jsonFactory = new JsonFactory();
 	}
 	

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
@@ -64,7 +64,7 @@ public class KafkaWriter extends BaseOutputWriter {
 			@JsonProperty("rootPrefix") String rootPrefix,
 			@JsonProperty("debug") Boolean debugEnabled,
 			@JsonProperty("topics") String topics,
-			@JsonProperty("settings") Map<String, Object> settings) throws Exception {
+			@JsonProperty("settings") Map<String, Object> settings) {
 		super(typeNames, booleanAsNumber, debugEnabled, settings);
 		this.rootPrefix = resolveProps(
 				firstNonNull(
@@ -86,7 +86,7 @@ public class KafkaWriter extends BaseOutputWriter {
 			throw new NullPointerException("serializer.class Kafka property cannot be null");
 		Iterator<String> iter = this.topics.iterator();
 		if(iter.next().length() == 0)
-			throw new Exception("Kafka topics list cannot be empty.");
+			throw new NullPointerException("Kafka topics list cannot be null");
 		jsonFactory = new JsonFactory();
 	}
 	

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
@@ -21,7 +21,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -30,6 +29,7 @@ import java.util.Map.Entry;
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
 import kafka.producer.ProducerConfig;
+
 import static com.fasterxml.jackson.core.JsonEncoding.UTF8;
 import static com.googlecode.jmxtrans.model.PropertyResolver.resolveProps;
 import static com.googlecode.jmxtrans.model.naming.KeyUtils.getKeyString;
@@ -64,7 +64,7 @@ public class KafkaWriter extends BaseOutputWriter {
 			@JsonProperty("rootPrefix") String rootPrefix,
 			@JsonProperty("debug") Boolean debugEnabled,
 			@JsonProperty("topics") String topics,
-			@JsonProperty("settings") Map<String, Object> settings) throws Exception {
+			@JsonProperty("settings") Map<String, Object> settings) {
 		super(typeNames, booleanAsNumber, debugEnabled, settings);
 		this.rootPrefix = resolveProps(
 				firstNonNull(
@@ -77,16 +77,7 @@ public class KafkaWriter extends BaseOutputWriter {
 		kafkaProperties.setProperty("zk.connect", Settings.getStringSetting(settings, "zk.connect", null));
 		kafkaProperties.setProperty("serializer.class", Settings.getStringSetting(settings, "serializer.class", null));
 		this.producer= new Producer<String,String>(new ProducerConfig(kafkaProperties));
-		this.topics = asList(Settings.getStringSetting(settings, "topics", "").split(","));
-		if ( kafkaProperties.getProperty("metadata.broker.list") == null )
-			throw new NullPointerException("metadata.broker.list Kafka property cannot be null.");
-		if ( kafkaProperties.getProperty("zk.connect") == null )
-			throw new NullPointerException("zk.connect Kafka property cannot be null.");
-		if( kafkaProperties.getProperty("serializer.class") == null )
-			throw new NullPointerException("serializer.class Kafka property cannot be null");
-		Iterator<String> iter = this.topics.iterator();
-		if(iter.next().length() == 0)
-			throw new Exception("Kafka topics list cannot be empty.");
+		this.topics = asList(Settings.getStringSetting(settings, "topics", null).split(","));
 		jsonFactory = new JsonFactory();
 	}
 	

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
-
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -13,7 +12,6 @@ import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
-
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -54,7 +52,7 @@ public class KafkaWriterTests {
 				.contains("\"timestamp\":0");
 	}
 	
-	private static KafkaWriter getTestKafkaWriter() throws Exception {
+	private static KafkaWriter getTestKafkaWriter() {
 		ImmutableList typenames = ImmutableList.of();
 		Map<String,Object> settings = new HashMap<String,Object>();
 		settings.put("zk.connect", "host:2181");

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -60,7 +60,7 @@ public class KafkaWriterTests {
 		settings.put("serializer.class", "kafka.serializer.StringEncoder");
 		settings.put("debug", false);
 		settings.put("booleanAsNumber", true);
-		settings.put("topics", "cloudwatch_ec2");
+		settings.put("topics", "myTopic");
 		return new KafkaWriter(typenames, true, "rootPrefix", true, "myTopic", settings);
 	}
 	

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
+
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -12,6 +13,7 @@ import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
+
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -52,7 +54,7 @@ public class KafkaWriterTests {
 				.contains("\"timestamp\":0");
 	}
 	
-	private static KafkaWriter getTestKafkaWriter() {
+	private static KafkaWriter getTestKafkaWriter() throws Exception {
 		ImmutableList typenames = ImmutableList.of();
 		Map<String,Object> settings = new HashMap<String,Object>();
 		settings.put("zk.connect", "host:2181");

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -62,7 +62,7 @@ public class KafkaWriterTests {
 		settings.put("serializer.class", "kafka.serializer.StringEncoder");
 		settings.put("debug", false);
 		settings.put("booleanAsNumber", true);
-		settings.put("topics", "myTopic");
+		settings.put("topics", "cloudwatch_ec2");
 		return new KafkaWriter(typenames, true, "rootPrefix", true, "myTopic", settings);
 	}
 	

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -54,7 +54,7 @@ public class KafkaWriterTests {
 				.contains("\"timestamp\":0");
 	}
 	
-	private static KafkaWriter getTestKafkaWriter() {
+	private static KafkaWriter getTestKafkaWriter() throws Exception {
 		ImmutableList typenames = ImmutableList.of();
 		Map<String,Object> settings = new HashMap<String,Object>();
 		settings.put("zk.connect", "host:2181");

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -62,7 +62,7 @@ public class KafkaWriterTests {
 		settings.put("serializer.class", "kafka.serializer.StringEncoder");
 		settings.put("debug", false);
 		settings.put("booleanAsNumber", true);
-		settings.put("topics", "cloudwatch_ec2");
+		settings.put("topics", "myTopic");
 		return new KafkaWriter(typenames, true, "rootPrefix", true, "myTopic", settings);
 	}
 	

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -54,7 +54,7 @@ public class KafkaWriterTests {
 				.contains("\"timestamp\":0");
 	}
 	
-	private static KafkaWriter getTestKafkaWriter() throws Exception {
+	private static KafkaWriter getTestKafkaWriter() {
 		ImmutableList typenames = ImmutableList.of();
 		Map<String,Object> settings = new HashMap<String,Object>();
 		settings.put("zk.connect", "host:2181");


### PR DESCRIPTION
Bug found. Topics were initialized to null as they were not read from the configuration file. Fixed it. Please review.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/311%23issuecomment-117570678%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/311%23discussion_r33664527%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/311%23discussion_r33665216%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/311%23discussion_r33688200%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/311%23issuecomment-117711612%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/311%23issuecomment-117570678%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Fix%20for%20%23310%20.%22%2C%20%22created_at%22%3A%20%222015-07-01T09%3A50%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1019609%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/utkarshcmu%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-07-01T15%3A12%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20dc868281e5ddfcb3732641da1e17ae7ade7fc5a3%20jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/311%23discussion_r33664527%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20seems%20that%20here%20we%20use%20a%20default%20value%20for%20topic%20of%20%60null%60%2C%20which%20means%20that%20we%20will%20throw%20a%20null%20pointer%20exception%20when%20doing%20the%20split.%20We%20should%20have%20a%20better%20validation%20here.%20Not%20really%20sure%20how%20kafka%20works%2C%20if%20we%20can%20have%20a%20safe%20default%20%28empty%20list%3F%29%20or%20not.%20If%20we%20can%20have%20a%20safe%20default%2C%20we%20should%20use%20it%2C%20else%2C%20we%20need%20to%20throw%20an%20exception%20at%20construction.%22%2C%20%22created_at%22%3A%20%222015-07-01T09%3A59%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Agreed.%20Let%20me%20add%20that%20validation.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-07-01T10%3A08%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1019609%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/utkarshcmu%22%7D%7D%2C%20%7B%22body%22%3A%20%22CodeReviewHub%20uses%20%5C%22thumbs%20up%5C%22%20to%20mark%20comments%20as%20corrected%20%28see%20%5Bdocumentation%5D%28https%3A//www.codereviewhub.com/%29%20for%20details%29.%20So%20adding%20a%20%3A-1%3A%20to%20mark%20it%20as%20uncomplete%20...%22%2C%20%22created_at%22%3A%20%222015-07-01T15%3A12%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java%3AL77-84%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull dc868281e5ddfcb3732641da1e17ae7ade7fc5a3 jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/311#discussion_r33664527'>File: jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java:L77-84</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> It seems that here we use a default value for topic of `null`, which means that we will throw a null pointer exception when doing the split. We should have a better validation here. Not really sure how kafka works, if we can have a safe default (empty list?) or not. If we can have a safe default, we should use it, else, we need to throw an exception at construction.
- <a href='https://github.com/utkarshcmu'><img border=0 src='https://avatars.githubusercontent.com/u/1019609?v=3' height=16 width=16'></a> Agreed. Let me add that validation. :+1:
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> CodeReviewHub uses "thumbs up" to mark comments as corrected (see [documentation](https://www.codereviewhub.com/) for details). So adding a :-1: to mark it as uncomplete ...
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/311#issuecomment-117570678'>General Comment</a></b>
- <a href='https://github.com/utkarshcmu'><img border=0 src='https://avatars.githubusercontent.com/u/1019609?v=3' height=16 width=16'></a> Fix for #310 .


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/311?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/311?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/311'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>