### PR TITLE
Disabling JavaDoc DocLint feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1069,6 +1069,26 @@
 				</pluginManagement>
 			</build>
 		</profile>
+		<profile>
+			<id>jdk_higher_or_equal_than_8</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-javadoc-plugin</artifactId>
+							<configuration>
+								<additionalparam>-Xdoclint:none</additionalparam>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
Java 8 has enabled DocLint feature by default which causes jmxtrans
build failure. This commit adds -Xdoclint:none param to maven-javadoc
plugin configuration when build is invoked for java versions higher
than 8.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/318%23issuecomment-129845400%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/318%23issuecomment-129847535%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/318%23issuecomment-129847709%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/318%23discussion_r36734351%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/318%23discussion_r36735999%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/318%23issuecomment-129845400%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Sure%2C%20it%20will%20be%20more%20readable%20with%20explicit%20profile%20for%20versions%20higher%20and%20equal%208.%22%2C%20%22created_at%22%3A%20%222015-08-11T11%3A30%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1992051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sogorkis%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20%60jdk_higher_or_equal_than_8%60%20profile%20with%20plugin%20configuration.%22%2C%20%22created_at%22%3A%20%222015-08-11T11%3A43%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1992051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sogorkis%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%2C%20much%20cleaner%2C%20all%20code%20related%20to%20this%20in%20mostly%20the%20same%20place...%20Thanks%20%21%20%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-11T11%3A45%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205658a6119c162e82bd337be19b650918d9de1bbc%20pom.xml%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/318%23discussion_r36734351%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20the%20additional%20option%20is%20only%20required%20for%20Java%208%20%28and%20probably%20Java%20%3E%3D%208%29%2C%20I%20would%20have%20added%20a%20pluginManagement%20section%20to%20a%20%60jdk_greater_than_eight%60%20profile.%20It%20seems%20to%20me%20more%20readable%20than%20having%20a%20property%20that%20is%20emptied%20for%20specific%20cases%20%28too%20many%20indirection%20and%20negation%20for%20my%20taste%29.%5Cr%5Cn%5Cr%5CnIf%20you%20feel%20that%20your%20way%20is%20the%20best%2C%20I%27ll%20merge%20as%20is...%22%2C%20%22created_at%22%3A%20%222015-08-11T11%3A21%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-11T11%3A46%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pom.xml%3AL649-658%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/gehel%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/gehel'><img src='https://avatars.githubusercontent.com/u/1415765?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-Pull 5658a6119c162e82bd337be19b650918d9de1bbc pom.xml 12'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/318#discussion_r36734351'>File: pom.xml:L649-658</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> As the additional option is only required for Java 8 (and probably Java >= 8), I would have added a pluginManagement section to a `jdk_greater_than_eight` profile. It seems to me more readable than having a property that is emptied for specific cases (too many indirection and negation for my taste).
If you feel that your way is the best, I'll merge as is...
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/318#issuecomment-129845400'>General Comment</a></b>
- <a href='https://github.com/sogorkis'><img border=0 src='https://avatars.githubusercontent.com/u/1992051?v=3' height=16 width=16'></a> Sure, it will be more readable with explicit profile for versions higher and equal 8.
- <a href='https://github.com/sogorkis'><img border=0 src='https://avatars.githubusercontent.com/u/1992051?v=3' height=16 width=16'></a> Added `jdk_higher_or_equal_than_8` profile with plugin configuration.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Yep, much cleaner, all code related to this in mostly the same place... Thanks ! :shipit:


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/318?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/318?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/318?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/318'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>