### PR TITLE
Changing jmxtrans user home dir in deb packages

### DIFF
--- a/jmxtrans/src/deb/control/preinst
+++ b/jmxtrans/src/deb/control/preinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
     install)
         if ! id jmxtrans > /dev/null 2>&1 ; then
-            adduser --system --shell /bin/bash --home /home/jmxtrans --disabled-login --disabled-password --group jmxtrans
+            adduser --system --shell /bin/bash --home /usr/share/jmxtrans --disabled-login --disabled-password --group jmxtrans
         fi
     ;;
     upgrade|abort-upgrade)


### PR DESCRIPTION
As jmxtrans is deamon user, it should not have its home directory
under /home/jmxtrans. This commit changes it to /usr/share/jmxtrans,
the same as in rpm version.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/319?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/319'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>