### PR TITLE
Changing jmxtrans user home dir in deb packages

### DIFF
--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -316,8 +316,9 @@
 								<script>if [ $1 = 1 ]; then
                   USER_ID=`id -u %{package.user} 2&gt;/dev/null`
                     if [ -z "$USER_ID" ]; then
+									    groupadd -f ${package.user}
 									    /usr/sbin/useradd -c "${project.name}" -s /bin/sh -r -d \
-									    ${package.install.dir} -U ${package.user}
+									    ${package.install.dir} -G ${package.user} ${package.user}
                     fi
 									fi</script>
 							</preinstallScriptlet>


### PR DESCRIPTION
Installing rpm in SLES failed as -U flag of useradd is not supported
on this system. This commit fixes this issue by manually creating
jmxtrans group first and then using -G flag in useradd command.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/320%23discussion_r36734156%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/320%23issuecomment-129844681%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/320%23issuecomment-129844681%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Added%20%60-f%60%20option%20to%20%60groupadd%60%20command.%22%2C%20%22created_at%22%3A%20%222015-08-11T11%3A28%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1992051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sogorkis%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20edd6daacd6997011ecaf3a4827974f9ab318065b%20jmxtrans/pom.xml%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/320%23discussion_r36734156%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20you%20add%20a%20check%20to%20only%20create%20the%20group%20if%20it%20already%20exists%3F%20Or%20use%20the%20%60-f%60%20option%3F%22%2C%20%22created_at%22%3A%20%222015-08-11T11%3A19%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans/pom.xml%3AL316-325%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull edd6daacd6997011ecaf3a4827974f9ab318065b jmxtrans/pom.xml 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/320#discussion_r36734156'>File: jmxtrans/pom.xml:L316-325</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Should you add a check to only create the group if it already exists? Or use the `-f` option?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/320#issuecomment-129844681'>General Comment</a></b>
- <a href='https://github.com/sogorkis'><img border=0 src='https://avatars.githubusercontent.com/u/1992051?v=3' height=16 width=16'></a> Added `-f` option to `groupadd` command.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/320?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/320?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/320'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>