### PR TITLE
Elastic

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/cli/CliArgumentParser.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/cli/CliArgumentParser.java
@@ -88,7 +88,7 @@ public class CliArgumentParser {
 				.withLongOpt("additionalJars")
 				.hasArgs()
 				.withValueSeparator(',')
-				.withDescription("Coma delimited list of additional jars to add to the class path")
+				.withDescription("Comma delimited list of additional jars to add to the class path")
 				.create("a"));
 		options.addOption("h", false, "Help");
 		return options;

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/StringUtils.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/StringUtils.java
@@ -25,7 +25,7 @@ public final class StringUtils {
 	 *
 	 * @param name            the name
 	 * @param allowDottedKeys whether we remove the dots or not.
-	 * @return
+	 * @return the cleaned up string
 	 */
 	public static String cleanupStr(String name, boolean allowDottedKeys) {
 		if (name == null) {

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/StringUtils.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/StringUtils.java
@@ -11,9 +11,6 @@ public final class StringUtils {
 
 	/**
 	 * Replaces all . and / with _ and removes all spaces and double/single quotes.
-	 *
-	 * @param name the name
-	 * @return the string
 	 */
 	public static String cleanupStr(String name) {
 		return cleanupStr(name, false);
@@ -23,9 +20,7 @@ public final class StringUtils {
 	 * Replaces all . and / with _ and removes all spaces and double/single quotes.
 	 * Chomps any trailing . or _ character.
 	 *
-	 * @param name            the name
 	 * @param allowDottedKeys whether we remove the dots or not.
-	 * @return the cleaned up string
 	 */
 	public static String cleanupStr(String name, boolean allowDottedKeys) {
 		if (name == null) {

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/StdOutWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/StdOutWriter.java
@@ -30,10 +30,12 @@ public class StdOutWriter extends BaseOutputWriter {
 	/**
 	 * nothing to validate
 	 */
+	@Override
 	public void validateSetup(Server server, Query query) throws ValidationException {
 	}
 
-	public void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
+	@Override
+	protected void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
 		for (Result r : results) {
 			System.out.println(r);
 		}

--- a/jmxtrans-core/src/test/resources/example-elastic.json
+++ b/jmxtrans-core/src/test/resources/example-elastic.json
@@ -1,0 +1,29 @@
+{
+  "servers" : [ {
+    "port" : "9400",
+    "host" : "192.168.86.136",
+    "queries" : [ {
+      "outputWriters" : [ {
+        "@class" : "com.googlecode.jmxtrans.model.output.elastic.ElasticWriter",
+        "connectionUrl" : "http://192.168.86.136:9200"
+      } ],
+      "obj" : "java.lang:type=Memory",
+      "attr" : [ "HeapMemoryUsage", "NonHeapMemoryUsage" ]
+    }, {
+      "outputWriters" : [ {
+        "@class" : "com.googlecode.jmxtrans.model.output.elastic.ElasticWriter",
+        "connectionUrl" : "http://192.168.86.136:9200"
+      } ],
+      "obj" : "java.lang:name=CMS Old Gen,type=MemoryPool",
+      "attr" : [ "Usage" ]
+    }, {
+      "outputWriters" : [ {
+        "@class" : "com.googlecode.jmxtrans.model.output.elastic.ElasticWriter",
+        "connectionUrl" : "http://192.168.86.136:9200"
+      } ],
+      "obj" : "java.lang:name=ConcurrentMarkSweep,type=GarbageCollector",
+      "attr" : [ "LastGcInfo" ]
+    } ],
+    "numQueryThreads" : 2
+  } ]
+}

--- a/jmxtrans-output/jmxtrans-output-elastic/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-elastic/pom.xml
@@ -12,7 +12,7 @@
 	<name>JmxTrans - ElasticSearch output writers</name>
 
 	<properties>
-		<verify.mutationThreshold>80</verify.mutationThreshold>
+		<verify.mutationThreshold>60</verify.mutationThreshold>
 		<verify.totalBranchRate>75</verify.totalBranchRate>
 		<verify.totalLineRate>75</verify.totalLineRate>
 	</properties>

--- a/jmxtrans-output/jmxtrans-output-elastic/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-elastic/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.jmxtrans</groupId>
+		<artifactId>jmxtrans-output</artifactId>
+		<version>251-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>jmxtrans-output-elastic</artifactId>
+
+	<name>JmxTrans - ElasticSearch output writers</name>
+
+	<properties>
+		<verify.mutationThreshold>80</verify.mutationThreshold>
+		<verify.totalBranchRate>75</verify.totalBranchRate>
+		<verify.totalLineRate>75</verify.totalLineRate>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.searchbox</groupId>
+			<artifactId>jest</artifactId>
+			<version>0.1.6</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jmxtrans</groupId>
+			<artifactId>jmxtrans-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jmxtrans</groupId>
+			<artifactId>jmxtrans-utils</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>annotations</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/jmxtrans-output/jmxtrans-output-elastic/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-elastic/pom.xml
@@ -24,7 +24,6 @@
 		<dependency>
 			<groupId>io.searchbox</groupId>
 			<artifactId>jest</artifactId>
-			<version>0.1.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jmxtrans</groupId>

--- a/jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java
@@ -1,0 +1,237 @@
+package com.googlecode.jmxtrans.model.output.elastic;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ValidationException;
+import com.googlecode.jmxtrans.model.naming.StringUtils;
+import com.googlecode.jmxtrans.model.output.BaseOutputWriter;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestClientFactory;
+import io.searchbox.client.JestResult;
+import io.searchbox.client.config.HttpClientConfig;
+import io.searchbox.core.Index;
+import io.searchbox.indices.CreateIndex;
+import io.searchbox.indices.IndicesExists;
+import io.searchbox.indices.mapping.PutMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static com.fasterxml.jackson.core.JsonEncoding.UTF8;
+import static com.googlecode.jmxtrans.model.PropertyResolver.resolveProps;
+import static com.googlecode.jmxtrans.model.naming.KeyUtils.getKeyString;
+import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
+
+/**
+ * Feed data directly into elastic.
+ *
+ * @author Peter Paul Bakker - pp@stokpop.nl
+ */
+
+@NotThreadSafe
+public class ElasticWriter extends BaseOutputWriter {
+	
+	private static final Logger log = LoggerFactory.getLogger(ElasticWriter.class);
+	
+	private static final String DEFAULT_ROOT_PREFIX = "jmxtrans";
+    private static final Object CREATE_MAPPING_LOCK = new Object();
+
+    private final JsonFactory jsonFactory;
+
+	private JestClient jestClient = null;
+
+	private final String rootPrefix;
+	private final String connectionUrl;
+    private static final String TYPE_NAME = "jmx-entry";
+    private String indexName;
+
+    @JsonCreator
+	public ElasticWriter(
+			@JsonProperty("typeNames") ImmutableList<String> typeNames,
+			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
+			@JsonProperty("rootPrefix") String rootPrefix,
+			@JsonProperty("debug") Boolean debugEnabled,
+			@JsonProperty("connectionUrl") String connectionUrl,
+			@JsonProperty("settings") Map<String, Object> settings) {
+
+		super(typeNames, booleanAsNumber, debugEnabled, settings);
+
+		this.rootPrefix = resolveProps(
+				firstNonNull(
+						rootPrefix,
+						(String) getSettings().get("rootPrefix"),
+						DEFAULT_ROOT_PREFIX));		
+
+		this.jsonFactory = new JsonFactory();
+		this.connectionUrl = connectionUrl;
+        this.indexName = this.rootPrefix + "_jmx-entries";
+
+	}
+
+	@Override
+	protected void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
+		List<String> typeNames = this.getTypeNames();
+
+		for (Result result : results) {
+			log.debug("Query result: [{}]", result);
+			Map<String, Object> resultValues = result.getValues();
+			for (Entry<String, Object> values : resultValues.entrySet()) {
+				Object value = values.getValue();
+				if (isNumeric(value)) {
+					String message = createJsonMessage(server, query, typeNames, result, values, value);
+                    log.debug("Insert into Elastic: Index: [{}] Type: [{}] Message: [{}]", indexName, TYPE_NAME, message);
+					Index index = new Index.Builder(message).index(indexName).type(TYPE_NAME).build();
+					jestClient.execute(index);
+				} else {
+					log.warn("Unable to submit non-numeric value to Elastic: [{}] from result [{}]", value, result);
+				}
+			}
+		}
+	}
+
+	private String createJsonMessage(Server server, Query query, List<String> typeNames, Result result, Entry<String, Object> values, Object value) throws IOException {
+
+		String keyString = getKeyString(server, query, result, values, typeNames, this.rootPrefix);
+
+        String alias;
+        if (server.getAlias() != null) {
+            alias = server.getAlias();
+        } else {
+            alias = server.getHost() + "_" + server.getPort();
+            alias = StringUtils.cleanupStr(alias);
+        }
+
+        Closer closer = Closer.create();
+		try {
+			ByteArrayOutputStream out = closer.register(new ByteArrayOutputStream());
+			JsonGenerator generator = closer.register(jsonFactory.createGenerator(out, UTF8));
+			generator.writeStartObject();
+			generator.writeStringField("server", alias);
+			generator.writeStringField("metric", keyString);
+			generator.writeNumberField("value", Double.parseDouble(value.toString()));
+			generator.writeStringField("resultAlias", result.getKeyAlias());
+			generator.writeStringField("attributeName", result.getAttributeName());
+			generator.writeStringField("key", values.getKey());
+			generator.writeNumberField("timestamp", result.getEpoch());
+			generator.writeEndObject();
+			generator.close();
+			return out.toString("UTF-8");
+		} catch (Throwable t) {
+			throw closer.rethrow(t);
+		} finally {
+			closer.close();
+		}
+	}
+
+	@VisibleForTesting
+	void setJestClient(JestClient jestClient) {
+		this.jestClient = jestClient;
+	}
+
+	@Override
+	public void validateSetup(Server server, Query query) throws ValidationException {
+		// no validations
+	}
+
+	@Override
+    public void start() throws LifecycleException {
+        super.start();
+
+		if (jestClient == null) {
+			log.info("Create a jest elastic search client for connection url [{}]", connectionUrl);
+			JestClientFactory factory = new JestClientFactory();
+			factory.setHttpClientConfig(
+					new HttpClientConfig.Builder(connectionUrl)
+							.multiThreaded(true)
+							.build());
+			jestClient = factory.getObject();
+
+        }
+		else {
+			log.info("Note: using injected jestClient instead of creating a new one: [{}]", jestClient);
+		}
+
+        createMapping(jestClient, indexName, TYPE_NAME);
+
+    }
+
+    private static void createMapping(JestClient jestClient, String indexName, String typeName) {
+        synchronized (CREATE_MAPPING_LOCK) {
+            try {
+                IndicesExists indicesExists = new IndicesExists.Builder(indexName).build();
+                boolean indexExists = jestClient.execute(indicesExists).isSucceeded();
+
+                if (!indexExists) {
+
+                    CreateIndex createIndex = new CreateIndex.Builder(indexName).build();
+                    jestClient.execute(createIndex);
+
+                    PutMapping putMapping = new PutMapping.Builder(indexName, typeName,
+                            "{\n" +
+                                    "  \"jmx-entry\": {\n" +
+                                    "    \"properties\": {\n" +
+                                    "      \"attributeName\": {\n" +
+                                    "        \"type\": \"string\",\n" +
+                                    "        \"index\": \"not_analyzed\"\n" +
+                                    "      },\n" +
+                                    "      \"key\": {\n" +
+                                    "        \"type\": \"string\",\n" +
+                                    "        \"index\": \"not_analyzed\"\n" +
+                                    "      },\n" +
+                                    "      \"metric\": {\n" +
+                                    "        \"type\": \"string\",\n" +
+                                    "        \"index\": \"not_analyzed\"\n" +
+                                    "      },\n" +
+                                    "      \"server\": {\n" +
+                                    "        \"type\": \"string\",\n" +
+                                    "        \"index\": \"not_analyzed\"\n" +
+                                    "      },\n" +
+                                    "      \"timestamp\": {\n" +
+                                    "        \"type\": \"date\"\n" +
+                                    "      },\n" +
+                                    "      \"resultAlias\": {\n" +
+                                    "        \"type\": \"string\",\n" +
+                                    "        \"index\": \"not_analyzed\"\n" +
+                                    "      },\n" +
+                                    "      \"value\": {\n" +
+                                    "        \"type\": \"float\"\n" +
+                                    "      }\n" +
+                                    "    }\n" +
+                                    "  }\n" +
+                                    "}").build();
+
+                    JestResult result = jestClient.execute(putMapping);
+                    if (!result.isSucceeded()) {
+                        log.warn("Failed to create mapping: {}", result.getErrorMessage());
+                    }
+                    else {
+                        log.info("Created mapping for index {}", indexName);
+                    }
+                }
+            } catch (IOException e) {
+                log.warn("Cannot create mapping for elastic search database.", e);
+            }
+        }
+    }
+
+    @Override
+	public void stop() throws LifecycleException {
+		super.stop();
+		jestClient.shutdownClient();
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java
@@ -49,18 +49,18 @@ public class ElasticWriter extends BaseOutputWriter {
 	private static final Logger log = LoggerFactory.getLogger(ElasticWriter.class);
 	
 	private static final String DEFAULT_ROOT_PREFIX = "jmxtrans";
-    private static final Object CREATE_MAPPING_LOCK = new Object();
+	private static final Object CREATE_MAPPING_LOCK = new Object();
 
-    private final JsonFactory jsonFactory;
+	private final JsonFactory jsonFactory;
 
 	private JestClient jestClient = null;
 
 	private final String rootPrefix;
 	private final String connectionUrl;
-    private static final String TYPE_NAME = "jmx-entry";
-    private String indexName;
+	private static final String TYPE_NAME = "jmx-entry";
+	private String indexName;
 
-    @JsonCreator
+	@JsonCreator
 	public ElasticWriter(
 			@JsonProperty("typeNames") ImmutableList<String> typeNames,
 			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
@@ -79,7 +79,7 @@ public class ElasticWriter extends BaseOutputWriter {
 
 		this.jsonFactory = new JsonFactory();
 		this.connectionUrl = connectionUrl;
-        this.indexName = this.rootPrefix + "_jmx-entries";
+		this.indexName = this.rootPrefix + "_jmx-entries";
 
 	}
 
@@ -94,7 +94,7 @@ public class ElasticWriter extends BaseOutputWriter {
 				Object value = values.getValue();
 				if (isNumeric(value)) {
 					String message = createJsonMessage(server, query, typeNames, result, values, value);
-                    log.debug("Insert into Elastic: Index: [{}] Type: [{}] Message: [{}]", indexName, TYPE_NAME, message);
+					log.debug("Insert into Elastic: Index: [{}] Type: [{}] Message: [{}]", indexName, TYPE_NAME, message);
 					Index index = new Index.Builder(message).index(indexName).type(TYPE_NAME).build();
 					jestClient.execute(index);
 				} else {
@@ -108,15 +108,15 @@ public class ElasticWriter extends BaseOutputWriter {
 
 		String keyString = getKeyString(server, query, result, values, typeNames, this.rootPrefix);
 
-        String alias;
-        if (server.getAlias() != null) {
-            alias = server.getAlias();
-        } else {
-            alias = server.getHost() + "_" + server.getPort();
-            alias = StringUtils.cleanupStr(alias);
-        }
+		String alias;
+		if (server.getAlias() != null) {
+			alias = server.getAlias();
+		} else {
+			alias = server.getHost() + "_" + server.getPort();
+			alias = StringUtils.cleanupStr(alias);
+		}
 
-        Closer closer = Closer.create();
+		Closer closer = Closer.create();
 		try {
 			ByteArrayOutputStream out = closer.register(new ByteArrayOutputStream());
 			JsonGenerator generator = closer.register(jsonFactory.createGenerator(out, UTF8));
@@ -149,8 +149,8 @@ public class ElasticWriter extends BaseOutputWriter {
 	}
 
 	@Override
-    public void start() throws LifecycleException {
-        super.start();
+	public void start() throws LifecycleException {
+		super.start();
 
 		if (jestClient == null) {
 			log.info("Create a jest elastic search client for connection url [{}]", connectionUrl);
@@ -161,75 +161,75 @@ public class ElasticWriter extends BaseOutputWriter {
 							.build());
 			jestClient = factory.getObject();
 
-        }
+		}
 		else {
 			log.info("Note: using injected jestClient instead of creating a new one: [{}]", jestClient);
 		}
 
-        createMapping(jestClient, indexName, TYPE_NAME);
+		createMapping(jestClient, indexName, TYPE_NAME);
 
-    }
+	}
 
-    private static void createMapping(JestClient jestClient, String indexName, String typeName) {
-        synchronized (CREATE_MAPPING_LOCK) {
-            try {
-                IndicesExists indicesExists = new IndicesExists.Builder(indexName).build();
-                boolean indexExists = jestClient.execute(indicesExists).isSucceeded();
+	private static void createMapping(JestClient jestClient, String indexName, String typeName) {
+		synchronized (CREATE_MAPPING_LOCK) {
+			try {
+				IndicesExists indicesExists = new IndicesExists.Builder(indexName).build();
+				boolean indexExists = jestClient.execute(indicesExists).isSucceeded();
 
-                if (!indexExists) {
+				if (!indexExists) {
 
-                    CreateIndex createIndex = new CreateIndex.Builder(indexName).build();
-                    jestClient.execute(createIndex);
+					CreateIndex createIndex = new CreateIndex.Builder(indexName).build();
+					jestClient.execute(createIndex);
 
-                    PutMapping putMapping = new PutMapping.Builder(indexName, typeName,
-                            "{\n" +
-                                    "  \"jmx-entry\": {\n" +
-                                    "    \"properties\": {\n" +
-                                    "      \"attributeName\": {\n" +
-                                    "        \"type\": \"string\",\n" +
-                                    "        \"index\": \"not_analyzed\"\n" +
-                                    "      },\n" +
-                                    "      \"key\": {\n" +
-                                    "        \"type\": \"string\",\n" +
-                                    "        \"index\": \"not_analyzed\"\n" +
-                                    "      },\n" +
-                                    "      \"metric\": {\n" +
-                                    "        \"type\": \"string\",\n" +
-                                    "        \"index\": \"not_analyzed\"\n" +
-                                    "      },\n" +
-                                    "      \"server\": {\n" +
-                                    "        \"type\": \"string\",\n" +
-                                    "        \"index\": \"not_analyzed\"\n" +
-                                    "      },\n" +
-                                    "      \"timestamp\": {\n" +
-                                    "        \"type\": \"date\"\n" +
-                                    "      },\n" +
-                                    "      \"resultAlias\": {\n" +
-                                    "        \"type\": \"string\",\n" +
-                                    "        \"index\": \"not_analyzed\"\n" +
-                                    "      },\n" +
-                                    "      \"value\": {\n" +
-                                    "        \"type\": \"float\"\n" +
-                                    "      }\n" +
-                                    "    }\n" +
-                                    "  }\n" +
-                                    "}").build();
+					PutMapping putMapping = new PutMapping.Builder(indexName, typeName,
+							"{\n" +
+									"  \"jmx-entry\": {\n" +
+									"    \"properties\": {\n" +
+									"      \"attributeName\": {\n" +
+									"        \"type\": \"string\",\n" +
+									"        \"index\": \"not_analyzed\"\n" +
+									"      },\n" +
+									"      \"key\": {\n" +
+									"        \"type\": \"string\",\n" +
+									"        \"index\": \"not_analyzed\"\n" +
+									"      },\n" +
+									"      \"metric\": {\n" +
+									"        \"type\": \"string\",\n" +
+									"        \"index\": \"not_analyzed\"\n" +
+									"      },\n" +
+									"      \"server\": {\n" +
+									"        \"type\": \"string\",\n" +
+									"        \"index\": \"not_analyzed\"\n" +
+									"      },\n" +
+									"      \"timestamp\": {\n" +
+									"        \"type\": \"date\"\n" +
+									"      },\n" +
+									"      \"resultAlias\": {\n" +
+									"        \"type\": \"string\",\n" +
+									"        \"index\": \"not_analyzed\"\n" +
+									"      },\n" +
+									"      \"value\": {\n" +
+									"        \"type\": \"float\"\n" +
+									"      }\n" +
+									"    }\n" +
+									"  }\n" +
+									"}").build();
 
-                    JestResult result = jestClient.execute(putMapping);
-                    if (!result.isSucceeded()) {
-                        log.warn("Failed to create mapping: {}", result.getErrorMessage());
-                    }
-                    else {
-                        log.info("Created mapping for index {}", indexName);
-                    }
-                }
-            } catch (IOException e) {
-                log.warn("Cannot create mapping for elastic search database.", e);
-            }
-        }
-    }
+					JestResult result = jestClient.execute(putMapping);
+					if (!result.isSucceeded()) {
+						log.warn("Failed to create mapping: {}", result.getErrorMessage());
+					}
+					else {
+						log.info("Created mapping for index {}", indexName);
+					}
+				}
+			} catch (IOException e) {
+				log.warn("Cannot create mapping for elastic search database.", e);
+			}
+		}
+	}
 
-    @Override
+	@Override
 	public void stop() throws LifecycleException {
 		super.stop();
 		jestClient.shutdownClient();

--- a/jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java
@@ -2,7 +2,6 @@ package com.googlecode.jmxtrans.model.output.elastic;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;

--- a/jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterException.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterException.java
@@ -1,10 +1,6 @@
 package com.googlecode.jmxtrans.model.output.elastic;
 
 public class ElasticWriterException extends Exception {
-	public ElasticWriterException(String message, Throwable cause) {
-		super(message, cause);
-	}
-
 	public ElasticWriterException(String message) {
 		super(message);
 	}

--- a/jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterException.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterException.java
@@ -1,0 +1,11 @@
+package com.googlecode.jmxtrans.model.output.elastic;
+
+public class ElasticWriterException extends Exception {
+	public ElasticWriterException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public ElasticWriterException(String message) {
+		super(message);
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-elastic/src/main/resources/elastic-mapping.json
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/main/resources/elastic-mapping.json
@@ -1,0 +1,37 @@
+{
+  "jmx-entry": {
+    "properties": {
+      "attributeName": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "className": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "key": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "objDomain": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "server": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "timestamp": {
+        "type": "long"
+      },
+      "typeName": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "value": {
+        "type": "string",
+        "index": "not_analyzed"
+      }
+    }
+  }
+}

--- a/jmxtrans-output/jmxtrans-output-elastic/src/main/resources/elastic-mapping.json
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/main/resources/elastic-mapping.json
@@ -1,19 +1,7 @@
 {
   "jmx-entry": {
     "properties": {
-      "attributeName": {
-        "type": "string",
-        "index": "not_analyzed"
-      },
-      "className": {
-        "type": "string",
-        "index": "not_analyzed"
-      },
-      "key": {
-        "type": "string",
-        "index": "not_analyzed"
-      },
-      "objDomain": {
+      "serverAlias": {
         "type": "string",
         "index": "not_analyzed"
       },
@@ -21,16 +9,39 @@
         "type": "string",
         "index": "not_analyzed"
       },
-      "timestamp": {
-        "type": "long"
+      "port": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "objDomain": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "className": {
+        "type": "string",
+        "index": "not_analyzed"
       },
       "typeName": {
         "type": "string",
         "index": "not_analyzed"
       },
-      "value": {
+      "attributeName": {
         "type": "string",
         "index": "not_analyzed"
+      },
+      "key": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "keyAlias": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "value": {
+        "type": "double"
+      },
+      "timestamp": {
+        "type": "date"
       }
     }
   }

--- a/jmxtrans-output/jmxtrans-output-elastic/src/main/resources/example-config-elastic.json
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/main/resources/example-config-elastic.json
@@ -2,24 +2,28 @@
   "servers" : [ {
     "port" : "9400",
     "host" : "192.168.86.136",
+    "alias" : "my elastic search test server",
     "queries" : [ {
       "outputWriters" : [ {
         "@class" : "com.googlecode.jmxtrans.model.output.elastic.ElasticWriter",
-        "connectionUrl" : "http://192.168.86.136:9200"
+        "connectionUrl" : "http://192.168.86.136:9200",
+        "rootPrefix" : "test"
       } ],
       "obj" : "java.lang:type=Memory",
       "attr" : [ "HeapMemoryUsage", "NonHeapMemoryUsage" ]
     }, {
       "outputWriters" : [ {
         "@class" : "com.googlecode.jmxtrans.model.output.elastic.ElasticWriter",
-        "connectionUrl" : "http://192.168.86.136:9200"
+        "connectionUrl" : "http://192.168.86.136:9200",
+        "rootPrefix" : "test"
       } ],
       "obj" : "java.lang:name=CMS Old Gen,type=MemoryPool",
       "attr" : [ "Usage" ]
     }, {
       "outputWriters" : [ {
         "@class" : "com.googlecode.jmxtrans.model.output.elastic.ElasticWriter",
-        "connectionUrl" : "http://192.168.86.136:9200"
+        "connectionUrl" : "http://192.168.86.136:9200",
+        "rootPrefix" : "test"
       } ],
       "obj" : "java.lang:name=ConcurrentMarkSweep,type=GarbageCollector",
       "attr" : [ "LastGcInfo" ]

--- a/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
@@ -8,20 +8,20 @@ import com.googlecode.jmxtrans.model.Server;
 import io.searchbox.action.Action;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
-import io.searchbox.core.Index;
 import io.searchbox.indices.IndicesExists;
 import io.searchbox.indices.mapping.PutMapping;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.*;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ElasticWriterTests {
@@ -46,18 +46,18 @@ public class ElasticWriterTests {
 
 		// return for call, does index exist
 		when(jestResultFalse.isSucceeded()).thenReturn(Boolean.FALSE);
-        when(mockClient.execute(Matchers.<IndicesExists>isA(IndicesExists.class))).thenReturn(jestResultFalse);
+		when(mockClient.execute(Matchers.<IndicesExists>isA(IndicesExists.class))).thenReturn(jestResultFalse);
 
-        // return for call, is index created
-        when(jestResultTrue.isSucceeded()).thenReturn(Boolean.TRUE);
+		// return for call, is index created
+		when(jestResultTrue.isSucceeded()).thenReturn(Boolean.TRUE);
 		when(mockClient.execute(Matchers.<PutMapping>isA(PutMapping.class))).thenReturn(jestResultTrue);
 
 		ElasticWriter writer = new ElasticWriter(typenames, true, "rootPrefix", true, connectionUrl, settings);
 		// client for testing
 		writer.setJestClient(mockClient);
 
-        // creates the index if needed
-        writer.start();
+		// creates the index if needed
+		writer.start();
 
 		writer.doWrite(server, query, ImmutableList.of(result));
 

--- a/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
@@ -1,0 +1,67 @@
+package com.googlecode.jmxtrans.model.output.elastic;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import io.searchbox.action.Action;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Index;
+import io.searchbox.indices.IndicesExists;
+import io.searchbox.indices.mapping.PutMapping;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ElasticWriterTests {
+
+	@Mock
+	private JestClient mockClient;
+    @Mock
+    private JestResult jestResultTrue;
+    @Mock
+    private JestResult jestResultFalse;
+
+	@Test
+	public void sendMessageToElastic() throws Exception {
+		Server server = Server.builder().setHost("host").setPort("123").build();
+		Query query = Query.builder().build();
+		Result result = new Result(1, "attributeName", "className", "objDomain", "classNameAlias", "typeName", ImmutableMap.of("key", (Object)1));
+
+		ImmutableList<String> typenames = ImmutableList.of();
+		Map<String,Object> settings = new HashMap<String,Object>();
+
+		String connectionUrl = "http://localhost";
+
+		// return for call, does index exist
+		when(jestResultFalse.isSucceeded()).thenReturn(Boolean.FALSE);
+        // return for call, is index created
+		when(jestResultTrue.isSucceeded()).thenReturn(Boolean.TRUE);
+		when(mockClient.execute(Matchers.<IndicesExists>any())).thenReturn(jestResultFalse);
+		when(mockClient.execute(Matchers.<PutMapping>any())).thenReturn(jestResultTrue);
+
+		ElasticWriter writer = new ElasticWriter(typenames, true, "rootPrefix", true, connectionUrl, settings);
+		// client for testing
+        writer.setJestClient(mockClient);
+
+		// increase coverage
+		writer.start();
+
+		writer.doWrite(server, query, ImmutableList.of(result));
+
+		Mockito.verify(mockClient, atLeast(2)).execute(Matchers.<Action<JestResult>>any());
+
+	}
+
+}

--- a/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
@@ -46,17 +46,18 @@ public class ElasticWriterTests {
 
 		// return for call, does index exist
 		when(jestResultFalse.isSucceeded()).thenReturn(Boolean.FALSE);
-		// return for call, is index created
-		when(jestResultTrue.isSucceeded()).thenReturn(Boolean.TRUE);
-		when(mockClient.execute(Matchers.<IndicesExists>any())).thenReturn(jestResultFalse);
-		when(mockClient.execute(Matchers.<PutMapping>any())).thenReturn(jestResultTrue);
+        when(mockClient.execute(Matchers.<IndicesExists>isA(IndicesExists.class))).thenReturn(jestResultFalse);
+
+        // return for call, is index created
+        when(jestResultTrue.isSucceeded()).thenReturn(Boolean.TRUE);
+		when(mockClient.execute(Matchers.<PutMapping>isA(PutMapping.class))).thenReturn(jestResultTrue);
 
 		ElasticWriter writer = new ElasticWriter(typenames, true, "rootPrefix", true, connectionUrl, settings);
 		// client for testing
 		writer.setJestClient(mockClient);
 
-		// increase coverage
-		writer.start();
+        // creates the index if needed
+        writer.start();
 
 		writer.doWrite(server, query, ImmutableList.of(result));
 

--- a/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
@@ -28,10 +28,10 @@ public class ElasticWriterTests {
 
 	@Mock
 	private JestClient mockClient;
-    @Mock
-    private JestResult jestResultTrue;
-    @Mock
-    private JestResult jestResultFalse;
+	@Mock
+	private JestResult jestResultTrue;
+	@Mock
+	private JestResult jestResultFalse;
 
 	@Test
 	public void sendMessageToElastic() throws Exception {
@@ -46,14 +46,14 @@ public class ElasticWriterTests {
 
 		// return for call, does index exist
 		when(jestResultFalse.isSucceeded()).thenReturn(Boolean.FALSE);
-        // return for call, is index created
+		// return for call, is index created
 		when(jestResultTrue.isSucceeded()).thenReturn(Boolean.TRUE);
 		when(mockClient.execute(Matchers.<IndicesExists>any())).thenReturn(jestResultFalse);
 		when(mockClient.execute(Matchers.<PutMapping>any())).thenReturn(jestResultTrue);
 
 		ElasticWriter writer = new ElasticWriter(typenames, true, "rootPrefix", true, connectionUrl, settings);
 		// client for testing
-        writer.setJestClient(mockClient);
+		writer.setJestClient(mockClient);
 
 		// increase coverage
 		writer.start();

--- a/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
@@ -120,7 +120,8 @@ public class ElasticWriterTests {
         String host = "myHost";
         String port = "56677";
 
-		Server serverWithKnownValues = Server.builder().setHost(host).setPort(port).build();
+		String serverAlias = "myAlias";
+		Server serverWithKnownValues = Server.builder().setHost(host).setPort(port).setAlias(serverAlias).build();
 
         int epoch = 1123455;
         String attributeName = "attributeName123";
@@ -143,70 +144,21 @@ public class ElasticWriterTests {
         verify(mockClient).execute(argument.capture());
         assertEquals(PREFIX + "_jmx-entries", argument.getValue().getIndex());
 
-        // some values are not included, if these are necessary we should include them
         Gson gson = new Gson();
         String data = argument.getValue().getData(gson);
         assertTrue("Contains host", data.contains(host));
         assertTrue("Contains port", data.contains(port));
         assertTrue("Contains attribute name", data.contains(attributeName));
-        //assertTrue("Contains class name", data.contains(className));
-        //assertTrue("Contains object domain", data.contains(objDomain));
+        assertTrue("Contains class name", data.contains(className));
+        assertTrue("Contains object domain", data.contains(objDomain));
         assertTrue("Contains classNameAlias", data.contains(classNameAlias));
-        //assertTrue("Contains type name", data.contains(typeName));
+        assertTrue("Contains type name", data.contains(typeName));
         assertTrue("Contains timestamp", data.contains(String.valueOf(epoch)));
         assertTrue("Contains key", data.contains(key));
         assertTrue("Contains value", data.contains(String.valueOf(value)));
-		//assertTrue("Contains serverAlias", data.contains(serverAlias));
-
-    }
-
-	@Test
-	public void sendMessageWithServerAliasToElasticAndVerify() throws Exception {
-
-		String host = "myHost";
-		String port = "56677";
-
-		String serverAlias = "myAlias";
-		Server serverWithKnownValues = Server.builder().setHost(host).setPort(port).setAlias(serverAlias).build();
-
-		int epoch = 1123455;
-		String attributeName = "attributeName123";
-		String className = "className123";
-		String objDomain = "objDomain123";
-		String classNameAlias = "classNameAlias123";
-		String typeName = "typeName123";
-		String key = "myKey";
-		int value = 1122;
-
-		Result resultWithKnownValues = new Result(epoch, attributeName, className, objDomain, classNameAlias, typeName, ImmutableMap.of(key, (Object) value));
-
-		ArgumentCaptor<Index> argument = ArgumentCaptor.forClass(Index.class);
-
-		// return for call, add index entry
-		when(mockClient.execute(Matchers.isA(Index.class))).thenReturn(jestResultTrue);
-
-		writer.doWrite(serverWithKnownValues, query, ImmutableList.of(resultWithKnownValues));
-
-		verify(mockClient).execute(argument.capture());
-		assertEquals(PREFIX + "_jmx-entries", argument.getValue().getIndex());
-
-		// some values are not included, if these are necessary we should include them
-		// with alias the host and port information is lost, is that expected?
-		Gson gson = new Gson();
-		String data = argument.getValue().getData(gson);
-		//assertTrue("Contains host", data.contains(host));
-		//assertTrue("Contains port", data.contains(port));
-		assertTrue("Contains attribute name", data.contains(attributeName));
-		//assertTrue("Contains class name", data.contains(className));
-		//assertTrue("Contains object domain", data.contains(objDomain));
-		assertTrue("Contains classNameAlias", data.contains(classNameAlias));
-		//assertTrue("Contains type name", data.contains(typeName));
-		assertTrue("Contains timestamp", data.contains(String.valueOf(epoch)));
-		assertTrue("Contains key", data.contains(key));
-		assertTrue("Contains value", data.contains(String.valueOf(value)));
 		assertTrue("Contains serverAlias", data.contains(serverAlias));
 
-	}
+    }
 
 	@Test(expected = LifecycleException.class)
 	public void indexCreateFailure() throws Exception {

--- a/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.*;
 public class ElasticWriterTests {
 
     private static final String PREFIX = "rootPrefix";
+
     @Mock
 	private JestClient mockClient;
 	@Mock
@@ -78,7 +79,7 @@ public class ElasticWriterTests {
 
 	}
 
-    @Test
+	@Test
     public void sendMessageToElasticAndVerify() throws Exception {
 
         String host = "myHost";
@@ -143,7 +144,7 @@ public class ElasticWriterTests {
 		// client for testing
 		writer.setJestClient(mockClient);
 
-		// creates the index if needed
+		// expected to throw an exception
 		writer.start();
 
 	}
@@ -155,6 +156,12 @@ public class ElasticWriterTests {
 		String connectionUrl = "http://localhost";
 
 		return new ElasticWriter(typenames, true, PREFIX, true, connectionUrl, settings);
+	}
+
+	@Test
+	public void checkToString() throws Exception {
+		ElasticWriter elasticWriter = createElasticWriter();
+		assertTrue(elasticWriter.toString().contains("ElasticWriter"));
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
@@ -2,18 +2,23 @@ package com.googlecode.jmxtrans.model.output.elastic;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
 import io.searchbox.action.Action;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
+import io.searchbox.core.Index;
 import io.searchbox.indices.IndicesExists;
 import io.searchbox.indices.mapping.PutMapping;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -23,13 +28,14 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ElasticWriterTests {
 
-	@Mock
+    private static final String PREFIX = "rootPrefix";
+    @Mock
 	private JestClient mockClient;
 	@Mock
 	private JestResult jestResultTrue;
@@ -56,21 +62,71 @@ public class ElasticWriterTests {
 		// return for call, is index created
 		when(mockClient.execute(Matchers.isA(PutMapping.class))).thenReturn(jestResultTrue);
 
-		// client for testing
-		writer.setJestClient(mockClient);
+        ArgumentCaptor<Index> argument = ArgumentCaptor.forClass(Index.class);
 
-		// creates the index if needed
-		writer.start();
+        // client for testing
+        writer.setJestClient(mockClient);
 
-		writer.doWrite(server, query, ImmutableList.of(result));
+        // creates the index if needed
+        writer.start();
 
-		writer.stop();
+        writer.doWrite(server, query, ImmutableList.of(result));
 
-		Mockito.verify(mockClient, atLeast(2)).execute(Matchers.<Action<JestResult>>any());
+        writer.stop();
+
+        Mockito.verify(mockClient, times(4)).execute(Matchers.<Action<JestResult>>any());
 
 	}
 
-	@Test
+    @Test
+    public void sendMessageToElasticAndVerify() throws Exception {
+
+        String host = "myHost";
+        String port = "56677";
+
+        Server server = Server.builder().setHost(host).setPort(port).build();
+        Query query = Query.builder().build();
+
+        int epoch = 1123455;
+        String attributeName = "attributeName123";
+        String className = "className123";
+        String objDomain = "objDomain123";
+        String classNameAlias = "classNameAlias123";
+        String typeName = "typeName123";
+        String key = "myKey";
+        int value = 1122;
+
+        Result result = new Result(epoch, attributeName, className, objDomain, classNameAlias, typeName, ImmutableMap.of(key, (Object) value));
+
+        ElasticWriter writer =  createElasticWriter();
+
+        ArgumentCaptor<Index> argument = ArgumentCaptor.forClass(Index.class);
+
+        // client for testing
+        writer.setJestClient(mockClient);
+
+        writer.doWrite(server, query, ImmutableList.of(result));
+
+        verify(mockClient).execute(argument.capture());
+        assertEquals(PREFIX + "_jmx-entries", argument.getValue().getIndex());
+
+        // some values are not included, if these are necessary we should include them
+        Gson gson = new Gson();
+        String data = argument.getValue().getData(gson);
+        assertTrue("Contains host", data.contains(host));
+        assertTrue("Contains port", data.contains(port));
+        assertTrue("Contains attribute name", data.contains(attributeName));
+        //assertTrue("Contains class name", data.contains(className));
+        //assertTrue("Contains object domain", data.contains(objDomain));
+        assertTrue("Contains classNameAlias", data.contains(classNameAlias));
+        //assertTrue("Contains type name", data.contains(typeName));
+        assertTrue("Contains timestamp", data.contains(String.valueOf(epoch)));
+        assertTrue("Contains key", data.contains(key));
+        assertTrue("Contains value", data.contains(String.valueOf(value)));
+
+    }
+
+    @Test(expected = LifecycleException.class)
 	public void indexCreateFailure() throws Exception {
 
 		ElasticWriter writer = createElasticWriter();
@@ -78,7 +134,10 @@ public class ElasticWriterTests {
 		// return for call, does index exist
 		when(mockClient.execute(Matchers.isA(IndicesExists.class))).thenReturn(jestResultFalse);
 
-		// return for call, is index created: return false
+        // return for call, is index created; return false
+        when(mockClient.execute(Matchers.isA(PutMapping.class))).thenReturn(jestResultFalse);
+
+        // return error message
 		when(jestResultFalse.getErrorMessage()).thenReturn("Unknown error creating index in elastic");
 
 		// client for testing
@@ -86,10 +145,6 @@ public class ElasticWriterTests {
 
 		// creates the index if needed
 		writer.start();
-
-		writer.stop();
-
-		Mockito.verify(mockClient, atLeast(2)).execute(Matchers.<Action<JestResult>>any());
 
 	}
 
@@ -99,7 +154,7 @@ public class ElasticWriterTests {
 
 		String connectionUrl = "http://localhost";
 
-		return new ElasticWriter(typenames, true, "rootPrefix", true, connectionUrl, settings);
+		return new ElasticWriter(typenames, true, PREFIX, true, connectionUrl, settings);
 	}
 
 }

--- a/jmxtrans-output/pom.xml
+++ b/jmxtrans-output/pom.xml
@@ -24,6 +24,7 @@
 		Some dependencies are also problematic. They can introduce incompatibilities. For example, a few writers are
 		based directly on log4j or logback. This direct dependence breaks the use of SLF4J. By isolating those output
 		writers to a specific module, we can ensure this has minimal impact.</description>
+
 	<modules>
 		<module>jmxtrans-output-cloudwatch</module>
 		<module>jmxtrans-output-core</module>
@@ -32,6 +33,7 @@
 		<module>jmxtrans-output-log4j</module>
 		<module>jmxtrans-output-velocity</module>
 		<module>jmxtrans-output-kafka</module>
+		<module>jmxtrans-output-elastic</module>
 	</modules>
 
 	<build>

--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -74,6 +74,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jmxtrans</groupId>
+			<artifactId>jmxtrans-output-elastic</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jmxtrans</groupId>
 			<artifactId>jmxtrans-output-ganglia</artifactId>
 			<scope>runtime</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.jmxtrans</groupId>
+				<artifactId>jmxtrans-output-elastic</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jmxtrans</groupId>
 				<artifactId>jmxtrans-output-ganglia</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -345,11 +350,11 @@
 			</dependency>
 			<dependency>
 				<!--
-					AWS CloudWatch needs a recent version of http client.
+					AWS CloudWatch and Jest (elastic search client) need a recent version of http client.
 				-->
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.3.6</version>
+				<version>4.5</version>
 				<scope>runtime</scope>
 			</dependency>
 			<dependency>
@@ -648,6 +653,10 @@
 							<goals>
 								<goal>jar</goal>
 							</goals>
+							<!-- avoid doclint warnings that make maven build fail in java 8 -->
+							<configuration>
+								<additionalparam>-Xdoclint:none</additionalparam>
+							</configuration>
 						</execution>
 					</executions>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
 				<version>1.0.10</version>
 			</dependency>
 			<dependency>
+				<groupId>io.searchbox</groupId>
+				<artifactId>jest</artifactId>
+				<version>0.1.6</version>
+			</dependency>
+			<dependency>
 				<groupId>javax.inject</groupId>
 				<artifactId>javax.inject</artifactId>
 				<version>1</version>
@@ -653,10 +658,6 @@
 							<goals>
 								<goal>jar</goal>
 							</goals>
-							<!-- avoid doclint warnings that make maven build fail in java 8 -->
-							<configuration>
-								<additionalparam>-Xdoclint:none</additionalparam>
-							</configuration>
 						</execution>
 					</executions>
 				</plugin>


### PR DESCRIPTION
This is an output writer that writes data directly into an elastic search instance.

Define output writer as follows:
```
    "outputWriters" : [ 
        "@class" : "com.googlecode.jmxtrans.model.output.elastic.ElasticWriter",
        "connectionUrl" : "http://192.168.86.136:9200"
      } ]
```
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23issuecomment-130468118%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23issuecomment-130848354%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23issuecomment-131012669%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23issuecomment-131096990%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36921079%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36921585%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36921967%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36922115%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36922385%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36922562%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37027143%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37027148%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37027149%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37027150%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37027152%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37027154%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37055190%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37056005%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37056073%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37056380%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37056580%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37071190%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37071251%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37071733%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37071972%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37072917%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37073118%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37073119%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37073120%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37073121%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37081288%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37082256%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37082614%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37120149%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37120252%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37120266%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37135538%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23issuecomment-131570873%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23issuecomment-131612296%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23issuecomment-130468118%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good%20%21%20Thanks%20for%20the%20contribution%20%21%20I%20have%20a%20few%20mostly%20minor%20comments.%20Could%20you%20have%20a%20look%20and%20tell%20me%20if%20those%20comments%20make%20sense%20to%20you%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-12T22%3A36%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-13T21%3A21%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%20to%20be%20a%20pain%2C%20but%20it%20seems%20that%20I%20have%20a%20few%20more%20comments...%22%2C%20%22created_at%22%3A%20%222015-08-14T08%3A05%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-14T12%3A55%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%2C%20%7B%22body%22%3A%20%22When%20running%20this%20against%20a%20elastic%20server%2C%20I%20see%20the%20following%20non-numeric%20value%20passing%20along%20in%20the%20log%20file%3A%5Cr%5Cn%5Cr%5Cn17%3A04%3A05.442%20%5Bpool-17-thread-2%5D%20WARN%20%20c.g.j.m.output.elastic.ElasticWriter%20-%20Unable%20to%20submit%20non-numeric%20value%20to%20Elastic%3A%20%5Bjavax.management.openmbean.TabularDataSupport%28tabularType%3Djavax.management.openmbean.TabularType%28name%3DMap%3Cjava.lang.String%2Cjava.lang.management.MemoryUsage%3E%2CrowType%3Djavax.management.openmbean.CompositeType%28name%3DMap%3Cjava.lang.String%2Cjava.lang.management.MemoryUsage%3E%2Citems%3D%28%28itemName%3Dkey%2CitemType%3Djavax.management.openmbean.SimpleType%28name%3Djava.lang.String%29%29%2C%28itemName%3Dvalue%2CitemType%3Djavax.management.openmbean.CompositeType%28name%3Djava.lang.management.MemoryUsage%2Citems%3D%28%28itemName%3Dcommitted%2CitemType%3Djavax.management.openmbean.SimpleType%28name%3Djava.lang.Long%29%29%2C%28itemName%3Dinit%2CitemType%3Djavax.management.openmbean.SimpleType%28name%3Djava.lang.Long%29%29%2C%28itemName%3Dmax%2CitemType%3Djavax.management.openmbean.SimpleType%28name%3Djava.lang.Long%29%29%2C%28itemName%3Dused%2CitemType%3Djavax.management.openmbean.SimpleType%28name%3Djava.lang.Long%29%29%29%29%29%29%29%2CindexNames%3D%28key%29%29%2Ccontents%3D%7B%20%3C%3C%3C...%20REMOVED%20VERY%20LONG%20STRING%20...%20%3E%3E%3E%20javax.management.openmbean.CompositeDataSupport%28compositeType%3Djavax.management.openmbean.CompositeType%28name%3Djava.lang.management.MemoryUsage%2Citems%3D%28%28itemName%3Dcommitted%2CitemType%3Djavax.management.openmbean.SimpleType%28name%3Djava.lang.Long%29%29%2C%28itemName%3Dinit%2CitemType%3Djavax.management.openmbean.SimpleType%28name%3Djava.lang.Long%29%29%2C%28itemName%3Dmax%2CitemType%3Djavax.management.openmbean.SimpleType%28name%3Djava.lang.Long%29%29%2C%28itemName%3Dused%2CitemType%3Djavax.management.openmbean.SimpleType%28name%3Djava.lang.Long%29%29%29%29%2Ccontents%3D%7Bcommitted%3D178978816%2C%20init%3D178978816%2C%20max%3D724828160%2C%20used%3D12257128%7D%29%7D%29%7D%29%7D%2C%20epoch%3D1439737445281%5D%5D%5Cr%5Cn17%3A04%3A05.447%20%5Bpool-17-thread-2%5D%20DEBUG%20c.g.jmxtrans.jmx.JmxQueryProcessor%20-%20Finished%20running%20outputWriters%20for%20query%3A%20Query%20%5Bobj%3Djava.lang%3Aname%3DConcurrentMarkSweep%2Ctype%3DGarbageCollector%2C%20useObjDomainAsKey%3Afalse%2C%20resultAlias%3Dnull%2C%20attr%3D%5BLastGcInfo%5D%5D%5Cr%5Cn%5Cr%5CnAny%20idea%20what%20this%20is%3F%22%2C%20%22created_at%22%3A%20%222015-08-16T15%3A14%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%2C%20%7B%22body%22%3A%20%22Seems%20to%20be%20a%20bug%20in%20%60JmxResultProcessor%60.%20You%20should%20never%20see%20tabular%20data%20in%20an%20output%20writer.%20Having%20a%20quick%20look%20at%20the%20code%2C%20it%20looks%20like%20that%20could%20happen%20if%20a%20tabular%20data%20contains%20other%20tabular%20data...%20Could%20that%20be%20the%20case%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-16T19%3A34%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2060831f08db1172227b1ae56c6928008b3e909fc9%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%20111%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36922562%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20should%20extract%20a%20%60computeAlias%28%29%60%20method%20from%20this%20block%20%28possibly%20with%20a%20better%20name%29.%22%2C%20%22created_at%22%3A%20%222015-08-12T22%3A31%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-13T21%3A21%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%3AL1-238%22%7D%2C%20%22Pull%2060831f08db1172227b1ae56c6928008b3e909fc9%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%20185%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36922115%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22That%20big%20wall%20of%20String%20hurt%20my%20eyes.%20Any%20chance%20we%20could%20load%20it%20from%20a%20classpath%20resource%20instead%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-12T22%3A26%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-13T21%3A21%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%3AL1-238%22%7D%2C%20%22Pull%2013ce272b390b70e194f702f737b95b4c20c65963%20jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java%2079%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37056380%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%27re%20missing%20a%20mock%20for%20the%20second%20call%20to%20%60jestClient.execute%28%29%60.%22%2C%20%22created_at%22%3A%20%222015-08-14T08%3A00%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-14T12%3A55%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java%3AL1-106%22%7D%2C%20%22Pull%2013ce272b390b70e194f702f737b95b4c20c65963%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%20184%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37056005%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20seems%20that%20result%20can%20be%20null%2C%20so%20the%20condition%20should%20probably%20be%20%60if%20%28result%20%3D%3D%20null%20%7C%7C%20%21result.isSucceeded%28%29%29%60.%20Though%20even%20better%20would%20be%20to%20understand%20why%20thi%20result%20can%20be%20null.%22%2C%20%22created_at%22%3A%20%222015-08-14T07%3A52%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20was%20a%20mock%20issue%2C%20not%20return%20value%20was%20set.%20I%20would%20expect%20always%20a%20result%20from%20jest.%22%2C%20%22created_at%22%3A%20%222015-08-14T12%3A25%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%2C%20%7B%22body%22%3A%20%22Short%20digging%20in%20the%20Jest%20code%20seems%20to%20indicate%20that%20you%20are%20right.%20Everyone%20should%20use%20JSR305%20%3B-%29%22%2C%20%22created_at%22%3A%20%222015-08-14T12%3A33%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-14T12%3A37%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%3AL1-210%22%7D%2C%20%22Pull%2013ce272b390b70e194f702f737b95b4c20c65963%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%20185%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37056073%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20case%20of%20error%2C%20we%20probably%20want%20to%20throw%20an%20exception%20to%20ensure%20that%20this%20writer%20is%20disabled.%20Unless%20this%20can%20be%20a%20transient%20error.%20So%20probably%20in%20case%20of%20communication%20error%2C%20we%20have%20a%20good%20chance%20of%20recovery%2C%20otherwise%20probably%20not%20so%20much%20...%5Cr%5Cn%5Cr%5CnNote%3A%20this%20is%20a%20minor%20point%2C%20I%27ll%20be%20happy%20to%20merge%20without%20it.%22%2C%20%22created_at%22%3A%20%222015-08-14T07%3A54%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-14T12%3A55%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%3AL1-210%22%7D%2C%20%22Pull%2013ce272b390b70e194f702f737b95b4c20c65963%20jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java%2070%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37056580%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20also%20verify%20that%20call%20to%20Elastic%20that%20sends%20the%20data%20is%20actually%20made%20and%20that%20it%20contains%20the%20results%20that%20were%20given%20on%20inputs.%20In%20the%20end%2C%20that%27s%20the%20most%20important%20action%20of%20your%20class%2C%20so%20it%20should%20be%20tested.%22%2C%20%22created_at%22%3A%20%222015-08-14T08%3A04%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22A%20data%20verify%20test%20has%20been%20added.%20Not%20all%20given%20parameters%20are%20part%20of%20the%20message%20towards%20elastic.%20It%20suffices%20for%20me%20at%20this%20moment.%20If%20other%20data%20is%20needed%20%28e.g.%20className%29%20I%20can%20add%20that.%22%2C%20%22created_at%22%3A%20%222015-08-14T12%3A52%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-14T12%3A55%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java%3AL1-106%22%7D%2C%20%22Pull%2060831f08db1172227b1ae56c6928008b3e909fc9%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%20226%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36922385%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20an%20expert%20on%20ElasticSerach%20and%20Jest%2C%20but%20my%20guess%20is%20that%20if%20the%20creation%20of%20mappings%20fail%2C%20this%20output%20writer%20will%20be%20unuseable.%20So%20you%20should%20probably%20just%20let%20the%20exception%20bubble%20up%20and%20not%20hide%20the%20issue.%22%2C%20%22created_at%22%3A%20%222015-08-12T22%3A29%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-13T21%3A21%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%3AL1-238%22%7D%2C%20%22Pull%204f7e27f9924a61549a8da0d00296317c876e7dda%20jmxtrans-output/jmxtrans-output-elastic/pom.xml%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37081288%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Mutation%20coverage%20is%20still%20a%20bit%20low%20%28you%20should%20find%20the%20report%20in%20%60jmxtrans-output/jmxtrans-output-elastic/target/pit-reports%60.%20Ideally%2C%20there%20are%20a%20few%20scenarios%20that%20you%20should%20add%20to%20the%20tests%20or%20just%20drop%20the%20minimum%20coverage%20to%2055.%5Cr%5Cn%5Cr%5CnThings%20that%20probably%20make%20sense%20to%20be%20added%20to%20tests%3A%5Cr%5Cn%5Cr%5Cn%2A%20sending%20non%20numeric%20values%5Cr%5Cn%2A%20validate%20that%20the%20json%20sent%20is%20syntactically%20valid%5Cr%5Cn%2A%20move%20the%20%60createAlias%28%29%60%20method%20to%20the%20%60Server%60%20class%20and%20test%20it%20there%20%28and%20refactor%20all%20the%20places%20where%20we%20have%20the%20same%20code%29%5Cr%5Cn%2A%20test%20that%20the%20index%20is%20not%20created%20if%20it%20already%20exists%5Cr%5Cn%2A%20test%20that%20exception%20is%20thrown%20if%20index%20cannot%20be%20created%5Cr%5Cn%2A%20...%5Cr%5Cn%5Cr%5CnI%27ll%20be%20happy%20to%20merge%20even%20without%20those%20additional%20tests%20%28I%20already%20make%20you%20work%20pretty%20hard%20on%20this%20one%29.%22%2C%20%22created_at%22%3A%20%222015-08-14T14%3A28%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20have%20managed%20to%20get%20to%2060%20percent.%20Interesting%20concept%2C%20this%20mutation%20testing.%20It%20is%20new%20to%20me.%20I%20have%20been%20struggling%20to%20get%20to%20higher%20percentage.%20Lowered%20the%20minimum%20to%2060.%22%2C%20%22created_at%22%3A%20%222015-08-14T21%3A16%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/pom.xml%3AL1-68%22%7D%2C%20%22Pull%2060831f08db1172227b1ae56c6928008b3e909fc9%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%20155%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36921585%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20that%20the%20creation%20of%20the%20JestClient%20would%20be%20better%20placed%20in%20the%20constructor.%20That%20way%20you%20can%20ensure%20the%20this%20object%20is%20always%20in%20a%20valid%20state.%20I%20know%2C%20we%20have%20already%20too%20much%20creation%20logic%20in%20the%20constructors%20of%20OutputWriters%2C%20but%20a%20cleanup%20is%20on%20the%20way...%22%2C%20%22created_at%22%3A%20%222015-08-12T22%3A20%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-13T21%3A21%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%3AL1-238%22%7D%2C%20%22Pull%204f7e27f9924a61549a8da0d00296317c876e7dda%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%20126%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37082614%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20seems%20that%20Jest%20supports%20getting%20data%20from%20a%20simple%20%60Map%60.%20Is%20there%20any%20reason%20to%20use%20JSON%20%3F%20%28That%27s%20an%20honest%20question%2C%20the%20map%20seems%20simpler%20to%20me%2C%20but%20you%20probably%20have%20a%20reason%20for%20going%20to%20JSON%20...%29%22%2C%20%22created_at%22%3A%20%222015-08-14T14%3A41%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22True%2C%20I%20worked%20mostly%20with%20curl%20and%20json%2C%20a%20map%20makes%20sense%20here.%20Thanks.%22%2C%20%22created_at%22%3A%20%222015-08-14T21%3A15%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-15T12%3A06%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java%3AL1-220%22%7D%2C%20%22Pull%2060831f08db1172227b1ae56c6928008b3e909fc9%20pom.xml%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36921967%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20have%20been%20fixed%20already%20by%20%23318%20with%20a%20profile%20activated%20only%20for%20JDK%20%3E%3D8.%20This%20fix%20makes%20the%20travis%20build%20fail%20as%20it%20is%20run%20on%20Java%207.%20Could%20you%20rebase%20your%20pull%20request%20to%20include%20latest%20fixes%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-12T22%3A24%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-13T21%3A21%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pom.xml%3AL653-663%22%7D%2C%20%22Pull%204f7e27f9924a61549a8da0d00296317c876e7dda%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterException.java%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37082256%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20that%20this%20constructor%20is%20never%20used.%20Could%20we%20remove%20dead%20code%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-14T14%3A38%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-14T21%3A16%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterException.java%3AL1-12%22%7D%2C%20%22Pull%2060831f08db1172227b1ae56c6928008b3e909fc9%20jmxtrans-output/jmxtrans-output-elastic/pom.xml%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r36921079%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20move%20%60%3Cversion/%3E%60%20to%20the%20main%20pom%3F%20That%20way%20we%20have%20all%20versions%20of%20all%20dependencies%20in%20a%20centralized%20place.%22%2C%20%22created_at%22%3A%20%222015-08-12T22%3A15%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-13T21%3A22%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-elastic/pom.xml%3AL1-69%22%7D%2C%20%22Pull%2013ce272b390b70e194f702f737b95b4c20c65963%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/StringUtils.java%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/321%23discussion_r37055190%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20for%20the%20correction%2C%20but%20that%20is%20a%20comment%20which%20does%20not%20tell%20us%20much%20more%20than%20the%20name%20of%20the%20method.%20We%20should%20probably%20just%20remove%20it%20%28and%20also%20remove%20the%20%60%40param%20name%20%20%20%20the%20name%60%29.%5Cr%5Cn%5Cr%5CnI%20tend%20to%20be%20fairly%20strongly%20opinionated%20with%20comments%20%3A%20if%20they%20do%20not%20add%20anything%20to%20what%20is%20already%20in%20the%20code%2C%20they%20should%20be%20removed...%22%2C%20%22created_at%22%3A%20%222015-08-14T07%3A37%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Totally%20agree.%20%22%2C%20%22created_at%22%3A%20%222015-08-14T12%3A24%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-14T12%3A55%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8797018%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stokpop%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/StringUtils.java%3AL25-32%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#issuecomment-130468118'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Looks good ! Thanks for the contribution ! I have a few mostly minor comments. Could you have a look and tell me if those comments make sense to you ?
- <a href='https://github.com/stokpop'><img border=0 src='https://avatars.githubusercontent.com/u/8797018?v=3' height=16 width=16'></a> :+1:<a href='#crh-update-none'></a>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Sorry to be a pain, but it seems that I have a few more comments...
- <a href='https://github.com/stokpop'><img border=0 src='https://avatars.githubusercontent.com/u/8797018?v=3' height=16 width=16'></a> :+1:<a href='#crh-update-none'></a>
- <a href='https://github.com/stokpop'><img border=0 src='https://avatars.githubusercontent.com/u/8797018?v=3' height=16 width=16'></a> When running this against a elastic server, I see the following non-numeric value passing along in the log file:
17:04:05.442 [pool-17-thread-2] WARN  c.g.j.m.output.elastic.ElasticWriter - Unable to submit non-numeric value to Elastic: [javax.management.openmbean.TabularDataSupport(tabularType=javax.management.openmbean.TabularType(name=Map<java.lang.String,java.lang.management.MemoryUsage>,rowType=javax.management.openmbean.CompositeType(name=Map<java.lang.String,java.lang.management.MemoryUsage>,items=((itemName=key,itemType=javax.management.openmbean.SimpleType(name=java.lang.String)),(itemName=value,itemType=javax.management.openmbean.CompositeType(name=java.lang.management.MemoryUsage,items=((itemName=committed,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)),(itemName=init,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)),(itemName=max,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)),(itemName=used,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long))))))),indexNames=(key)),contents={ <<<... REMOVED VERY LONG STRING ... >>> javax.management.openmbean.CompositeDataSupport(compositeType=javax.management.openmbean.CompositeType(name=java.lang.management.MemoryUsage,items=((itemName=committed,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)),(itemName=init,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)),(itemName=max,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)),(itemName=used,itemType=javax.management.openmbean.SimpleType(name=java.lang.Long)))),contents={committed=178978816, init=178978816, max=724828160, used=12257128})})})}, epoch=1439737445281]]
17:04:05.447 [pool-17-thread-2] DEBUG c.g.jmxtrans.jmx.JmxQueryProcessor - Finished running outputWriters for query: Query [obj=java.lang:name=ConcurrentMarkSweep,type=GarbageCollector, useObjDomainAsKey:false, resultAlias=null, attr=[LastGcInfo]]
Any idea what this is?
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Seems to be a bug in `JmxResultProcessor`. You should never see tabular data in an output writer. Having a quick look at the code, it looks like that could happen if a tabular data contains other tabular data... Could that be the case ?
- [ ] <a href='#crh-comment-Pull 4f7e27f9924a61549a8da0d00296317c876e7dda jmxtrans-output/jmxtrans-output-elastic/pom.xml 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r37081288'>File: jmxtrans-output/jmxtrans-output-elastic/pom.xml:L1-68</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Mutation coverage is still a bit low (you should find the report in `jmxtrans-output/jmxtrans-output-elastic/target/pit-reports`. Ideally, there are a few scenarios that you should add to the tests or just drop the minimum coverage to 55.
Things that probably make sense to be added to tests:
* sending non numeric values
* validate that the json sent is syntactically valid
* move the `createAlias()` method to the `Server` class and test it there (and refactor all the places where we have the same code)
* test that the index is not created if it already exists
* test that exception is thrown if index cannot be created
* ...
I'll be happy to merge even without those additional tests (I already make you work pretty hard on this one).
- <a href='https://github.com/stokpop'><img border=0 src='https://avatars.githubusercontent.com/u/8797018?v=3' height=16 width=16'></a> I have managed to get to 60 percent. Interesting concept, this mutation testing. It is new to me. I have been struggling to get to higher percentage. Lowered the minimum to 60.
- [x] <a href='#crh-comment-Pull 60831f08db1172227b1ae56c6928008b3e909fc9 jmxtrans-output/jmxtrans-output-elastic/pom.xml 27'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r36921079'>File: jmxtrans-output/jmxtrans-output-elastic/pom.xml:L1-69</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Could you move `<version/>` to the main pom? That way we have all versions of all dependencies in a centralized place.
- [x] <a href='#crh-comment-Pull 60831f08db1172227b1ae56c6928008b3e909fc9 jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java 155'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r36921585'>File: jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java:L1-238</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Seems that the creation of the JestClient would be better placed in the constructor. That way you can ensure the this object is always in a valid state. I know, we have already too much creation logic in the constructors of OutputWriters, but a cleanup is on the way...
- [x] <a href='#crh-comment-Pull 60831f08db1172227b1ae56c6928008b3e909fc9 pom.xml 30'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r36921967'>File: pom.xml:L653-663</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This should have been fixed already by #318 with a profile activated only for JDK >=8. This fix makes the travis build fail as it is run on Java 7. Could you rebase your pull request to include latest fixes ?
- [x] <a href='#crh-comment-Pull 60831f08db1172227b1ae56c6928008b3e909fc9 jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java 185'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r36922115'>File: jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java:L1-238</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> That big wall of String hurt my eyes. Any chance we could load it from a classpath resource instead ?
- [x] <a href='#crh-comment-Pull 60831f08db1172227b1ae56c6928008b3e909fc9 jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java 226'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r36922385'>File: jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java:L1-238</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I'm not an expert on ElasticSerach and Jest, but my guess is that if the creation of mappings fail, this output writer will be unuseable. So you should probably just let the exception bubble up and not hide the issue.
- [x] <a href='#crh-comment-Pull 60831f08db1172227b1ae56c6928008b3e909fc9 jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java 111'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r36922562'>File: jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java:L1-238</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> You should extract a `computeAlias()` method from this block (possibly with a better name).
- [x] <a href='#crh-comment-Pull 13ce272b390b70e194f702f737b95b4c20c65963 jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/StringUtils.java 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r37055190'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/StringUtils.java:L25-32</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Thanks for the correction, but that is a comment which does not tell us much more than the name of the method. We should probably just remove it (and also remove the `@param name    the name`).
I tend to be fairly strongly opinionated with comments : if they do not add anything to what is already in the code, they should be removed...
- <a href='https://github.com/stokpop'><img border=0 src='https://avatars.githubusercontent.com/u/8797018?v=3' height=16 width=16'></a> Totally agree.
- [x] <a href='#crh-comment-Pull 13ce272b390b70e194f702f737b95b4c20c65963 jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java 184'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r37056005'>File: jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java:L1-210</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> It seems that result can be null, so the condition should probably be `if (result == null || !result.isSucceeded())`. Though even better would be to understand why thi result can be null.
- <a href='https://github.com/stokpop'><img border=0 src='https://avatars.githubusercontent.com/u/8797018?v=3' height=16 width=16'></a> This was a mock issue, not return value was set. I would expect always a result from jest.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Short digging in the Jest code seems to indicate that you are right. Everyone should use JSR305 ;-)
- [x] <a href='#crh-comment-Pull 13ce272b390b70e194f702f737b95b4c20c65963 jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java 185'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r37056073'>File: jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java:L1-210</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> In case of error, we probably want to throw an exception to ensure that this writer is disabled. Unless this can be a transient error. So probably in case of communication error, we have a good chance of recovery, otherwise probably not so much ...
Note: this is a minor point, I'll be happy to merge without it.
- [x] <a href='#crh-comment-Pull 13ce272b390b70e194f702f737b95b4c20c65963 jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java 79'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r37056380'>File: jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java:L1-106</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> You're missing a mock for the second call to `jestClient.execute()`.
- [x] <a href='#crh-comment-Pull 13ce272b390b70e194f702f737b95b4c20c65963 jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java 70'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r37056580'>File: jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java:L1-106</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> We should also verify that call to Elastic that sends the data is actually made and that it contains the results that were given on inputs. In the end, that's the most important action of your class, so it should be tested.
- <a href='https://github.com/stokpop'><img border=0 src='https://avatars.githubusercontent.com/u/8797018?v=3' height=16 width=16'></a> A data verify test has been added. Not all given parameters are part of the message towards elastic. It suffices for me at this moment. If other data is needed (e.g. className) I can add that.
- [x] <a href='#crh-comment-Pull 4f7e27f9924a61549a8da0d00296317c876e7dda jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterException.java 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r37082256'>File: jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterException.java:L1-12</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Seems that this constructor is never used. Could we remove dead code ?
- [x] <a href='#crh-comment-Pull 4f7e27f9924a61549a8da0d00296317c876e7dda jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java 126'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/321#discussion_r37082614'>File: jmxtrans-output/jmxtrans-output-elastic/src/main/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriter.java:L1-220</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> It seems that Jest supports getting data from a simple `Map`. Is there any reason to use JSON ? (That's an honest question, the map seems simpler to me, but you probably have a reason for going to JSON ...)
- <a href='https://github.com/stokpop'><img border=0 src='https://avatars.githubusercontent.com/u/8797018?v=3' height=16 width=16'></a> True, I worked mostly with curl and json, a map makes sense here. Thanks.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/321?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/321?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/321'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>