### PR TITLE
Allow to connect to a local PID

### DIFF
--- a/jmxtrans-core/pom.xml
+++ b/jmxtrans-core/pom.xml
@@ -82,6 +82,13 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.sun</groupId>
+			<artifactId>tools</artifactId>
+			<version>1.6.0</version>
+			<scope>system</scope>
+			<systemPath>${toolsjar}</systemPath>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
@@ -110,13 +117,6 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.sun</groupId>
-			<artifactId>tools</artifactId>
-			<version>1.6.0</version>
-			<scope>system</scope>
-			<systemPath>${toolsjar}</systemPath>
 		</dependency>
 	</dependencies>
 

--- a/jmxtrans-core/pom.xml
+++ b/jmxtrans-core/pom.xml
@@ -17,6 +17,7 @@
 		<verify.mutationThreshold>43</verify.mutationThreshold>
 		<verify.totalBranchRate>46</verify.totalBranchRate>
 		<verify.totalLineRate>46</verify.totalLineRate>
+		<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
 	</properties>
 
 	<dependencies>
@@ -139,40 +140,4 @@
 		</plugins>
 	</build>
 
-	<profiles>
-		<profile>
-			<id>windows_profile</id>
-			<activation>
-				<os>
-					<family>windows</family>
-				</os>
-			</activation>
-			<properties>
-				<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-			</properties>
-		</profile>
-		<profile>
-			<id>unix_profile</id>
-			<activation>
-				<os>
-					<family>unix</family>
-				</os>
-			</activation>
-			<properties>
-				<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-			</properties>
-		</profile>
-		<profile>
-			<id>osx_profile</id>
-			<activation>
-				<activeByDefault>false</activeByDefault>
-				<os>
-					<family>mac</family>
-				</os>
-			</activation>
-			<properties>
-				<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-			</properties>
-		</profile>
-	</profiles>
 </project>

--- a/jmxtrans-core/pom.xml
+++ b/jmxtrans-core/pom.xml
@@ -14,10 +14,10 @@
 	<description>This module contains most of the core logic of JmxTrans.</description>
 
 	<properties>
+		<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
 		<verify.mutationThreshold>43</verify.mutationThreshold>
 		<verify.totalBranchRate>46</verify.totalBranchRate>
 		<verify.totalLineRate>46</verify.totalLineRate>
-		<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
 	</properties>
 
 	<dependencies>

--- a/jmxtrans-core/pom.xml
+++ b/jmxtrans-core/pom.xml
@@ -111,6 +111,13 @@
 			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.sun</groupId>
+			<artifactId>tools</artifactId>
+			<version>1.6.0</version>
+			<scope>system</scope>
+			<systemPath>${toolsjar}</systemPath>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -132,4 +139,40 @@
 		</plugins>
 	</build>
 
+	<profiles>
+		<profile>
+			<id>windows_profile</id>
+			<activation>
+				<os>
+					<family>windows</family>
+				</os>
+			</activation>
+			<properties>
+				<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+			</properties>
+		</profile>
+		<profile>
+			<id>unix_profile</id>
+			<activation>
+				<os>
+					<family>unix</family>
+				</os>
+			</activation>
+			<properties>
+				<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+			</properties>
+		</profile>
+		<profile>
+			<id>osx_profile</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+				<os>
+					<family>mac</family>
+				</os>
+			</activation>
+			<properties>
+				<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+			</properties>
+		</profile>
+	</profiles>
 </project>

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java
@@ -3,6 +3,7 @@ package com.googlecode.jmxtrans.jobs;
 import com.googlecode.jmxtrans.connections.JMXConnectionParams;
 import com.googlecode.jmxtrans.jmx.JmxUtils;
 import com.googlecode.jmxtrans.model.Server;
+import com.sun.tools.attach.VirtualMachine;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
@@ -13,6 +14,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXServiceURL;
+import java.io.File;
 
 /**
  * This is a quartz job that is responsible for executing a Server object on a
@@ -21,6 +24,9 @@ import javax.management.remote.JMXConnector;
  * @author jon
  */
 public class ServerJob implements Job {
+
+	private static final String CONNECTOR_ADDRESS = "com.sun.management.jmxremote.localConnectorAddress";
+
 	private static final Logger log = LoggerFactory.getLogger(ServerJob.class);
 
 	private final GenericKeyedObjectPool<JMXConnectionParams, JMXConnector> jmxPool;
@@ -41,8 +47,17 @@ public class ServerJob implements Job {
 
 		JMXConnector conn = null;
 		JMXConnectionParams connectionParams = null;
+
 		try {
-			connectionParams = new JMXConnectionParams(server.getJmxServiceURL(), server.getEnvironment());
+			JMXServiceURL jmxUrl;
+			if(server.getPid() != null) {
+				jmxUrl = extractJMXServiceURLFromPid(server.getPid());
+			}
+			else {
+				jmxUrl = new JMXServiceURL(server.getUrl());
+			}
+
+			connectionParams = new JMXConnectionParams(jmxUrl, server.getEnvironment());
 			if (!server.isLocal()) {
 				conn = jmxPool.borrowObject(connectionParams);
 			}
@@ -59,5 +74,33 @@ public class ServerJob implements Job {
 		}
 
 		log.debug("+++++ Finished server job: {}", server);
+	}
+
+	private JMXServiceURL extractJMXServiceURLFromPid(String pid) throws Exception
+	{
+		// attach to the target application
+		VirtualMachine vm = VirtualMachine.attach(pid	);
+
+		try {
+			// get the connector address
+			String connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
+
+			// no connector address, so we start the JMX agent
+			if (connectorAddress == null) {
+				String agent = vm.getSystemProperties().getProperty("java.home") +
+					File.separator + "lib" + File.separator + "management-agent.jar";
+				vm.loadAgent(agent);
+
+				// agent is started, get the connector address
+				connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
+			}
+
+			// establish connection to connector server
+			return new JMXServiceURL(connectorAddress);
+		}
+		finally
+		{
+			vm.detach();
+		}
 	}
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java
@@ -78,28 +78,22 @@ public class ServerJob implements Job {
 
 	private JMXServiceURL extractJMXServiceURLFromPid(String pid) throws Exception
 	{
-		// attach to the target application
-		VirtualMachine vm = VirtualMachine.attach(pid	);
+		VirtualMachine vm = VirtualMachine.attach(pid);
 
 		try {
-			// get the connector address
 			String connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
 
-			// no connector address, so we start the JMX agent
 			if (connectorAddress == null) {
 				String agent = vm.getSystemProperties().getProperty("java.home") +
 					File.separator + "lib" + File.separator + "management-agent.jar";
 				vm.loadAgent(agent);
 
-				// agent is started, get the connector address
 				connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
 			}
 
-			// establish connection to connector server
 			return new JMXServiceURL(connectorAddress);
 		}
-		finally
-		{
+		finally {
 			vm.detach();
 		}
 	}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -25,6 +25,8 @@ import javax.management.remote.JMXServiceURL;
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -172,6 +174,14 @@ public class Server {
 	}
 
 	public String getHost() {
+		if (pid != null) {
+			try {
+				return InetAddress.getLocalHost().getHostName();
+			} catch (UnknownHostException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
 		if (host == null && url == null) {
 			return null;
 		}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -161,9 +161,6 @@ public class Server {
 	 * @return pid of the java process
 	 */
 	public String getPid() {
-		if(this.pid == null) {
-			return null;
-		}
 		return this.pid;
 	}
 

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -23,12 +23,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import static com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.*;
+import static com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.NON_NULL;
 import static com.google.common.collect.ImmutableSet.copyOf;
-import static com.googlecode.jmxtrans.model.PropertyResolver.*;
-import static java.util.Arrays.*;
-import static javax.management.remote.JMXConnectorFactory.*;
-import static javax.naming.Context.*;
+import static com.googlecode.jmxtrans.model.PropertyResolver.resolveProps;
+import static java.util.Arrays.asList;
+import static javax.management.remote.JMXConnectorFactory.PROTOCOL_PROVIDER_PACKAGES;
+import static javax.naming.Context.SECURITY_CREDENTIALS;
+import static javax.naming.Context.SECURITY_PRINCIPAL;
 
 /**
  * Represents a jmx server that we want to connect to. This also stores the

--- a/jmxtrans-examples/src/main/java/com/googlecode/jmxtrans/example/Local.java
+++ b/jmxtrans-examples/src/main/java/com/googlecode/jmxtrans/example/Local.java
@@ -1,0 +1,33 @@
+package com.googlecode.jmxtrans.example;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.googlecode.jmxtrans.JmxTransformer;
+import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
+import com.googlecode.jmxtrans.guice.JmxTransModule;
+import com.googlecode.jmxtrans.model.JmxProcess;
+import com.googlecode.jmxtrans.util.JsonPrinter;
+import com.googlecode.jmxtrans.util.JsonUtils;
+
+import java.io.File;
+
+/**
+ * Shows how to connect to a local process.
+ * 
+ * @author henri
+ */
+public class Local {
+
+	/**
+     *
+     */
+	public static void main(String[] args) throws Exception {
+		JmxProcess process = JsonUtils.getJmxProcess(new File("local.json"));
+		new JsonPrinter(System.out).print(process);
+		Injector injector = Guice.createInjector(new JmxTransModule(new JmxTransConfiguration()));
+		JmxTransformer transformer = injector.getInstance(JmxTransformer.class);
+		transformer.executeStandalone(process);
+
+		System.out.println("done!");
+	}
+}

--- a/jmxtrans-examples/src/main/resources/local.json
+++ b/jmxtrans-examples/src/main/resources/local.json
@@ -1,0 +1,14 @@
+{
+  "servers" : [ {
+    "pid" : "${pid}",
+    "queries" : [ {
+      "obj" : "java.lang:type=MemoryPool,name=*",
+      "outputWriters" : [ {
+        "@class" : "com.googlecode.jmxtrans.model.output.Slf4JOutputWriter",
+        "settings" : {
+            "debug" : true
+        }
+      } ]
+    } ]
+  } ]
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
@@ -10,14 +10,19 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.collect.ImmutableList.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.google.common.collect.ImmutableList.of;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link OpenTSDBWriter}.

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
@@ -1,34 +1,23 @@
 package com.googlecode.jmxtrans.model.output;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
-import com.googlecode.jmxtrans.model.ValidationException;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.mockito.Matchers;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-import java.io.BufferedReader;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.Socket;
+import java.io.*;
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.collect.ImmutableList.of;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.collect.ImmutableList.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for {@link OpenTSDBWriter}.
@@ -106,7 +95,7 @@ public class OpenTSDBWriterTests {
 
 	@Test
 	public void writeSingleResult() throws Exception {
-		Server server = Server.builder().build();
+		Server server = Server.builder().setPid("1").build();
 		Query query = Query.builder().build();
 		Result result = new Result(System.currentTimeMillis(), "attributeName", "className", "objDomain", "classNameAlias", "typeName", ImmutableMap.of("key", (Object)1));
 

--- a/pom.xml
+++ b/pom.xml
@@ -476,7 +476,7 @@
 				<plugin>
 					<groupId>com.google.code.sortpom</groupId>
 					<artifactId>maven-sortpom-plugin</artifactId>
-					<version>2.3.0</version>
+					<version>2.4.0</version>
 					<configuration>
 						<predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
 						<sortDependencies>scope,groupId,artifactId</sortDependencies>
@@ -557,7 +557,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.15</version>
+					<version>2.16</version>
 					<configuration>
 						<configLocation>src/etc/checkstyle.xml</configLocation>
 						<consoleOutput>true</consoleOutput>
@@ -572,6 +572,14 @@
 							<phase>verify</phase>
 						</execution>
 					</executions>
+					<dependencies>
+						<!-- to workaround https://github.com/jcgay/maven-color/issues/8 -->
+						<dependency>
+							<groupId>org.slf4j</groupId>
+							<artifactId>jcl-over-slf4j</artifactId>
+							<version>1.7.5</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -826,8 +834,8 @@
 				<artifactId>site-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>com.google.code.sortpom</groupId>
-				<artifactId>maven-sortpom-plugin</artifactId>
+				<groupId>com.github.ekryd.sortpom</groupId>
+				<artifactId>sortpom-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -877,7 +885,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.15</version>
+				<version>2.16</version>
 				<configuration>
 					<configLocation>src/etc/checkstyle.xml</configLocation>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -454,28 +454,8 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>com.github.github</groupId>
-					<artifactId>site-maven-plugin</artifactId>
-					<!--
-						version 0.11 seem to have some problem to publish, let's wait until 0.12 to upgrade
-					-->
-					<version>0.10</version>
-					<configuration>
-						<message>Creating site for ${project.name}
-							${project.version}</message>
-					</configuration>
-					<executions>
-						<execution>
-							<goals>
-								<goal>site</goal>
-							</goals>
-							<phase>site</phase>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>com.google.code.sortpom</groupId>
-					<artifactId>maven-sortpom-plugin</artifactId>
+					<groupId>com.github.ekryd.sortpom</groupId>
+					<artifactId>sortpom-maven-plugin</artifactId>
 					<version>2.4.0</version>
 					<configuration>
 						<predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
@@ -494,6 +474,26 @@
 								<goal>verify</goal>
 							</goals>
 							<phase>verify</phase>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>com.github.github</groupId>
+					<artifactId>site-maven-plugin</artifactId>
+					<!--
+						version 0.11 seem to have some problem to publish, let's wait until 0.12 to upgrade
+					-->
+					<version>0.10</version>
+					<configuration>
+						<message>Creating site for ${project.name}
+							${project.version}</message>
+					</configuration>
+					<executions>
+						<execution>
+							<goals>
+								<goal>site</goal>
+							</goals>
+							<phase>site</phase>
 						</execution>
 					</executions>
 				</plugin>
@@ -563,6 +563,14 @@
 						<consoleOutput>true</consoleOutput>
 						<maxAllowedViolations>${checkstyle.max.allowed.violations}</maxAllowedViolations>
 					</configuration>
+					<dependencies>
+						<!-- to workaround https://github.com/jcgay/maven-color/issues/8 -->
+						<dependency>
+							<groupId>org.slf4j</groupId>
+							<artifactId>jcl-over-slf4j</artifactId>
+							<version>1.7.5</version>
+						</dependency>
+					</dependencies>
 					<executions>
 						<execution>
 							<id>checkstyle-check</id>
@@ -572,14 +580,6 @@
 							<phase>verify</phase>
 						</execution>
 					</executions>
-					<dependencies>
-						<!-- to workaround https://github.com/jcgay/maven-color/issues/8 -->
-						<dependency>
-							<groupId>org.slf4j</groupId>
-							<artifactId>jcl-over-slf4j</artifactId>
-							<version>1.7.5</version>
-						</dependency>
-					</dependencies>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -830,12 +830,12 @@
 
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
 				<groupId>com.github.ekryd.sortpom</groupId>
 				<artifactId>sortpom-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>com.github.github</groupId>
+				<artifactId>site-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This patch allow jmxtrans to connect to a local process using its PID.  This is useful if you want to have a local jmxtrans but don't want to embed it or use a java agent.

I've noticed 2 things  that I want to raise to your attention:
* Writer tend to use the server and port in their messages. Those are null in my case. However, they also must be null when jmxtrans is embedded. It seems that jmxtrans-embedded has its own writer. We could probably mutualize them by adding a Server.getIdentity method
* tools.jar must be in the classpath to make it works. An attempt to add it can probably be done in the jmxtrans.sh script
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627417%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627551%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627647%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627650%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627658%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627729%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627873%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37628270%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37628360%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37628419%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37628491%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37628520%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37636918%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37636920%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37636922%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37637037%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37637038%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37637039%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37637041%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37637042%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37637043%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37637372%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37637528%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37637614%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37637976%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37638192%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37638316%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37638394%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37638457%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37638469%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37638668%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37655056%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37655670%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37655671%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37688971%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37689469%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23issuecomment-133604216%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37694040%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37697413%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23issuecomment-133604216%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22All%20changes%20implemented.%20It%20is%20now%20fully%20functional%20without%20tools.jar.%22%2C%20%22created_at%22%3A%20%222015-08-22T00%3A36%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2078ffb8d977b124942c043d579b6b2c8765cf5f47%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37638668%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20we%20are%20adding%20a%20dependency%20to%20the%20Sun%20/%20Oracle%20JVM.%20Not%20good.%20We%20need%20to%20at%20least%20encapsulate%20this%20so%20that%20it%20runs%20correctly%20on%20non%20Sun%20JVM.%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A22%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%20good%20catch%2C%20we%20have%20to%20isolate%20this%20in%20a%20tiny%20class%20that%20would%20only%20be%20instantiated%20if%20Class.forname%28%5C%22com.sun.tools.attach.VirtualMachine%5C%22%29%20succeeds.%20Otherwise%2C%20jmxtrans%20may%20no%20longer%20start%20on%20IBM%20JVM%20...%22%2C%20%22created_at%22%3A%20%222015-08-21T17%3A07%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/459691%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cyrille-leclerc%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java%3AL3-10%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20pom.xml%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37628491%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20group%20is%20not%20aligned%20anymore%20with%20the%20pluginManagement%20section.%22%2C%20%22created_at%22%3A%20%222015-08-21T12%3A14%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T17%3A14%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pom.xml%3AL834-842%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37628419%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20test%20of%20%60OpenTSDBWriter%60%20should%20have%20nothing%20to%20do%20with%20pid.%20So%20there%20should%20be%20no%20reason%20to%20update%20it.%22%2C%20%22created_at%22%3A%20%222015-08-21T12%3A13%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Precondition%20in%20Server%20are%20requiring%20to%20have%20a%20pid%20or%20a%20url.%20I%20picked%20the%20pid.%20Removing%20this%20will%20mean%20removing%20the%20preconditions%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A12%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%2C%20I%20did%20read%20that%20too%20fast.%20Please%20disregard%20this%20comment%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A20%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java%3AL95-102%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20jmxtrans-core/pom.xml%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627417%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20seems%20that%20at%20the%20moment%2C%20all%20those%20different%20profiles%20set%20the%20same%20value%20to%20%60toolsjar%60.%20So%20we%20can%20inline%20this%20property%20for%20the%20moment%2C%20and%20introduce%20profiles%20once%20we%20know%20about%20an%20actual%20difference%20between%20OS.%22%2C%20%22created_at%22%3A%20%222015-08-21T11%3A54%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A07%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/pom.xml%3AL139-179%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627551%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20seems%20that%20we%20now%20have%20the%20concept%20of%20a%20%60ServerJob%60%20and%20a%20%60LocalJob%60.%20Could%20we%20reflect%20this%20in%20the%20class%20hierarchy%20instead%20of%20increasing%20the%20cyclomatic%20complexity%20of%20%60ServerJob%60%20%3F%20Or%20at%20least%20encapsulate%20the%20construction%20of%20the%20jmxUrl%20a%20bit%20better%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-21T11%3A56%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22LocalJob%20doesn%27t%20exist.%20This%20comment%20is%20incompatible%20with%20the%20one%20on%20getJmxServiceURL.%20You%20need%20to%20pick%20one%20way.%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A10%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%2C%20%7B%22body%22%3A%20%22Disregard%20this%20comment%20and%20move%20the%20implementation%20in%20%60Server%60%5Cr%5Cn%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A18%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java%3AL47-64%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java%20104%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37628270%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Instead%20of%20removing%20this%20method%2C%20we%20should%20actually%20start%20using%20it.%20If%20we%20encapsulate%20the%20JMX%20URL%20here%2C%20we%20can%20have%20a%20%60ServerJob%60%20class%20that%20is%20completely%20agnostic%20of%20where%20the%20JMX%20values%20are%20coming%20from.%20Much%20much%20cleaner%20...%22%2C%20%22created_at%22%3A%20%222015-08-21T12%3A10%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%20do.%20However%2C%20the%20exception%20will%20change%20since%20I%20will%20need%20to%20throw%20IOException%2C%20AttachNotSupportedException%2C%20AgentLoadException%2C%20AgentInitializationException%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A11%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20fine%20with%20adding%20additional%20exceptions%20to%20the%20method...%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A20%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T17%3A14%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java%3AL239-245%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java%2078%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627873%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20really%20dislike%20methods%20returning%20null%20%28there%20are%20a%20lot%20of%20them%20for%20%5C%22historical%20reasons%5C%22%29.%20Still%2C%20let%27s%20try%20not%20to%20introduce%20new%20ones.%20In%20the%20case%20of%20a%20local%20JVM%20accessed%20by%20PID%2C%20the%20hostname%20of%20the%20JVM%20is%20the%20hostname%20of%20the%20machine%20on%20which%20JmxTrans%20runs.%20So%20we%20have%20a%20way%20to%20cleanly%20expose%20a%20hostname%20also%20in%20this%20case.%20So%20let%27s%20not%20break%20the%20contract%20unless%20we%20really%20have%20to.%22%2C%20%22created_at%22%3A%20%222015-08-21T12%3A02%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20almost%20did%20that.%20However%2C%20the%20port%20would%20stay%20null.%20This%20is%20also%20why%20I%20was%20talking%20about%20getIdentity.%20That%20would%20return%20host%3Aport%20or%20pid%40host%20depending%20on%20the%20use-case%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A16%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20would%20be%20cleaner%2C%20but%20would%20also%20break%20backward%20compatibility.%20So%20no%20go...%5Cr%5Cn%5Cr%5CnStill%2C%20let%27s%20save%20what%20can%20be%20saved.%20Host%20has%20a%20meaning%20in%20all%20cases%2C%20so%20it%20should%20be%20%60%40NonNull%60%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A19%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-22T00%3A18%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java%3AL155-176%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java%2068%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627729%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20%60if%60%20is%20useless%2C%20if%20you%20remove%20it%20you%20will%20get%20the%20exact%20same%20behaviour.%22%2C%20%22created_at%22%3A%20%222015-08-21T12%3A00%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A07%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java%3AL155-176%22%7D%2C%20%22Pull%20f3cb374efe383171ce456254ef944f10c4f52ce9%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java%20182%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37694040%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20always%20confused%20by%20classloaders%2C%20but%20in%20this%20case%2C%20it%20seems%20that%20we%20will%20still%20throw%20a%20ClassNotFoundException%20in%20case%20we%20load%20this%20on%20a%20non%20SUN%20JVM.%20It%20should%20run%20fine%20as%20long%20as%20we%20do%20not%20try%20to%20attach%20to%20a%20local%20process%20though.%5Cr%5Cn%5Cr%5CnI%27m%20still%20thinking%20about%20this%20one.%20It%20seems%20that%20it%20does%20not%20break%20backward%20compatibility%2C%20so%20that%27s%20probably%20good%20enough%20to%20merge.%5Cr%5Cn%5Cr%5CnAny%20idea%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-22T08%3A20%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Right%20now%2C%20if%20tools.jar%20isn%27t%20in%20the%20classpath%2C%20you%20get%20java.lang.NoClassDefFoundError%3A%20com/sun/tools/attach/VirtualMachine.%5Cr%5Cn%5Cr%5CnOther%20frameworks%20are%20having%20pretty%20much%20the%20same%20behavior.%20They%20usually%20try%20to%20guess%20where%20is%20tools.jar%20to%20add%20it%20to%20the%20classpath%20in%20their%20sh.%20I%20haven%27t%20done%20it%20because%20I%20was%20a%20bit%20lost%20in%20the%20sh%20code.%20So%20I%27ll%20leave%20that%20to%20you.%5Cr%5Cn%5Cr%5CnIn%20case%20of%20error%2C%20the%20only%20other%20thing%20we%20can%20do%20is%20to%20have%20a%20nicer%20error%20message.%20And%20some%20documentation%20%28but%20again%2C%20I%20got%20lost%20a%20bit%29%22%2C%20%22created_at%22%3A%20%222015-08-22T16%3A58%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java%3AL355-395%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java%2070%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627658%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Comment%20is%20redundant%20with%20the%20line%20of%20code%20below%2C%20it%20should%20be%20removed.%22%2C%20%22created_at%22%3A%20%222015-08-21T11%3A58%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A05%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A07%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java%3AL75-107%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37628360%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20tend%20to%20dislike%20star%20imports%20...%22%2C%20%22created_at%22%3A%20%222015-08-21T12%3A12%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A07%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java%3AL1-24%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627650%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Comment%20is%20redundant%20with%20the%20line%20of%20code%20below%2C%20it%20should%20be%20removed.%22%2C%20%22created_at%22%3A%20%222015-08-21T11%3A58%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A05%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A07%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java%3AL75-107%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java%2057%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37627647%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Comment%20is%20redundant%20with%20the%20line%20of%20code%20below%2C%20it%20should%20be%20removed.%22%2C%20%22created_at%22%3A%20%222015-08-21T11%3A58%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A05%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A07%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java%3AL75-107%22%7D%2C%20%22Pull%207b22832e52d81d76258df0f1d6b93f10681e33fd%20pom.xml%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/323%23discussion_r37628520%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22While%20it%20is%20a%20good%20idea%20to%20update%20dependencies%2C%20this%20is%20not%20related%20to%20your%20PR%20%28as%20far%20as%20I%20can%20see%29%2C%20so%20it%20should%20be%20part%20of%20another%20PR.%22%2C%20%22created_at%22%3A%20%222015-08-21T12%3A14%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20know.%20At%20first%20there%20was%20a%20sorting%20issue%20that%20forced%20me%20to%20upgrade.%20If%20I%20create%20another%20pull%20request%2C%20you%20might%20need%20to%20accept%20it%20to%20make%20this%20one%20pass%22%2C%20%22created_at%22%3A%20%222015-08-21T14%3A20%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-22T00%3A35%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1216819%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/henri-tremblay%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pom.xml%3AL476-483%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#issuecomment-133604216'>General Comment</a></b>
- <a href='https://github.com/henri-tremblay'><img border=0 src='https://avatars.githubusercontent.com/u/1216819?v=3' height=16 width=16'></a> All changes implemented. It is now fully functional without tools.jar.
- [ ] <a href='#crh-comment-Pull f3cb374efe383171ce456254ef944f10c4f52ce9 jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java 182'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37694040'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java:L355-395</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I'm always confused by classloaders, but in this case, it seems that we will still throw a ClassNotFoundException in case we load this on a non SUN JVM. It should run fine as long as we do not try to attach to a local process though.
I'm still thinking about this one. It seems that it does not break backward compatibility, so that's probably good enough to merge.
Any idea ?
- <a href='https://github.com/henri-tremblay'><img border=0 src='https://avatars.githubusercontent.com/u/1216819?v=3' height=16 width=16'></a> Right now, if tools.jar isn't in the classpath, you get java.lang.NoClassDefFoundError: com/sun/tools/attach/VirtualMachine.
Other frameworks are having pretty much the same behavior. They usually try to guess where is tools.jar to add it to the classpath in their sh. I haven't done it because I was a bit lost in the sh code. So I'll leave that to you.
In case of error, the only other thing we can do is to have a nicer error message. And some documentation (but again, I got lost a bit)
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd jmxtrans-core/pom.xml 27'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37627417'>File: jmxtrans-core/pom.xml:L139-179</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> It seems that at the moment, all those different profiles set the same value to `toolsjar`. So we can inline this property for the moment, and introduce profiles once we know about an actual difference between OS.
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java 34'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37627551'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java:L47-64</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> It seems that we now have the concept of a `ServerJob` and a `LocalJob`. Could we reflect this in the class hierarchy instead of increasing the cyclomatic complexity of `ServerJob` ? Or at least encapsulate the construction of the jmxUrl a bit better ?
- <a href='https://github.com/henri-tremblay'><img border=0 src='https://avatars.githubusercontent.com/u/1216819?v=3' height=16 width=16'></a> LocalJob doesn't exist. This comment is incompatible with the one on getJmxServiceURL. You need to pick one way.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Disregard this comment and move the implementation in `Server`
:+1:
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java 57'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37627647'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java:L75-107</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Comment is redundant with the line of code below, it should be removed.
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java 53'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37627650'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java:L75-107</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Comment is redundant with the line of code below, it should be removed.
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java 70'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37627658'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java:L75-107</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Comment is redundant with the line of code below, it should be removed.
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java 68'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37627729'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java:L155-176</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This `if` is useless, if you remove it you will get the exact same behaviour.
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java 78'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37627873'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java:L155-176</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I really dislike methods returning null (there are a lot of them for "historical reasons"). Still, let's try not to introduce new ones. In the case of a local JVM accessed by PID, the hostname of the JVM is the hostname of the machine on which JmxTrans runs. So we have a way to cleanly expose a hostname also in this case. So let's not break the contract unless we really have to.
- <a href='https://github.com/henri-tremblay'><img border=0 src='https://avatars.githubusercontent.com/u/1216819?v=3' height=16 width=16'></a> I almost did that. However, the port would stay null. This is also why I was talking about getIdentity. That would return host:port or pid@host depending on the use-case
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> That would be cleaner, but would also break backward compatibility. So no go...
Still, let's save what can be saved. Host has a meaning in all cases, so it should be `@NonNull`
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java 104'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37628270'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java:L239-245</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Instead of removing this method, we should actually start using it. If we encapsulate the JMX URL here, we can have a `ServerJob` class that is completely agnostic of where the JMX values are coming from. Much much cleaner ...
- <a href='https://github.com/henri-tremblay'><img border=0 src='https://avatars.githubusercontent.com/u/1216819?v=3' height=16 width=16'></a> Can do. However, the exception will change since I will need to throw IOException, AttachNotSupportedException, AgentLoadException, AgentInitializationException
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I'm fine with adding additional exceptions to the method...
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java 35'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37628360'>File: jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java:L1-24</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> We tend to dislike star imports ...
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java 45'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37628419'>File: jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java:L95-102</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> The test of `OpenTSDBWriter` should have nothing to do with pid. So there should be no reason to update it.
- <a href='https://github.com/henri-tremblay'><img border=0 src='https://avatars.githubusercontent.com/u/1216819?v=3' height=16 width=16'></a> Precondition in Server are requiring to have a pid or a url. I picked the pid. Removing this will mean removing the preconditions
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Sorry, I did read that too fast. Please disregard this comment :+1:
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd pom.xml 39'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37628491'>File: pom.xml:L834-842</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> The group is not aligned anymore with the pluginManagement section.
- [x] <a href='#crh-comment-Pull 7b22832e52d81d76258df0f1d6b93f10681e33fd pom.xml 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37628520'>File: pom.xml:L476-483</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> While it is a good idea to update dependencies, this is not related to your PR (as far as I can see), so it should be part of another PR.
- <a href='https://github.com/henri-tremblay'><img border=0 src='https://avatars.githubusercontent.com/u/1216819?v=3' height=16 width=16'></a> I know. At first there was a sorting issue that forced me to upgrade. If I create another pull request, you might need to accept it to make this one pass
- [x] <a href='#crh-comment-Pull 78ffb8d977b124942c043d579b6b2c8765cf5f47 jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/323#discussion_r37638668'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jobs/ServerJob.java:L3-10</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Seems we are adding a dependency to the Sun / Oracle JVM. Not good. We need to at least encapsulate this so that it runs correctly on non Sun JVM.
- <a href='https://github.com/cyrille-leclerc'><img border=0 src='https://avatars.githubusercontent.com/u/459691?v=3' height=16 width=16'></a> :+1:  good catch, we have to isolate this in a tiny class that would only be instantiated if Class.forname("com.sun.tools.attach.VirtualMachine") succeeds. Otherwise, jmxtrans may no longer start on IBM JVM ...


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/323?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/323?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/323'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>