### PR TITLE
Fixed useradd on redhat release less then or equal RHEL5

### DIFF
--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -20,6 +20,7 @@
 		<verify.mutationThreshold>0</verify.mutationThreshold>
 		<verify.totalBranchRate>0</verify.totalBranchRate>
 		<verify.totalLineRate>0</verify.totalLineRate>
+		<dollar.sign>$</dollar.sign>
 	</properties>
 
 	<dependencies>
@@ -243,6 +244,8 @@
 									<extraArgument>-Dcom.sun.management.jmxremote.ssl=false</extraArgument>
 									<extraArgument>-Dcom.sun.management.jmxremote.authenticate=false</extraArgument>
 									<extraArgument>-Dcom.sun.management.jmxremote.port=2101</extraArgument>
+									<extraArgument>-Djmxtrans.log.level=INFO</extraArgument>
+									<extraArgument>-Djmxtrans.log.dir=/var/log/${package.daemon.name}</extraArgument>
 								</extraArguments>
 							</jvmSettings>
 							<platforms>
@@ -319,13 +322,20 @@
 							</defineStatements>
 							<preinstallScriptlet>
 								<script>if [ $1 = 1 ]; then
-                  USER_ID=`id -u %{package.user} 2&gt;/dev/null`
-                    if [ -z "$USER_ID" ]; then
-									    groupadd -f ${package.user}
-									    /usr/sbin/useradd -c "${project.name}" -s /bin/sh -r -d \
-									    ${package.install.dir} -G ${package.user} ${package.user}
-                    fi
-									fi</script>
+									USER_ID=${dollar.sign}(id -u ${package.user} 2&gt;/dev/null)
+									if [ -z "$USER_ID" ]; then
+										REDHAT_RELEASE=${dollar.sign}(lsb_release -sr|cut -d"." -f1)
+										if [ ${dollar.sign}{REDHAT_RELEASE} -gt 5 ]; then
+											/usr/sbin/useradd -c "${project.name}" -s /bin/sh -r -d \
+											${package.install.dir} -u ${package.userId} -U ${package.user}
+										else
+											/usr/sbin/groupadd -g ${package.userId} ${package.user}
+											/usr/sbin/useradd -c "${project.name}" -s /bin/sh -r -d \
+												${package.install.dir} -g ${package.userId} \
+												-u ${package.userId} ${package.user}
+										fi
+									fi
+								fi</script>
 							</preinstallScriptlet>
 							<postinstallScriptlet>
 								<script>/sbin/chkconfig --add ${package.daemon.name}</script>

--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -17,10 +17,10 @@
 		or other packaging.</description>
 
 	<properties>
+		<dollar.sign>$</dollar.sign>
 		<verify.mutationThreshold>0</verify.mutationThreshold>
 		<verify.totalBranchRate>0</verify.totalBranchRate>
 		<verify.totalLineRate>0</verify.totalLineRate>
-		<dollar.sign>$</dollar.sign>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -53,14 +53,14 @@
 			</roles>
 		</developer>
 		<developer>
-                        <id>utkarshcmu</id>
-                        <name>Utkarsh Bhatnagar</name>
-                        <email>utkarsh.cmu@gmail.com</email>
-                        <url>http://www.cloudart.io</url>
-                        <roles>
-                                <role>developer</role>
-                        </roles>
-                </developer>
+			<id>utkarshcmu</id>
+			<name>Utkarsh Bhatnagar</name>
+			<email>utkarsh.cmu@gmail.com</email>
+			<url>http://www.cloudart.io</url>
+			<roles>
+				<role>developer</role>
+			</roles>
+		</developer>
 	</developers>
 
 	<prerequisites>
@@ -111,7 +111,7 @@
 		<package.group>${project.artifactId}</package.group>
 		<package.install.dir>/usr/share/${project.artifactId}</package.install.dir>
 		<package.user>${project.artifactId}</package.user>
-                <package.userId>102</package.userId>
+		<package.userId>102</package.userId>
 		<packageBuildTimeStamp>${maven.build.timestamp}</packageBuildTimeStamp>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<verify.mutationThreshold>100</verify.mutationThreshold>


### PR DESCRIPTION
I simply added an if statement to check redhat version in %pre phase.
I have also added another variable to pom.xml to prevent dollar escape (I usually use it in archetype creation).
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23discussion_r38304284%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23issuecomment-136347717%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23discussion_r38304774%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23discussion_r38312907%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23discussion_r38316415%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23issuecomment-136401141%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23issuecomment-136406538%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23issuecomment-136416030%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23issuecomment-136481643%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23issuecomment-136347717%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20we%20have%20a%20merge%20conflict.%20Could%20you%20resolve%20it%20%3F%20Ideally%20by%20rebasing%20your%20commits%20on%20top%20of%20master%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-31T11%3A46%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%2C%20I%20managed%20to%20fast%20forward%20to%20upstream%2C%20merge%20conflicts%20and%20fix%20indentation.%20Hope%20it%20works.%22%2C%20%22created_at%22%3A%20%222015-08-31T15%3A09%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/478636%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/magullo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Minor%20issue%20with%20the%20sort%20order%20in%20the%20pom%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20The%20xml%20element%20%3Cdollar.sign%3E%20should%20be%20placed%20before%20%3Cverify.mutationThreshold%3E%5Cr%5Cn%5Cr%5CnThe%20sortPom%20plugin%20provides%20a%20way%20for%20you%20to%20automatically%20sort%20the%20pom%20%28%60mvn%20com.github.ekryd.sortpom%3Asortpom-maven-plugin%3Asort%60%29.%20Or%20to%20check%20it%20locally%20%28%60mvn%20com.github.ekryd.sortpom%3Asortpom-maven-plugin%3Averify%60%29.%22%2C%20%22created_at%22%3A%20%222015-08-31T15%3A30%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thank%20you%2C%20never%20though%20this%20plugin%20existed%2C%20I%20will%20introduce%20it%20in%20my%20company%20as%20well.%22%2C%20%22created_at%22%3A%20%222015-08-31T16%3A04%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/478636%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/magullo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Makes%20code%20review%20much%20easier%20when%20everything%20is%20in%20a%20predictable%20order...%22%2C%20%22created_at%22%3A%20%222015-08-31T19%3A53%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%203ea263e06db2adcfad42ea27d92dd1b99e26394a%20pom.xml%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23discussion_r38304774%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20going%20to%20show%20my%20ignorance%2C%20but%20how%20do%20we%20ensure%20that%20%60102%60%20does%20not%20conflict%20with%20an%20existing%20package%3F%20A%20quick%20look%20into%20%60/usr/share/doc/setup-%2A/uidgid%60%20indicates%20that%20%60102%60%20is%20currently%20free%2C%20but%20this%20does%20not%20seem%20to%20be%20future%20proof...%22%2C%20%22created_at%22%3A%20%222015-08-31T11%3A54%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20could%20prevent%20specifing%20number%2C%20and%20letting%20system%20decide%20%28with%20-r%20option%29%2C%20couldn%27t%20we%3F%20%22%2C%20%22created_at%22%3A%20%222015-08-31T13%3A48%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/478636%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/magullo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20really%20have%20no%20idea%20how%20this%20kind%20of%20things%20are%20usually%20done.%20It%20seems%20like%20we%20are%20probably%20not%20the%20first%20to%20create%20packages%20for%20RedHat%20%28or%20any%20other%20distro%29%20where%20we%20need%20consistent%20UID%2C%20so%20there%20is%20probably%20a%20standard%20solution%20to%20this.%5Cr%5Cn%5Cr%5CnIn%20the%20end%2C%20do%20whatever%20seems%20right%20to%20you%2C%20you%20probably%20know%20more%20than%20me%20about%20it...%22%2C%20%22created_at%22%3A%20%222015-08-31T14%3A23%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pom.xml%3AL94-104%22%7D%2C%20%22Pull%203ea263e06db2adcfad42ea27d92dd1b99e26394a%20pom.xml%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/326%23discussion_r38304284%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20we%20have%20inconsistent%20indentation.%20Could%20you%20make%20sure%20indentation%20is%20tab%20based%20and%20coherent%3F%22%2C%20%22created_at%22%3A%20%222015-08-31T11%3A45%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pom.xml%3AL1124-1144%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 3ea263e06db2adcfad42ea27d92dd1b99e26394a pom.xml 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/326#discussion_r38304284'>File: pom.xml:L1124-1144</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Seems we have inconsistent indentation. Could you make sure indentation is tab based and coherent?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/326#issuecomment-136347717'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Seems we have a merge conflict. Could you resolve it ? Ideally by rebasing your commits on top of master ?
- <a href='https://github.com/magullo'><img border=0 src='https://avatars.githubusercontent.com/u/478636?v=3' height=16 width=16'></a> Sorry, I managed to fast forward to upstream, merge conflicts and fix indentation. Hope it works.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Minor issue with the sort order in the pom:
The xml element <dollar.sign> should be placed before <verify.mutationThreshold>
The sortPom plugin provides a way for you to automatically sort the pom (`mvn com.github.ekryd.sortpom:sortpom-maven-plugin:sort`). Or to check it locally (`mvn com.github.ekryd.sortpom:sortpom-maven-plugin:verify`).
- <a href='https://github.com/magullo'><img border=0 src='https://avatars.githubusercontent.com/u/478636?v=3' height=16 width=16'></a> Thank you, never though this plugin existed, I will introduce it in my company as well.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Makes code review much easier when everything is in a predictable order...
- [x] <a href='#crh-comment-Pull 3ea263e06db2adcfad42ea27d92dd1b99e26394a pom.xml 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/326#discussion_r38304774'>File: pom.xml:L94-104</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I'm going to show my ignorance, but how do we ensure that `102` does not conflict with an existing package? A quick look into `/usr/share/doc/setup-*/uidgid` indicates that `102` is currently free, but this does not seem to be future proof...
- <a href='https://github.com/magullo'><img border=0 src='https://avatars.githubusercontent.com/u/478636?v=3' height=16 width=16'></a> We could prevent specifing number, and letting system decide (with -r option), couldn't we?
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I really have no idea how this kind of things are usually done. It seems like we are probably not the first to create packages for RedHat (or any other distro) where we need consistent UID, so there is probably a standard solution to this.
In the end, do whatever seems right to you, you probably know more than me about it...


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/326?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/326?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/326'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>