### PR TITLE
CentOS-7.X fix

### DIFF
--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -349,6 +349,7 @@
 							</preremoveScriptlet>
 							<requires>
 								<require>java</require>
+								<require>/usr/bin/lsb_release</require>
 							</requires>
 							<mappings>
 								<mapping>


### PR DESCRIPTION
when installing on clean CentOS-7.x, I encountered the following:

# rpm -i ./jmxtrans/target/rpm/jmxtrans/RPMS/noarch/jmxtrans-251-SNAPSHOT20150901110714.noarch.rpm
/var/tmp/rpm-tmp.OICFi5: line 4: lsb_release: command not found
/var/tmp/rpm-tmp.OICFi5: line 5: [: -gt: unary operator expected


so, I suggest to add lsb_release as requirement
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/327?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/327'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>