### PR TITLE
Fixed Suse groupadd/useradd

### DIFF
--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -322,18 +322,15 @@
 							</defineStatements>
 							<preinstallScriptlet>
 								<script>if [ $1 = 1 ]; then
-									USER_ID=${dollar.sign}(id -u ${package.user} 2&gt;/dev/null)
-									if [ -z "$USER_ID" ]; then
-										REDHAT_RELEASE=${dollar.sign}(lsb_release -sr|cut -d"." -f1)
-										if [ ${dollar.sign}{REDHAT_RELEASE} -gt 5 ]; then
-											/usr/sbin/useradd -c "${project.name}" -s /bin/sh -r -d \
-											${package.install.dir} -u ${package.userId} -U ${package.user}
-										else
-											/usr/sbin/groupadd -g ${package.userId} ${package.user}
-											/usr/sbin/useradd -c "${project.name}" -s /bin/sh -r -d \
-												${package.install.dir} -g ${package.userId} \
-												-u ${package.userId} ${package.user}
-										fi
+									getent group ${package.user} &gt;/dev/null || groupadd -r ${package.user}
+									OS_RELEASE=${dollar.sign}(lsb_release -sd)
+									REDHAT_RELEASE=${dollar.sign}(lsb_release -sr|cut -d"." -f1)
+									if [[ ${dollar.sign}{OS_RELEASE} == *"Red Hat"* &amp;&amp; ${dollar.sign}{REDHAT_RELEASE} -le 5 ]]; then
+										getent passwd ${package.user} &gt;/dev/null || useradd -c "${project.name}" -s /bin/sh -r \
+										-d ${package.install.dir} -g ${package.user} \
+										${package.user}
+									else
+										getent passwd ${package.user} &gt;/dev/null || useradd -r -g ${package.user} -d ${package.install.dir} -s /bin/sh -c "${project.name}" ${package.user}
 									fi
 								fi</script>
 							</preinstallScriptlet>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
 		<package.group>${project.artifactId}</package.group>
 		<package.install.dir>/usr/share/${project.artifactId}</package.install.dir>
 		<package.user>${project.artifactId}</package.user>
-		<package.userId>102</package.userId>
 		<packageBuildTimeStamp>${maven.build.timestamp}</packageBuildTimeStamp>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<verify.mutationThreshold>100</verify.mutationThreshold>


### PR DESCRIPTION
I have removed fixed guid/uid number, letting system decide.
A problem could happend though, during an upgrade: already created folder could not be updated, if guid/uid is different from the previous one.
The %pre script still checks for RHEL5, otherwise uses default script for everything else.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/328?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/328'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>