### PR TITLE
preserve properties order

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jmx/JmxResultProcessor.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jmx/JmxResultProcessor.java
@@ -164,6 +164,6 @@ public class JmxResultProcessor {
 	 * Builds up the base Result object
 	 */
 	private Result getNewResultObject(String attributeName, Map<String, Object> values) {
-		return new Result(System.currentTimeMillis(), attributeName, className, objDomain, query.getResultAlias(), objectInstance.getObjectName().getCanonicalKeyPropertyListString(), values);
+		return new Result(System.currentTimeMillis(), attributeName, className, objDomain, query.getResultAlias(), objectInstance.getObjectName().getKeyPropertyListString(), values);
 	}
 }

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/jmx/JmxResultProcessorTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/jmx/JmxResultProcessorTest.java
@@ -68,6 +68,23 @@ public class JmxResultProcessorTest {
 	}
 
 	@Test
+	public void doesNotReorderTypeNames() throws MalformedObjectNameException {
+		String className = "java.lang.SomeClass";
+		String propertiesOutOfOrder = "z-key=z-value,a-key=a-value,k-key=k-value";
+		List<Result> results = new JmxResultProcessor(
+				query,
+				new ObjectInstance(className + ":" + propertiesOutOfOrder, className),
+				ImmutableList.of(new Attribute("SomeAttribute", 1)),
+				className,
+				TEST_DOMAIN_NAME).getResults();
+
+		assertThat(results).hasSize(1);
+		Result integerResult = results.get(0);
+		assertThat(integerResult.getTypeName()).isEqualTo(propertiesOutOfOrder);
+
+	}
+
+	@Test
 	public void canReadSingleIntegerValue() throws MalformedObjectNameException, InstanceNotFoundException {
 		Attribute integerAttribute = new Attribute("CollectionCount", 51L);
 		ObjectInstance runtime = getRuntime();


### PR DESCRIPTION
Recently merged #337 makes much more sense if we preserve the original order properties (a.k.a. type name values). It seems that nothing depends on the fact that they are sorted lexicographically, so we may change that behaviour and stick to the original order. That is what JConsole/VisualVM seem to be doing and the point of `useAllTypeNames` was to support  "construct the same tree I see in JConsole/VisualVM in Graphite" out of the box.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/338%23issuecomment-147488424%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/338%23issuecomment-147488424%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Yep%2C%20seems%20to%20make%20sense%20...%22%2C%20%22created_at%22%3A%20%222015-10-12T18%3A43%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/338#issuecomment-147488424'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Yep, seems to make sense ...


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/338?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/338?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/338'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>