### PR TITLE
GraphiteWriter: ignore non-numeric

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter.java
@@ -45,6 +45,8 @@ public class GraphiteWriter extends BaseOutputWriter {
 	private final String rootPrefix;
 	private final InetSocketAddress address;
 
+	private boolean didWarnAboutNonNumeric = false;
+
 	@JsonCreator
 	public GraphiteWriter(
 			@JsonProperty("typeNames") ImmutableList<String> typeNames,
@@ -103,7 +105,12 @@ public class GraphiteWriter extends BaseOutputWriter {
 							log.debug("Graphite Message: {}", line);
 							writer.write(line);
 						} else {
-							log.warn("Unable to submit non-numeric value to Graphite: [{}] from result [{}]", value, result);
+							if (!didWarnAboutNonNumeric) {
+								log.warn("Unable to submit non-numeric value to Graphite: [{}] from result [{}]", value, result);
+								log.warn("The warning above is displayed once per writer, there are possibly more non-numeric values");
+								didWarnAboutNonNumeric = true;
+							}
+							log.debug("Unable to submit non-numeric value to Graphite: [{}] from result [{}]", value, result);
 						}
 					}
 				}


### PR DESCRIPTION
I don't see how this warning could be helpful (who would expect a string in Graphite anyway?) and it fills log files so fast that WARNING level becomes useless (for anyone who does not want to list every possible numeric attribute name inside the query).
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/340%23issuecomment-148420134%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/340%23issuecomment-148448102%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/340%23issuecomment-148449359%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/340%23issuecomment-148503879%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/340%23issuecomment-149121352%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/340%23discussion_r42352654%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/340%23issuecomment-150560389%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/340%23issuecomment-148420134%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20that%20some%20kind%20of%20feedback%20is%20usefull%20for%20when%20you%20wonder%20why%20this%20metric%20does%20not%20show%20up%20in%20Graphite%20and%20you%20did%20not%20realize%20that%20it%20is%20non%20numeric.%20Changing%20the%20level%20to%20INFO%20or%20DEBUG%20probably%20make%20sense.%22%2C%20%22created_at%22%3A%20%222015-10-15T15%3A21%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20implemented%20a%20circuit%20breaker%20in%20jmxtrans-agent%2C%20this%20may%20help%3A%5Cr%5Cn%5Cr%5Cnhttps%3A//github.com/jmxtrans/jmxtrans-agent/blob/master/src/main/java/org/jmxtrans/agent/OutputWriterCircuitBreakerDecorator.java%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-15T16%3A36%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/459691%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cyrille-leclerc%22%7D%7D%2C%20%7B%22body%22%3A%20%22And%20a%20more%20generic%20one%20in%20Jmxtrans%202%20%3A%20https%3A//github.com/jmxtrans/jmxtrans2/blob/master/jmxtrans2-core/src/main/java/org/jmxtrans/core/circuitbreaker/CircuitBreakerProxy.java%22%2C%20%22created_at%22%3A%20%222015-10-15T16%3A39%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Alternative%20solution%20could%20be%20to%20filter%20duplicate%20messages%20at%20logback%20level%20with%20a%20%5BDuplicateMessageFilter%5D%28http%3A//logback.qos.ch/manual/filters.html%23DuplicateMessageFilter%29.%22%2C%20%22created_at%22%3A%20%222015-10-15T19%3A57%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20implemented%20simple%20circuit%20breaking%2C%20without%20any%20complex%20and%20generic%20classes.%20Is%20that%20OK%3F%22%2C%20%22created_at%22%3A%20%222015-10-19T06%3A57%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3083638%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bm371613%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40bm371613%20Could%20you%20please%20have%20a%20look%20at%20%23343%20and%20see%20if%20you%20think%20it%20is%20good%20enough%20to%20replace%20this%20PR%3F%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A40%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ca16a8cafb8bc96bf2a2c3df04532a855a2dfb8f%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter.java%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/340%23discussion_r42352654%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20circuit%20should%20probably%20be%20broken%20by%20%60Query%60%20/%20result%20and%20not%20by%20output%20writer.%20In%20this%20implementation%2C%20if%20we%20have%20multiple%20non%20numeric%20results%2C%20there%20will%20only%20be%20a%20warning%20for%20the%20first%20one.%20Also%2C%20an%20OutputWriter%20should%20be%20threadsafe%20%28this%20is%20not%20the%20case%20for%20all%20output%20writers%2C%20and%20in%20this%20case%20a%20race%20condition%20is%20not%20too%20bad%2C%20still...%29.%5Cr%5Cn%5Cr%5CnSide%20note%2C%20this%20is%20not%20a%20circuit%20braker%2C%20but%20a%20%5C%22only%20once%5C%22%20warning%2C%20which%20is%20a%20good%20thing%21%22%2C%20%22created_at%22%3A%20%222015-10-19T09%3A43%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter.java%3AL105-117%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/340#issuecomment-148420134'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I think that some kind of feedback is usefull for when you wonder why this metric does not show up in Graphite and you did not realize that it is non numeric. Changing the level to INFO or DEBUG probably make sense.
- <a href='https://github.com/cyrille-leclerc'><img border=0 src='https://avatars.githubusercontent.com/u/459691?v=3' height=16 width=16'></a> We implemented a circuit breaker in jmxtrans-agent, this may help:
https://github.com/jmxtrans/jmxtrans-agent/blob/master/src/main/java/org/jmxtrans/agent/OutputWriterCircuitBreakerDecorator.java
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> And a more generic one in Jmxtrans 2 : https://github.com/jmxtrans/jmxtrans2/blob/master/jmxtrans2-core/src/main/java/org/jmxtrans/core/circuitbreaker/CircuitBreakerProxy.java
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Alternative solution could be to filter duplicate messages at logback level with a [DuplicateMessageFilter](http://logback.qos.ch/manual/filters.html#DuplicateMessageFilter).
- <a href='https://github.com/bm371613'><img border=0 src='https://avatars.githubusercontent.com/u/3083638?v=3' height=16 width=16'></a> I implemented simple circuit breaking, without any complex and generic classes. Is that OK?
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> @bm371613 Could you please have a look at #343 and see if you think it is good enough to replace this PR?
- [ ] <a href='#crh-comment-Pull ca16a8cafb8bc96bf2a2c3df04532a855a2dfb8f jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter.java 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/340#discussion_r42352654'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter.java:L105-117</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> The circuit should probably be broken by `Query` / result and not by output writer. In this implementation, if we have multiple non numeric results, there will only be a warning for the first one. Also, an OutputWriter should be threadsafe (this is not the case for all output writers, and in this case a race condition is not too bad, still...).
Side note, this is not a circuit braker, but a "only once" warning, which is a good thing!


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/340?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/340?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/340'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>