### PR TITLE
Output writer factory

### DIFF
--- a/jmxtrans-core/pom.xml
+++ b/jmxtrans-core/pom.xml
@@ -139,6 +139,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.jmxtrans</groupId>
+			<artifactId>jmxtrans-test-utils</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
@@ -248,7 +248,7 @@ public class JmxTransformer implements WatchedCallback {
 	private void stopWriterAndClearMasterServerList() {
 		for (Server server : this.masterServersList) {
 			for (Query query : server.getQueries()) {
-				for (OutputWriter writer : query.getOutputWriters()) {
+				for (OutputWriter writer : query.getOutputWriterInstances()) {
 					try {
 						writer.stop();
 						log.debug("Stopped writer: " + writer.getClass().getSimpleName() + " for query: " + query);
@@ -311,8 +311,7 @@ public class JmxTransformer implements WatchedCallback {
 	}
 
 	private void validateSetup(Server server, Query query) throws ValidationException {
-		List<OutputWriter> writers = query.getOutputWriters();
-		for (OutputWriter w : writers) {
+		for (OutputWriter w : (List<OutputWriter>) query.getOutputWriterInstances()) {
 			injector.injectMembers(w);
 			w.validateSetup(server, query);
 		}
@@ -345,7 +344,7 @@ public class JmxTransformer implements WatchedCallback {
 
 				// need to inject the poolMap
 				for (Query query : server.getQueries()) {
-					for (OutputWriter writer : query.getOutputWriters()) {
+					for (OutputWriter writer : query.getOutputWriterInstances()) {
 						writer.start();
 					}
 				}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jmx/JmxQueryProcessor.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jmx/JmxQueryProcessor.java
@@ -92,7 +92,7 @@ public class JmxQueryProcessor {
 	}
 
 	private void runOutputWritersForQuery(Server server, Query query, ImmutableList<Result> results) throws Exception {
-		for (OutputWriter writer : query.getOutputWriters()) {
+		for (OutputWriter writer : query.getOutputWriterInstances()) {
 			writer.doWrite(server, query, results);
 		}
 		log.debug("Finished running outputWriters for query: {}", query);

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/OutputWriterFactory.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/OutputWriterFactory.java
@@ -1,0 +1,36 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import static com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.NON_NULL;
+
+@JsonSerialize(include = NON_NULL)
+@JsonTypeInfo(use = Id.CLASS, include = As.PROPERTY, property = "@class")
+public interface OutputWriterFactory {
+	OutputWriter create();
+}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/QueryFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/QueryFixtures.java
@@ -20,29 +20,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.util;
+package com.googlecode.jmxtrans.model;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.googlecode.jmxtrans.model.JmxProcess;
+import com.googlecode.jmxtrans.model.Query;
 
-import java.io.File;
-import java.io.IOException;
+public final class QueryFixtures {
 
-public final class JsonUtils {
+	private QueryFixtures() {}
 
-	private JsonUtils() {}
-
-	/**
-	 * Uses jackson to load json configuration from a File into a full object
-	 * tree representation of that json.
-	 */
-	public static JmxProcess getJmxProcess(File file) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.setNodeFactory(new PlaceholderResolverJsonNodeFactory());
-		mapper.registerModule(new GuavaModule());
-		JmxProcess jmx = mapper.readValue(file, JmxProcess.class);
-		jmx.setName(file.getName());
-		return jmx;
+	public static Query dummyQuery() {
+		return Query.builder()
+				.setObj("myQuery")
+				.build();
 	}
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
@@ -1,0 +1,79 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.googlecode.jmxtrans.model.Result;
+
+public final class ResultFixtures {
+	private ResultFixtures() {}
+
+	public static Result booleanTrueResult() {
+		return new Result(
+				0,
+				"Verbose",
+				"sun.management.MemoryImpl",
+				"ObjectDomainName",
+				"VerboseMemory",
+				"type=Memory",
+				ImmutableMap.<String, Object>of("Verbose", true));
+	}
+
+	public static ImmutableList<Result> singleTrueResult() {
+		return ImmutableList.of(booleanTrueResult());
+	}
+
+	public static Result booleanFalseResult() {
+		return new Result(
+				0,
+				"Verbose",
+				"sun.management.MemoryImpl",
+				"ObjectDomainName",
+				"VerboseMemory",
+				"type=Memory",
+				ImmutableMap.<String, Object>of("Verbose", false));
+	}
+
+	public static Result numericResult() {
+		return new Result(
+				0,
+				"ObjectPendingFinalizationCount",
+				"sun.management.MemoryImpl",
+				"ObjectDomainName",
+				"ObjectPendingFinalizationCount",
+				"type=Memory",
+				ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", 10));
+	}
+
+	public static ImmutableList<Result> singleFalseResult() {
+		return ImmutableList.of(booleanFalseResult());
+	}
+
+	public static ImmutableList<Result> dummyResults() {
+		return ImmutableList.of(
+				numericResult(),
+				booleanTrueResult(),
+				booleanFalseResult());
+	}
+}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ServerFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ServerFixtures.java
@@ -20,29 +20,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.util;
+package com.googlecode.jmxtrans.model;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.googlecode.jmxtrans.model.JmxProcess;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Server;
 
-import java.io.File;
-import java.io.IOException;
+public final class ServerFixtures {
+	private ServerFixtures() {}
 
-public final class JsonUtils {
+	public static Server createServerWithOneQuery(String host, String port, String queryObject) {
+		return Server.builder()
+				.setHost(host)
+				.setPort(port)
+				.addQuery(Query.builder()
+					.setObj(queryObject)
+					.build())
+				.build();
+	}
 
-	private JsonUtils() {}
-
-	/**
-	 * Uses jackson to load json configuration from a File into a full object
-	 * tree representation of that json.
-	 */
-	public static JmxProcess getJmxProcess(File file) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.setNodeFactory(new PlaceholderResolverJsonNodeFactory());
-		mapper.registerModule(new GuavaModule());
-		JmxProcess jmx = mapper.readValue(file, JmxProcess.class);
-		jmx.setName(file.getName());
-		return jmx;
+	public static Server dummyServer() {
+		return createServerWithOneQuery("host.example.net", "4321", "myQuery");
 	}
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/BaseOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/BaseOutputWriter.java
@@ -24,10 +24,8 @@ package com.googlecode.jmxtrans.model.output;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.OutputWriter;
 import com.googlecode.jmxtrans.model.OutputWriterFactory;
@@ -37,6 +35,7 @@ import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.naming.typename.TypeNameValuesStringBuilder;
 import com.googlecode.jmxtrans.model.results.BooleanAsNumberValueTransformer;
 import com.googlecode.jmxtrans.model.results.IdentityValueTransformer;
+import com.googlecode.jmxtrans.model.results.ResultValuesTransformer;
 import com.googlecode.jmxtrans.model.results.ValueTransformer;
 import lombok.Getter;
 
@@ -146,17 +145,11 @@ public abstract class BaseOutputWriter implements OutputWriter, OutputWriterFact
 		return TypeNameValuesStringBuilder.getDefaultBuilder().build(this.getTypeNames(), typeNameStr);
 	}
 
-	/**
-	 * A do nothing method.
-	 */
 	@Override
 	public void start() throws LifecycleException {
 		// Do nothing.
 	}
 
-	/**
-	 * A do nothing method.
-	 */
 	@Override
 	public void stop() throws LifecycleException {
 		// Do nothing.
@@ -174,29 +167,4 @@ public abstract class BaseOutputWriter implements OutputWriter, OutputWriterFact
 		return this;
 	}
 
-	private static final class ResultValuesTransformer implements Function<Result, Result> {
-
-		private final ValueTransformer valueTransformer;
-
-		private ResultValuesTransformer(ValueTransformer valueTransformer) {
-			this.valueTransformer = valueTransformer;
-		}
-
-		@Nullable
-		@Override
-		public Result apply(@Nullable Result input) {
-			if (input == null) {
-				return null;
-			}
-			return new Result(
-					input.getEpoch(),
-					input.getAttributeName(),
-					input.getClassName(),
-					input.getObjDomain(),
-					input.getKeyAlias(),
-					input.getTypeName(),
-					Maps.transformValues(input.getValues(), valueTransformer)
-			);
-		}
-	}
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/BaseOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/BaseOutputWriter.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
@@ -59,7 +60,7 @@ import static com.googlecode.jmxtrans.model.output.Settings.getBooleanSetting;
  * @author jon
  */
 @NotThreadSafe
-public abstract class BaseOutputWriter implements OutputWriter {
+public abstract class BaseOutputWriter implements OutputWriter, OutputWriterFactory {
 
 	public static final String HOST = "host";
 	public static final String PORT = "port";
@@ -167,6 +168,11 @@ public abstract class BaseOutputWriter implements OutputWriter {
 	}
 
 	protected abstract void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception;
+
+	@Override
+	public OutputWriter create() {
+		return this;
+	}
 
 	private static final class ResultValuesTransformer implements Function<Result, Result> {
 

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/BooleanAsNumberOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/BooleanAsNumberOutputWriter.java
@@ -20,29 +20,44 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.util;
+package com.googlecode.jmxtrans.model.output;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.googlecode.jmxtrans.model.JmxProcess;
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ValidationException;
 
-import java.io.File;
-import java.io.IOException;
+import java.util.Map;
 
-public final class JsonUtils {
+import static java.util.Collections.emptyMap;
 
-	private JsonUtils() {}
+public class BooleanAsNumberOutputWriter implements OutputWriter {
+	@Override
+	public void start() throws LifecycleException {
+	}
 
-	/**
-	 * Uses jackson to load json configuration from a File into a full object
-	 * tree representation of that json.
-	 */
-	public static JmxProcess getJmxProcess(File file) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.setNodeFactory(new PlaceholderResolverJsonNodeFactory());
-		mapper.registerModule(new GuavaModule());
-		JmxProcess jmx = mapper.readValue(file, JmxProcess.class);
-		jmx.setName(file.getName());
-		return jmx;
+	@Override
+	public void stop() throws LifecycleException {
+	}
+
+	@Override
+	public void doWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
+
+	}
+
+	@Override
+	public Map<String, Object> getSettings() {
+		return emptyMap();
+	}
+
+	@Override
+	public void setSettings(Map<String, Object> settings) {
+	}
+
+	@Override
+	public void validateSetup(Server server, Query query) throws ValidationException {
 	}
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/StdOutWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/StdOutWriter.java
@@ -25,6 +25,8 @@ package com.googlecode.jmxtrans.model.output;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
@@ -38,7 +40,13 @@ import java.util.Map;
  * 
  * @author jon
  */
-public class StdOutWriter extends BaseOutputWriter {
+public class StdOutWriter implements OutputWriterFactory {
+
+	private final ImmutableList<String> typeNames;
+	private final  boolean booleanAsNumber;
+	private final  Boolean debugEnabled;
+	private final  Map<String, Object> settings;
+
 
 	@JsonCreator
 	public StdOutWriter(
@@ -46,20 +54,42 @@ public class StdOutWriter extends BaseOutputWriter {
 			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
 			@JsonProperty("debug") Boolean debugEnabled,
 			@JsonProperty("settings") Map<String, Object> settings) {
-		super(typeNames, booleanAsNumber, debugEnabled, settings);
-	}
-
-	/**
-	 * nothing to validate
-	 */
-	@Override
-	public void validateSetup(Server server, Query query) throws ValidationException {
+			this.typeNames = typeNames;
+			this.booleanAsNumber = booleanAsNumber;
+			this.debugEnabled = debugEnabled;
+			this.settings = settings;
 	}
 
 	@Override
-	protected void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
-		for (Result r : results) {
-			System.out.println(r);
+	public OutputWriter create() {
+		return new W(
+				typeNames,
+				booleanAsNumber,
+				debugEnabled,
+				settings
+		);
+	}
+
+
+	public static class W extends BaseOutputWriter {
+		public W (
+				ImmutableList<String> typeNames,
+				boolean booleanAsNumber,
+				Boolean debugEnabled,
+				Map<String, Object> settings) {
+			super(typeNames, booleanAsNumber, debugEnabled, settings);
+		}
+
+		@Override
+		public void validateSetup(Server server, Query query) throws ValidationException {
+			// nothing to validate
+		}
+
+		@Override
+		protected void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
+			for (Result r : results) {
+				System.out.println(r);
+			}
 		}
 	}
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/results/ResultValuesTransformer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/results/ResultValuesTransformer.java
@@ -20,29 +20,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.util;
+package com.googlecode.jmxtrans.model.results;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.googlecode.jmxtrans.model.JmxProcess;
+import com.google.common.base.Function;
+import com.google.common.collect.Maps;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.results.ValueTransformer;
 
-import java.io.File;
-import java.io.IOException;
+import javax.annotation.Nullable;
 
-public final class JsonUtils {
+public class ResultValuesTransformer implements Function<Result, Result> {
 
-	private JsonUtils() {}
+	private final ValueTransformer valueTransformer;
 
-	/**
-	 * Uses jackson to load json configuration from a File into a full object
-	 * tree representation of that json.
-	 */
-	public static JmxProcess getJmxProcess(File file) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.setNodeFactory(new PlaceholderResolverJsonNodeFactory());
-		mapper.registerModule(new GuavaModule());
-		JmxProcess jmx = mapper.readValue(file, JmxProcess.class);
-		jmx.setName(file.getName());
-		return jmx;
+	public ResultValuesTransformer(ValueTransformer valueTransformer) {
+		this.valueTransformer = valueTransformer;
 	}
+
+	@Nullable
+	@Override
+	public Result apply(@Nullable Result input) {
+		if (input == null) {
+			return null;
+		}
+		return new Result(
+				input.getEpoch(),
+				input.getAttributeName(),
+				input.getClassName(),
+				input.getObjDomain(),
+				input.getKeyAlias(),
+				input.getTypeName(),
+				Maps.transformValues(input.getValues(), valueTransformer)
+		);
+	}
+
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/util/PlaceholderResolverJsonNodeFactory.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/util/PlaceholderResolverJsonNodeFactory.java
@@ -20,18 +20,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.model;
+package com.googlecode.jmxtrans.util;
 
-public final class ServerFixtures {
-	private ServerFixtures() {}
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.TextNode;
 
-	public static Server createServerWithOneQuery(String host, String port, String queryObject) {
-		return Server.builder()
-				.setHost(host)
-				.setPort(port)
-				.addQuery(Query.builder()
-					.setObj(queryObject)
-					.build())
-				.build();
+import static com.googlecode.jmxtrans.model.PropertyResolver.resolveProps;
+
+public class PlaceholderResolverJsonNodeFactory extends JsonNodeFactory {
+
+	@Override
+	public TextNode textNode(String text) {
+		return super.textNode(resolveProps(text));
 	}
 }

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/jmx/JmxProcessingTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/jmx/JmxProcessingTests.java
@@ -24,6 +24,7 @@ package com.googlecode.jmxtrans.jmx;
 
 import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
@@ -47,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JmxProcessingTests {
@@ -67,11 +69,14 @@ public class JmxProcessingTests {
 
 	@Test
 	public void querySimpleAttribute() throws Exception {
+		OutputWriterFactory outputWriterFactory = mock(OutputWriterFactory.class);
 		OutputWriter outputWriter = mock(OutputWriter.class);
+		when(outputWriterFactory.create()).thenReturn(outputWriter);
+
 		Query query = Query.builder()
 				.setObj(MBEAN_NAME)
 				.addAttr("DummyValue")
-				.addOutputWriter(outputWriter)
+				.addOutputWriter(outputWriterFactory)
 				.build();
 
 		new JmxQueryProcessor().processQuery(server, null, query);

--- a/jmxtrans-examples/src/main/java/com/googlecode/jmxtrans/example/TreeWalker3.java
+++ b/jmxtrans-examples/src/main/java/com/googlecode/jmxtrans/example/TreeWalker3.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.jmx.JmxQueryProcessor;
 import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
@@ -122,7 +123,7 @@ public class TreeWalker3 {
 		}
 	}
 
-	private static final class ResultCapture implements OutputWriter {
+	private static final class ResultCapture implements OutputWriter, OutputWriterFactory {
 
 		private List<Result> results;
 
@@ -148,5 +149,9 @@ public class TreeWalker3 {
 		@Override
 		public void validateSetup(Server server, Query query) throws ValidationException {}
 
+		@Override
+		public OutputWriter create() {
+			return this;
+		}
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-core/pom.xml
@@ -53,6 +53,10 @@
 			<artifactId>jackson-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.github.chrisvest</groupId>
+			<artifactId>stormpot</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>
@@ -94,8 +98,18 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.jayway.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -111,6 +125,11 @@
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-library</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jmxtrans</groupId>
+			<artifactId>jmxtrans-test-utils</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter2.java
@@ -1,0 +1,138 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.naming.KeyUtils;
+import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.TcpOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.WriterBasedOutputWriter;
+import com.googlecode.jmxtrans.util.OnlyOnceLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
+
+/**
+ * This low latency and thread safe output writer sends data to a host/port combination
+ * in the Graphite format.
+ *
+ * @see <a href="http://graphite.wikidot.com/getting-your-data-into-graphite">Getting your data into Graphite</a>
+ */
+@ThreadSafe
+public class GraphiteWriter2 implements OutputWriterFactory {
+	private static final Logger log = LoggerFactory.getLogger(GraphiteWriter2.class);
+
+	private static final String DEFAULT_ROOT_PREFIX = "servers";
+
+	private final String rootPrefix;
+	private final InetSocketAddress graphiteServer;
+	private final ImmutableList<String> typeNames;
+	private final boolean booleanAsNumber;
+
+	@JsonCreator
+	public GraphiteWriter2(
+			@JsonProperty("typeNames") ImmutableList<String> typeNames,
+			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
+			@JsonProperty("rootPrefix") String rootPrefix,
+			@JsonProperty("host") String host,
+			@JsonProperty("port") Integer port) {
+		this.typeNames = typeNames;
+		this.booleanAsNumber = booleanAsNumber;
+		this.rootPrefix = firstNonNull(rootPrefix, DEFAULT_ROOT_PREFIX);
+
+		this.graphiteServer = new InetSocketAddress(
+				checkNotNull(host, "Host cannot be null."),
+				checkNotNull(port, "Port cannot be null."));
+	}
+
+	@Override
+	public OutputWriter create() {
+		return ResultTransformerOutputWriter.booleanToNumber(
+				booleanAsNumber,
+				TcpOutputWriter.builder(graphiteServer, new W(typeNames, rootPrefix))
+						.setCharset(UTF_8)
+						.build()
+		);
+	}
+
+	@ThreadSafe
+	public static class W implements WriterBasedOutputWriter {
+		private final OnlyOnceLogger onlyOnceLogger = new OnlyOnceLogger(log);
+
+		private final ImmutableList<String> typeNames;
+		private final String rootPrefix;
+
+		public W(ImmutableList<String> typeNames, String rootPrefix) {
+			this.typeNames = typeNames;
+			this.rootPrefix = rootPrefix;
+		}
+
+		@Override
+		public void write(
+				@Nonnull Writer writer,
+				@Nonnull Server server,
+				@Nonnull Query query,
+				@Nonnull ImmutableList<Result> results) throws IOException {
+
+			for (Result result : results) {
+				log.debug("Query result: {}", result);
+				Map<String, Object> resultValues = result.getValues();
+				if (resultValues != null) {
+					for (Entry<String, Object> values : resultValues.entrySet()) {
+						Object value = values.getValue();
+						if (isNumeric(value)) {
+
+							String line = KeyUtils.getKeyString(server, query, result, values, typeNames, rootPrefix)
+									.replaceAll("[()]", "_") + " " + value.toString() + " "
+									+ result.getEpoch() / 1000 + "\n";
+							log.debug("Graphite Message: {}", line);
+							writer.write(line);
+						} else {
+							onlyOnceLogger.infoOnce("Unable to submit non-numeric value to Graphite: [{}] from result [{}]", value, result);
+						}
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
@@ -1,0 +1,95 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output.support;
+
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ValidationException;
+import com.googlecode.jmxtrans.model.results.BooleanAsNumberValueTransformer;
+import com.googlecode.jmxtrans.model.results.IdentityValueTransformer;
+import com.googlecode.jmxtrans.model.results.ResultValuesTransformer;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.google.common.collect.FluentIterable.from;
+
+public class ResultTransformerOutputWriter<T extends OutputWriter> implements OutputWriter {
+
+	@Nonnull private final ResultValuesTransformer resultValuesTransformer;
+	@Nonnull private final T target;
+
+	public ResultTransformerOutputWriter(@Nonnull ResultValuesTransformer resultValuesTransformer, @Nonnull T target) {
+		this.resultValuesTransformer = resultValuesTransformer;
+		this.target = target;
+	}
+
+	@Override
+	public void start() throws LifecycleException {
+	}
+
+	@Override
+	public void stop() throws LifecycleException {
+	}
+
+	@Override
+	public void doWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
+		target.doWrite(
+				server,
+				query,
+				from(results).transform(resultValuesTransformer).toList());
+	}
+
+	@Override
+	public Map<String, Object> getSettings() {
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public void setSettings(Map<String, Object> settings) {
+	}
+
+	@Override
+	public void validateSetup(Server server, Query query) throws ValidationException {
+	}
+
+	public static <T extends OutputWriter> ResultTransformerOutputWriter<T> booleanToNumber(boolean booleanToNumber, T target) {
+		if (booleanToNumber) return booleanToNumber(target);
+		return identity(target);
+	}
+
+	public static <T extends OutputWriter> ResultTransformerOutputWriter<T> booleanToNumber(T target) {
+		return new ResultTransformerOutputWriter<T>(new ResultValuesTransformer(new BooleanAsNumberValueTransformer(1, 0)), target);
+	}
+
+	public static <T extends OutputWriter> ResultTransformerOutputWriter<T> identity(T target) {
+		return new ResultTransformerOutputWriter<T>(new ResultValuesTransformer(new IdentityValueTransformer()), target);
+	}
+
+
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriter.java
@@ -1,0 +1,134 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output.support;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ValidationException;
+import com.googlecode.jmxtrans.model.output.support.pool.SocketAllocator;
+import com.googlecode.jmxtrans.model.output.support.pool.SocketExpiration;
+import com.googlecode.jmxtrans.model.output.support.pool.SocketPoolable;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import stormpot.BlazePool;
+import stormpot.Config;
+import stormpot.Pool;
+import stormpot.Timeout;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TcpOutputWriter<T extends WriterBasedOutputWriter> implements OutputWriter {
+
+	@Nonnull private final T target;
+	@Nonnull private final Pool<SocketPoolable> socketPool;
+
+	public TcpOutputWriter(@Nonnull T target, @Nonnull Pool<SocketPoolable> socketPool) {
+		this.target = target;
+		this.socketPool = socketPool;
+	}
+
+	@Override
+	public void start() throws LifecycleException {
+
+	}
+
+	@Override
+	public void stop() throws LifecycleException {
+
+	}
+
+	@Override
+	public void doWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
+		try {
+			SocketPoolable socketPoolable = socketPool.claim(new Timeout(1, SECONDS));
+			try {
+				target.write(socketPoolable.getWriter(), server, query, results);
+			} catch (IOException ioe) {
+				socketPoolable.invalidate();
+				throw ioe;
+			} finally {
+				socketPoolable.release();
+			}
+		} catch (InterruptedException e) {
+			throw new IllegalStateException("Could not get socket from pool, please check is the server is available");
+		}
+	}
+
+	@Override
+	public Map<String, Object> getSettings() {
+		return null;
+	}
+
+	@Override
+	public void setSettings(Map<String, Object> settings) {
+
+	}
+
+	@Override
+	public void validateSetup(Server server, Query query) throws ValidationException {
+
+	}
+
+	public static <T extends WriterBasedOutputWriter> Builder<T> builder(
+			@Nonnull InetSocketAddress server,
+			@Nonnull T target) {
+		return new Builder<T>(server, target);
+	}
+
+	@Accessors(chain = true)
+	public static class Builder<T extends WriterBasedOutputWriter> {
+		@Nonnull private final InetSocketAddress server;
+		@Nonnull private final T target;
+		@Nonnull @Setter private Charset charset = Charsets.UTF_8;
+		@Setter private int socketTimeoutMillis = 200;
+		@Setter private int poolSize = 1;
+
+		public Builder(@Nonnull InetSocketAddress server, @Nonnull T target) {
+			this.server = server;
+			this.target = target;
+		}
+
+		public TcpOutputWriter<T> build() {
+			Config<SocketPoolable> config = new Config<SocketPoolable>()
+					.setAllocator(new SocketAllocator(
+							server,
+							socketTimeoutMillis,
+							charset))
+					.setExpiration(new SocketExpiration())
+					.setSize(poolSize);
+			Pool<SocketPoolable> pool = new BlazePool<SocketPoolable>(config);
+			return new TcpOutputWriter<T>(target, pool);
+		}
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/WriterBasedOutputWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/WriterBasedOutputWriter.java
@@ -20,29 +20,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.util;
+package com.googlecode.jmxtrans.model.output.support;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.googlecode.jmxtrans.model.JmxProcess;
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
 
-import java.io.File;
+import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.io.Writer;
 
-public final class JsonUtils {
-
-	private JsonUtils() {}
-
-	/**
-	 * Uses jackson to load json configuration from a File into a full object
-	 * tree representation of that json.
-	 */
-	public static JmxProcess getJmxProcess(File file) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.setNodeFactory(new PlaceholderResolverJsonNodeFactory());
-		mapper.registerModule(new GuavaModule());
-		JmxProcess jmx = mapper.readValue(file, JmxProcess.class);
-		jmx.setName(file.getName());
-		return jmx;
-	}
+public interface WriterBasedOutputWriter {
+	void write(
+			@Nonnull Writer writer,
+			@Nonnull Server server,
+			@Nonnull Query query,
+			@Nonnull ImmutableList<Result> results) throws IOException;
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/SocketExpiration.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/SocketExpiration.java
@@ -20,29 +20,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.util;
+package com.googlecode.jmxtrans.model.output.support.pool;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.googlecode.jmxtrans.model.JmxProcess;
+import stormpot.Expiration;
+import stormpot.SlotInfo;
 
-import java.io.File;
-import java.io.IOException;
+import java.net.Socket;
 
-public final class JsonUtils {
+public class SocketExpiration implements Expiration<SocketPoolable> {
 
-	private JsonUtils() {}
-
-	/**
-	 * Uses jackson to load json configuration from a File into a full object
-	 * tree representation of that json.
-	 */
-	public static JmxProcess getJmxProcess(File file) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.setNodeFactory(new PlaceholderResolverJsonNodeFactory());
-		mapper.registerModule(new GuavaModule());
-		JmxProcess jmx = mapper.readValue(file, JmxProcess.class);
-		jmx.setName(file.getName());
-		return jmx;
+	@Override
+	public boolean hasExpired(SlotInfo<? extends SocketPoolable> info) throws Exception {
+		Socket socket = info.getPoolable().getSocket();
+		try {
+			return socket == null
+					|| !socket.isConnected()
+					|| !socket.isBound()
+					|| socket.isClosed()
+					|| socket.isInputShutdown()
+					|| socket.isOutputShutdown();
+		} catch (Exception e) {
+			return true;
+		}
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/SocketPoolable.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/SocketPoolable.java
@@ -20,29 +20,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.util;
+package com.googlecode.jmxtrans.model.output.support.pool;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.googlecode.jmxtrans.model.JmxProcess;
+import lombok.Getter;
+import stormpot.Poolable;
+import stormpot.Slot;
 
-import java.io.File;
-import java.io.IOException;
+import javax.annotation.Nonnull;
+import java.io.Writer;
+import java.net.Socket;
 
-public final class JsonUtils {
+public class SocketPoolable implements Poolable {
+	@Nonnull
+	private final Slot slot;
+	@Nonnull
+	@Getter
+	private final Socket socket;
+	@Nonnull
+	@Getter
+	private final Writer writer;
 
-	private JsonUtils() {}
+	public SocketPoolable(@Nonnull Slot slot, @Nonnull Socket socket, @Nonnull Writer writer) {
+		this.slot = slot;
+		this.socket = socket;
+		this.writer = writer;
+	}
 
-	/**
-	 * Uses jackson to load json configuration from a File into a full object
-	 * tree representation of that json.
-	 */
-	public static JmxProcess getJmxProcess(File file) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.setNodeFactory(new PlaceholderResolverJsonNodeFactory());
-		mapper.registerModule(new GuavaModule());
-		JmxProcess jmx = mapper.readValue(file, JmxProcess.class);
-		jmx.setName(file.getName());
-		return jmx;
+	@Override
+	public void release() {
+		slot.release(this);
+	}
+
+	public void invalidate() {
+		slot.expire(this);
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriterTest.java
@@ -1,0 +1,80 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output.support;
+
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.ResultFixtures.singleFalseResult;
+import static com.googlecode.jmxtrans.model.ResultFixtures.singleTrueResult;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
+import static com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter.booleanToNumber;
+import static com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter.identity;
+import static java.lang.Boolean.FALSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResultTransformerOutputWriterTest {
+
+	@Mock private OutputWriter outputWriter;
+	@Captor private ArgumentCaptor<ImmutableList<Result>> resultsCaptor;
+
+	@Test
+	public void booleanValuesAreTransformed() throws Exception {
+		ResultTransformerOutputWriter<OutputWriter> resultTransformerOutputWriter = booleanToNumber(outputWriter);
+		resultTransformerOutputWriter.doWrite(dummyServer(), dummyQuery(), singleTrueResult());
+
+		verify(outputWriter)
+				.doWrite(any(Server.class), any(Query.class), resultsCaptor.capture());
+		assertThat(resultsCaptor.getValue()).hasSize(1);
+
+		Result transformedResult = resultsCaptor.getValue().get(0);
+		assertThat(transformedResult.getValues()).containsEntry("Verbose", 1);
+	}
+
+	@Test
+	public void identityTransformerDoesNotTransformValues() throws Exception {
+		ResultTransformerOutputWriter<OutputWriter> resultTransformerOutputWriter = identity(outputWriter);
+		resultTransformerOutputWriter.doWrite(dummyServer(), dummyQuery(), singleFalseResult());
+
+		verify(outputWriter)
+				.doWrite(any(Server.class), any(Query.class), resultsCaptor.capture());
+		assertThat(resultsCaptor.getValue()).hasSize(1);
+
+		Result transformedResult = resultsCaptor.getValue().get(0);
+		assertThat(transformedResult.getValues()).containsEntry("Verbose", FALSE);
+	}
+
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriterTest.java
@@ -1,0 +1,124 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output.support;
+
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.output.support.pool.SocketPoolable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import stormpot.Allocator;
+import stormpot.BlazePool;
+import stormpot.Config;
+import stormpot.LifecycledPool;
+import stormpot.Slot;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.concurrent.Callable;
+
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.ResultFixtures.dummyResults;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
+import static com.jayway.awaitility.Awaitility.await;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TcpOutputWriterTest {
+
+	private LifecycledPool<SocketPoolable> pool;
+	@Spy private DummyAllocator allocator = new DummyAllocator();
+	@Mock private WriterBasedOutputWriter target;
+	private Writer writer = new StringWriter();
+	@Captor private ArgumentCaptor<Writer> writerCaptor;
+
+	@Before
+	public void setupPool() {
+		Config<SocketPoolable> config = new Config<SocketPoolable>()
+				.setAllocator(allocator);
+		pool = new BlazePool<SocketPoolable>(config);
+	}
+
+	@Test
+	public void writerIsPassedToTargetOutputWriter() throws Exception {
+		TcpOutputWriter<WriterBasedOutputWriter> outputWriter = new TcpOutputWriter<WriterBasedOutputWriter>(target, pool);
+
+		outputWriter.doWrite(dummyServer(), dummyQuery(), dummyResults());
+
+		verify(target).write(writerCaptor.capture(), any(Server.class), any(Query.class), any(ImmutableList.class));
+
+		assertThat(writerCaptor.getValue()).isSameAs(writer);
+	}
+
+	@Test(expected = IOException.class)
+	public void socketIsReleasedOnIOException() throws Exception {
+		doThrow(IOException.class).when(target).write(any(Writer.class), any(Server.class), any(Query.class), any(ImmutableList.class));
+
+		TcpOutputWriter<WriterBasedOutputWriter> outputWriter = new TcpOutputWriter<WriterBasedOutputWriter>(target, pool);
+		try {
+			outputWriter.doWrite(dummyServer(), dummyQuery(), dummyResults());
+		} finally {
+			await()
+					.atMost(500, MILLISECONDS)
+					.until(socketDeallocated());
+		}
+	}
+
+	private Callable<Boolean> socketDeallocated() {
+		return new Callable<Boolean>() {
+			@Override
+			public Boolean call() throws Exception {
+				try {
+					verify(allocator).deallocate(any(SocketPoolable.class));
+				} catch (IOException e) {
+					return false;
+				}
+				return true;
+			}
+		};
+	}
+
+
+	private class DummyAllocator implements Allocator<SocketPoolable> {
+		@Override
+		public SocketPoolable allocate(Slot slot) throws Exception {
+			return new SocketPoolable(slot, null, writer);
+		}
+
+		@Override
+		public void deallocate(SocketPoolable poolable) throws Exception {
+		}
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/SocketAllocatorTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/SocketAllocatorTest.java
@@ -1,0 +1,96 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output.support.pool;
+
+import com.googlecode.jmxtrans.test.TCPEchoServer;
+import com.googlecode.jmxtrans.test.IntegrationTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import stormpot.Slot;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class SocketAllocatorTest {
+
+	@Category(IntegrationTest.class)
+	@Test
+	public void addressResolutionIsAlwaysDone() throws Exception {
+		TCPEchoServer echoServer = new TCPEchoServer();
+		try {
+			echoServer.start();
+
+			SocketAllocator socketAllocator = new SocketAllocator(echoServer.getLocalSocketAddress(), 100, UTF_8);
+			SocketPoolable socketPoolable = socketAllocator.allocate(mock(Slot.class));
+
+			try {
+				InetSocketAddress remoteSocketAddress = (InetSocketAddress) socketPoolable.getSocket().getRemoteSocketAddress();
+				assertThat(remoteSocketAddress).isEqualTo(echoServer.getLocalSocketAddress());
+				// FIXME: the following test is not actually good. Not really sure how to validate that DNS resolution is done.
+				assertThat(remoteSocketAddress).isNotSameAs(echoServer.getLocalSocketAddress());
+			} finally {
+				socketPoolable.getSocket().close();
+			}
+		} finally {
+			echoServer.stop();
+		}
+	}
+
+	@Test
+	public void socketAndWritersAreClosed() throws Exception {
+		SocketAllocator socketAllocator = new SocketAllocator(new InetSocketAddress("localhost", 80), 100, UTF_8);
+
+		Socket socket = mock(Socket.class);
+		Writer writer = mock(Writer.class);
+		SocketPoolable socketPoolable = new SocketPoolable(null, socket, writer);
+		socketAllocator.deallocate(socketPoolable);
+
+		verify(socket).close();
+		verify(writer).close();
+	}
+
+	@Test(expected = IOException.class)
+	public void socketAndWritersAreClosedEvenWhenExceptions() throws Exception {
+		SocketAllocator socketAllocator = new SocketAllocator(new InetSocketAddress("localhost", 80), 100, UTF_8);
+
+		Socket socket = mock(Socket.class);
+		doThrow(IOException.class).when(socket).close();
+		Writer writer = mock(Writer.class);
+		doThrow(IOException.class).when(writer).close();
+
+		SocketPoolable socketPoolable = new SocketPoolable(null, socket, writer);
+		socketAllocator.deallocate(socketPoolable);
+
+		verify(socket).close();
+		verify(writer).close();
+	}
+
+}

--- a/jmxtrans-test-utils/pom.xml
+++ b/jmxtrans-test-utils/pom.xml
@@ -31,16 +31,16 @@
 		<version>252-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>jmxtrans-utils</artifactId>
+	<artifactId>jmxtrans-test-utils</artifactId>
 
-	<name>JmxTrans - utils</name>
+	<name>JmxTrans - test utils</name>
 
-	<description>This module contains utilities that do not have direct dependencies on JmxTrans.</description>
+	<description>This module contains utilities used purely in tests.</description>
 
 	<properties>
-		<verify.mutationThreshold>53</verify.mutationThreshold>
-		<verify.totalBranchRate>66</verify.totalBranchRate>
-		<verify.totalLineRate>60</verify.totalLineRate>
+		<verify.mutationThreshold>0</verify.mutationThreshold>
+		<verify.totalBranchRate>0</verify.totalBranchRate>
+		<verify.totalLineRate>0</verify.totalLineRate>
 	</properties>
 
 	<dependencies>
@@ -49,51 +49,13 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.sf.jpathwatch</groupId>
-			<artifactId>jpathwatch</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.mojo</groupId>
-			<artifactId>animal-sniffer-annotations</artifactId>
-			<optional>true</optional>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>annotations</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -105,13 +67,20 @@
 				<configuration>
 					<merge>true</merge>
 					<message>Creating site for ${project.name}
-						${project.version}</message>
+                        ${project.version}</message>
 					<path>${project.artifactId}</path>
 				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.pitest</groupId>
+				<artifactId>pitest-maven</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/jmxtrans-test-utils/src/etc/checkstyle.xml
+++ b/jmxtrans-test-utils/src/etc/checkstyle.xml
@@ -1,0 +1,44 @@
+<!--
+
+    The MIT License
+    Copyright (c) 2010 JmxTrans team
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+
+	<module name="TreeWalker">
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^\t* +\t*\S"/>
+			<property name="message"
+					  value="Line has leading space characters; indentation should be performed with tabs only."/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+		<module name="AvoidStarImport">
+			<property name="allowClassImports" value="false"/>
+			<property name="allowStaticMemberImports" value="false"/>
+		</module>
+		<module name="UnusedImports"/>
+		<module name="RedundantModifier"/>
+		<module name="EqualsHashCode"/>
+	</module>
+</module>

--- a/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/IntegrationTest.java
+++ b/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/IntegrationTest.java
@@ -20,29 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.util;
+package com.googlecode.jmxtrans.test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.googlecode.jmxtrans.model.JmxProcess;
-
-import java.io.File;
-import java.io.IOException;
-
-public final class JsonUtils {
-
-	private JsonUtils() {}
-
-	/**
-	 * Uses jackson to load json configuration from a File into a full object
-	 * tree representation of that json.
-	 */
-	public static JmxProcess getJmxProcess(File file) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.setNodeFactory(new PlaceholderResolverJsonNodeFactory());
-		mapper.registerModule(new GuavaModule());
-		JmxProcess jmx = mapper.readValue(file, JmxProcess.class);
-		jmx.setName(file.getName());
-		return jmx;
-	}
+public interface IntegrationTest {
 }

--- a/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/SlowTest.java
+++ b/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/SlowTest.java
@@ -20,29 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.util;
+package com.googlecode.jmxtrans.test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.googlecode.jmxtrans.model.JmxProcess;
-
-import java.io.File;
-import java.io.IOException;
-
-public final class JsonUtils {
-
-	private JsonUtils() {}
-
-	/**
-	 * Uses jackson to load json configuration from a File into a full object
-	 * tree representation of that json.
-	 */
-	public static JmxProcess getJmxProcess(File file) throws IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.setNodeFactory(new PlaceholderResolverJsonNodeFactory());
-		mapper.registerModule(new GuavaModule());
-		JmxProcess jmx = mapper.readValue(file, JmxProcess.class);
-		jmx.setName(file.getName());
-		return jmx;
-	}
+public interface SlowTest {
 }

--- a/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/TCPEchoServer.java
+++ b/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/TCPEchoServer.java
@@ -20,23 +20,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.connections;
+package com.googlecode.jmxtrans.test;
 
 import com.google.common.io.Closer;
+import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkState;
 
-public class TCPEchoServer {
+public class TCPEchoServer extends ExternalResource {
 
 	private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -44,6 +47,16 @@ public class TCPEchoServer {
 	private volatile ServerSocket server;
 
 	private final Object startSynchro = new Object();
+
+	@Override
+	public void before() {
+		start();
+	}
+
+	@Override
+	protected void after() {
+		stop();
+	}
 
 	public void start() {
 		if (thread != null) {
@@ -88,8 +101,8 @@ public class TCPEchoServer {
 			synchronized (startSynchro) {
 				startSynchro.notifyAll();
 			}
-			BufferedReader in = closer.register(new BufferedReader(new InputStreamReader(socket.getInputStream())));
-			PrintWriter out = closer.register(new PrintWriter(socket.getOutputStream()));
+			BufferedReader in = closer.register(new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8)));
+			PrintWriter out = closer.register(new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), UTF_8)));
 			String line;
 			while ((line = in.readLine()) != null) {
 				out.print(line);

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
 		<module>jmxtrans-output</module>
 		<module>jmxtrans-examples</module>
 		<module>jmxtrans-core</module>
+		<module>jmxtrans-test-utils</module>
 	</modules>
 
 	<scm>
@@ -195,6 +196,11 @@
 				<groupId>com.fasterxml.jackson.datatype</groupId>
 				<artifactId>jackson-datatype-guava</artifactId>
 				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.chrisvest</groupId>
+				<artifactId>stormpot</artifactId>
+				<version>2.4</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>
@@ -429,6 +435,12 @@
 				<scope>runtime</scope>
 			</dependency>
 			<dependency>
+				<groupId>com.jayway.awaitility</groupId>
+				<artifactId>awaitility</artifactId>
+				<version>1.6.5</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>4.12</version>
@@ -451,6 +463,26 @@
 				<groupId>org.hamcrest</groupId>
 				<artifactId>hamcrest-library</artifactId>
 				<version>1.3</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jmxtrans</groupId>
+				<artifactId>jmxtrans-core</artifactId>
+				<version>${project.version}</version>
+				<type>test-jar</type>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jmxtrans</groupId>
+				<artifactId>jmxtrans-test-utils</artifactId>
+				<version>${project.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.jmxtrans</groupId>
+				<artifactId>jmxtrans-utils</artifactId>
+				<version>${project.version}</version>
+				<type>test-jar</type>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Having OutputWriter implemented directly as Json beans tends to encourage
breaking the single responsibility principle. The creation logic of
OutputWriters tends to be more complex than what is reasonable to put in a
constructor. Further more, having factories for OutputWriter will help use
more composition and less inheritance, which should help increase code reuse
between OutputWriters.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/345?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/345'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>