### PR TITLE
added query_defaults feature to yaml2jmxtrans.py

### DIFF
--- a/jmxtrans/doc/tools/yaml2jmxtrans-example.yaml
+++ b/jmxtrans/doc/tools/yaml2jmxtrans-example.yaml
@@ -36,6 +36,10 @@ outputWriters:
 # Global port to query JMX on
 query_port: 5400
 
+# Default query attributes, may be overridden by the query definition
+query_defaults:
+  allowDottedKeys: true
+
 # Query definitions, every query needs obj, resultAlias, attr
 #   from jmxtrans format, "name" must be given for referencing
 #   the query in host sets

--- a/jmxtrans/tools/yaml2jmxtrans.py
+++ b/jmxtrans/tools/yaml2jmxtrans.py
@@ -51,13 +51,16 @@ class Queries(object):
     """
     Generate query object snippets suitable for consumption by jmxtrans
     """
-    def __init__(self, queries, query_attributes, outputWriters, outputWriters_attributes, monitor_host, monitor_port):
+    def __init__(self, queries, query_attributes, query_defaults,
+            outputWriters, outputWriters_attributes, monitor_host,
+            monitor_port):
         """
         Initialize Queries configuration with data from YAML structure, making
         named queries accessible by name
         """
         self.queries = {}
         self.query_attributes = query_attributes
+        self.query_defaults = query_defaults
         self.outputWriters = []
         self.outputWriters_attributes = outputWriters_attributes
         self.monitor_host = monitor_host
@@ -68,6 +71,8 @@ class Queries(object):
             for attribute in query_attributes:
                 if attribute in query:
                     queryentry[attribute] = query[attribute]
+                elif attribute in query_defaults:
+                    queryentry[attribute] = query_defaults[attribute]
                 else:
                     queryentry[attribute] = None
             self.queries[query['name']] = queryentry
@@ -265,7 +270,8 @@ if __name__ == '__main__':
     graphite_host = yf['graphite_host'] if ('graphite_host' in yf) else None
     graphite_port = yf['graphite_port'] if ('graphite_port' in yf) else None
 
-    q = Queries(yf['queries'], query_attributes, outputWriters, outputWriters_attributes, graphite_host, graphite_port)
+    q = Queries(yf['queries'], query_attributes, yf.get('query_defaults', {}),
+        outputWriters, outputWriters_attributes, graphite_host, graphite_port)
     h = HostSets(yf['sets'])
 
     for set_name in h.set_names():


### PR DESCRIPTION
I added support for default query attributes in YAML configuration.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/347%23issuecomment-151883703%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/347%23issuecomment-151883703%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good%20to%20me.%5Cr%5Cn%5Cr%5CnCould%20you%20add%20an%20example%20into%20https%3A//github.com/jmxtrans/jmxtrans/tree/master/jmxtrans/doc/tools%20%3F%22%2C%20%22created_at%22%3A%20%222015-10-28T15%3A32%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/347#issuecomment-151883703'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Looks good to me.
Could you add an example into https://github.com/jmxtrans/jmxtrans/tree/master/jmxtrans/doc/tools ?


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/347?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/347?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/347'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>