### PR TITLE
Sensu writer now uses TcpOutputWriter

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
@@ -1,0 +1,85 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
+import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.TcpOutputWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.net.InetSocketAddress;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
+
+/**
+ * This low latency and thread safe output writer sends data to a host/port combination
+ * in the Graphite format.
+ *
+ * @see <a href="http://graphite.wikidot.com/getting-your-data-into-graphite">Getting your data into Graphite</a>
+ */
+@ThreadSafe
+public class GraphiteWriterFactory implements OutputWriterFactory {
+
+	private static final String DEFAULT_ROOT_PREFIX = "servers";
+
+	private final String rootPrefix;
+	private final InetSocketAddress graphiteServer;
+	private final ImmutableList<String> typeNames;
+	private final boolean booleanAsNumber;
+
+	@JsonCreator
+	public GraphiteWriterFactory(
+			@JsonProperty("typeNames") ImmutableList<String> typeNames,
+			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
+			@JsonProperty("rootPrefix") String rootPrefix,
+			@JsonProperty("host") String host,
+			@JsonProperty("port") Integer port) {
+		this.typeNames = typeNames;
+		this.booleanAsNumber = booleanAsNumber;
+		this.rootPrefix = firstNonNull(rootPrefix, DEFAULT_ROOT_PREFIX);
+
+		this.graphiteServer = new InetSocketAddress(
+				checkNotNull(host, "Host cannot be null."),
+				checkNotNull(port, "Port cannot be null."));
+	}
+
+	@Override
+	public OutputWriter create() {
+		return ResultTransformerOutputWriter.booleanToNumber(
+				booleanAsNumber,
+				TcpOutputWriter.builder(graphiteServer, new GraphiteWriter2(typeNames, rootPrefix))
+						.setCharset(UTF_8)
+						.build()
+		);
+	}
+
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
@@ -29,8 +29,6 @@ import com.googlecode.jmxtrans.model.OutputWriter;
 import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter;
 import com.googlecode.jmxtrans.model.output.support.TcpOutputWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.net.InetSocketAddress;
@@ -38,7 +36,6 @@ import java.net.InetSocketAddress;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
 
 /**
  * This low latency and thread safe output writer sends data to a host/port combination

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/SensuWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/SensuWriter2.java
@@ -1,0 +1,72 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.output.support.WriterBasedOutputWriter;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+public class SensuWriter2 implements WriterBasedOutputWriter {
+
+	@Nonnull private final GraphiteWriter2 graphiteWriter;
+	@Nonnull private final JsonFactory jsonFactory;
+
+	public SensuWriter2(@Nonnull GraphiteWriter2 graphiteWriter, @Nonnull JsonFactory jsonFactory) {
+		this.graphiteWriter = graphiteWriter;
+		this.jsonFactory = jsonFactory;
+	}
+
+	@Override
+	public void write(@Nonnull Writer writer, @Nonnull Server server, @Nonnull Query query, @Nonnull ImmutableList<Result> results) throws IOException {
+		Closer closer = Closer.create();
+		try {
+			JsonGenerator g = closer.register(jsonFactory.createGenerator(writer));
+			g.useDefaultPrettyPrinter();
+			g.writeStartObject();
+			g.writeStringField("name", "jmxtrans");
+			g.writeStringField("type", "metric");
+			g.writeStringField("handler", "graphite");
+
+			StringWriter temporaryWriter = closer.register(new StringWriter());
+			graphiteWriter.write(temporaryWriter, server, query, results);
+
+			g.writeStringField("output", temporaryWriter.toString());
+			g.writeEndObject();
+			g.flush();
+		} catch (Throwable t) {
+			closer.rethrow(t);
+		} finally {
+			closer.close();
+		}
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/SensuWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/SensuWriterFactory.java
@@ -1,0 +1,72 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
+import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.TcpOutputWriter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.InetSocketAddress;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+public class SensuWriterFactory implements OutputWriterFactory {
+
+	private final boolean booleanAsNumber;
+	@Nonnull private final InetSocketAddress server;
+	@Nonnull private final ImmutableList<String> typeNames;
+	@Nullable private final String rootPrefix;
+
+	public SensuWriterFactory(
+			@JsonProperty("typeNames") ImmutableList<String> typeNames,
+			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
+			@JsonProperty("host") String host,
+			@JsonProperty("port") Integer port,
+			@JsonProperty("rootPrefix") String rootPrefix) {
+		this.rootPrefix = rootPrefix;
+		this.typeNames = firstNonNull(typeNames, ImmutableList.<String>of());
+		this.booleanAsNumber = booleanAsNumber;
+		this.server = new InetSocketAddress(
+				firstNonNull(host, "localhost"),
+				firstNonNull(port, 3030));
+	}
+
+	@Override
+	public OutputWriter create() {
+		return ResultTransformerOutputWriter.booleanToNumber(
+				booleanAsNumber,
+				TcpOutputWriter.builder(
+						server,
+						new SensuWriter2(
+								new GraphiteWriter2(typeNames, rootPrefix),
+								new JsonFactory()))
+						.build());
+	}
+
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/SensuWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/SensuWriter2Test.java
@@ -22,33 +22,34 @@
  */
 package com.googlecode.jmxtrans.model.output;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.google.common.collect.ImmutableList;
-import com.googlecode.jmxtrans.model.output.support.WriterBasedOutputWriter;
+import com.googlecode.jmxtrans.model.QueryFixtures;
+import com.googlecode.jmxtrans.model.ResultFixtures;
+import com.googlecode.jmxtrans.model.ServerFixtures;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringWriter;
 
-import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
-import static com.googlecode.jmxtrans.model.ResultFixtures.dummyResults;
-import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class GraphiteWriter2Test {
+public class SensuWriter2Test {
 
 	@Test
-	public void correctFormatIsSentToGraphite() throws IOException {
-		WriterBasedOutputWriter outputWriter = new GraphiteWriter2(ImmutableList.<String>of(), "servers");
+	public void metricsAreFormattedCorrectly() throws IOException {
 		StringWriter writer = new StringWriter();
+		SensuWriter2 sensuWriter = new SensuWriter2(new GraphiteWriter2(ImmutableList.<String>of(), null), new JsonFactory());
 
-		outputWriter.write(writer, dummyServer(), dummyQuery(), dummyResults());
+		sensuWriter.write(writer, ServerFixtures.dummyServer(), QueryFixtures.dummyQuery(), ResultFixtures.dummyResults());
 
-		String graphiteLine = writer.toString();
-		assertThat(graphiteLine)
-				.hasLineCount(1)
-				.startsWith("servers")
-				.contains("example_net_4321")
-				.endsWith(" 10 0\n");
+		assertThat(writer.toString()).isEqualTo(
+				"{\n" +
+				"  \"name\" : \"jmxtrans\",\n" +
+				"  \"type\" : \"metric\",\n" +
+				"  \"handler\" : \"graphite\",\n" +
+				"  \"output\" : \"host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount 10 0\\n\"\n" +
+				"}");
 	}
 
 }


### PR DESCRIPTION
Minor refactoring to GraphiteWriter2
Sensu writer uses the Graphite format, so it should reuse the GraphiteOutputWriter
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/356?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/356'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>