### PR TITLE
Use 'alias' when provided, don't send NaN values.

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -235,6 +235,14 @@ public class Server {
 		return url.substring(url.lastIndexOf("//") + 2, url.lastIndexOf(':'));
 	}
 
+	public String getSource() {
+		if (alias != null) {
+			return alias;
+		}
+
+		return this.getHost();
+	}
+
 	public String getPort() {
 		if (port == null && url == null) {
 			return null;

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -156,10 +156,10 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 		for (Result result : results) {
 
 			HashMap<String, Object> filteredValues = new HashMap(Maps.filterValues(result.getValues(), isNotNaN));
-			filteredValues.put("_jmx_port", Integer.parseInt(server.getPort()));
 
 			// send the point if filteredValues isn't empty
-			if (filteredValues.size() > 1) {
+			if (!filteredValues.isEmpty()) {
+				filteredValues.put("_jmx_port", Integer.parseInt(server.getPort()));
 				Map<String, String> resultTagsToApply = buildResultTagMap(result);
 				Point point = Point.measurement(result.getKeyAlias()).time(result.getEpoch(), MILLISECONDS)
 						.tag(resultTagsToApply).fields(filteredValues).build();

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -88,7 +88,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 		this.resultAttributesToWriteAsTags = resultAttributesToWriteAsTags;
 	}
 
-	Predicate<Object> isNaN = new Predicate<Object>() {
+	Predicate<Object> isNotNaN = new Predicate<Object>() {
 		@Override
 		public boolean apply(Object input) {
 			return !input.toString().equals("NaN");
@@ -155,7 +155,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 
 		for (Result result : results) {
 
-			HashMap<String, Object> filteredValues = new HashMap(Maps.filterValues(result.getValues(), isNaN));
+			HashMap<String, Object> filteredValues = new HashMap(Maps.filterValues(result.getValues(), isNotNaN));
 			filteredValues.put("_jmx_port", Integer.parseInt(server.getPort()));
 
 			// send the point if filteredValues isn't empty

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -151,6 +151,8 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 		for (Result result : results) {
 			// we'll create a copy of result values here
 			Map<String, Object> fixedValues = new HashMap<String,Object>();
+			// _jmx_port as a field so we can filter on it in influx
+			fixedValues.put("_jmx_port", Integer.parseInt(server.getPort()));
 			// clean up an NaN values in values
 			Map<String, Object> resultValues = result.getValues();
 			if (resultValues != null) {
@@ -162,7 +164,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 				}
 			}
 			// send the point if fixedValues isn't empty
-			if (fixedValues.size() > 0) {
+			if (fixedValues.size() > 1) {
 				Map<String, String> resultTagsToApply = buildResultTagMap(result);
 				Point point = Point.measurement(result.getKeyAlias()).time(result.getEpoch(), MILLISECONDS)
 						.tag(resultTagsToApply).fields(fixedValues).build();


### PR DESCRIPTION
If 'alias' is specified it should be used as the hostname.  

JMX values sometimes come back as NaN, which result in the following:

    java.lang.RuntimeException: unable to parse 'cassandra.cql,attributeName=Value,className=org.apache.cassandra.metrics.CassandraMetricsRegistry$JmxGauge,hostname=will-macbook,typeName=type\=Cache\,scope\=RowCache\,name\=HitRate Value=� 1447690865696000000': invalid boolean

    at org.influxdb.impl.InfluxDBErrorHandler.handleError(InfluxDBErrorHandler.java:19) ~[jmxtrans-252-SNAPSHOT-all.jar:na]
    at retrofit.RestAdapter$RestHandler.invoke(RestAdapter.java:242) ~[jmxtrans-252-SNAPSHOT-all.jar:na]
    at org.influxdb.impl.$Proxy19.writePoints(Unknown Source) ~[na:na]
    at org.influxdb.impl.InfluxDBImpl.write(InfluxDBImpl.java:156) ~[jmxtrans-252-SNAPSHOT-all.jar:na]
    at com.googlecode.jmxtrans.model.output.InfluxDbWriter.doWrite(InfluxDbWriter.java:148) ~[jmxtrans-252-SNAPSHOT-all.jar:na]
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45067715%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45068702%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45069233%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23issuecomment-157395294%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45085544%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45085676%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45126982%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45127215%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45127951%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45129115%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45130556%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23issuecomment-157395294%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good.%20I%20have%20only%20a%20few%20minor%20comments%20%28see%20inline%29.%20I%20would%20appreciate%20if%20you%20could%20address%20them.%5Cr%5Cn%5Cr%5CnA%20unit%20test%20for%20the%20filtering%20of%20NaN%20values%20would%20be%20welcomed%21%22%2C%20%22created_at%22%3A%20%222015-11-17T15%3A03%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20edc8e419b5957478a9e1f53a8fe42c16483a83a4%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45127215%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20condition%20should%20probably%20be%20%60if%20%28%21filteredValues.isEmpty%28%29%29%60.%20Or%20at%20least%20correct%20the%20boundary%20by%20%60%3E%200%60%20or%20%60%3E%3D%201%60.%22%2C%20%22created_at%22%3A%20%222015-11-17T21%3A53%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%3AL151-187%22%7D%2C%20%22Pull%20d30424c32702e416342f6189af1fb94eab33a587%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%2070%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45067715%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22That%27s%20probably%20something%20that%20should%20be%20moved%20directly%20on%20the%20%60Server%60%20class.%20The%20same%20kind%20of%20behaviour%20should%20be%20used%20for%20most%20output%20writers.%22%2C%20%22created_at%22%3A%20%222015-11-17T14%3A49%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22getSource%20moved%20to%20the%20Server%20class%20and%20InfluxDbWriter%20updated%20accordingly.%22%2C%20%22created_at%22%3A%20%222015-11-17T16%3A54%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7266099%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/willmpls%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%3AL181-193%22%7D%2C%20%22Pull%20edc8e419b5957478a9e1f53a8fe42c16483a83a4%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45126982%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20predicate%20should%20probably%20be%20called%20%60isNotNaN%60%20to%20match%20its%20implementation.%22%2C%20%22created_at%22%3A%20%222015-11-17T21%3A51%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20true%21%20%20Fixed.%22%2C%20%22created_at%22%3A%20%222015-11-17T21%3A57%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7266099%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/willmpls%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%3AL88-101%22%7D%2C%20%22Pull%209699f3c5109f2b76dff6265bc5a8574d48070f80%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45129115%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20read%20that%20too%20fast%20...%20I%27d%20prefer%20moving%20the%20part%20about%20%60_jmx_port%60%20inside%20the%20%60if%60.%20That%20way%20we%20can%20use%20an%20%60isEmpty%28%29%60%20which%20is%20a%20bit%20more%20clear%20IMHO.%20Does%20it%20make%20sense%20to%20you%20%3F%22%2C%20%22created_at%22%3A%20%222015-11-17T22%3A06%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%20that%20makes%20perfect%20sense%20and%20agreed%20on%20the%20clarity.%20%20Latest%20commit%20reflects%20the%20updates.%20%20Thanks%21%22%2C%20%22created_at%22%3A%20%222015-11-17T22%3A16%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7266099%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/willmpls%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%3AL151-187%22%7D%2C%20%22Pull%20d30424c32702e416342f6189af1fb94eab33a587%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45068702%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60result.getValues%28%29%60%20is%20tagged%20%60%20%40Nonnull%60%2C%20so%20the%20null%20check%20should%20be%20removed%20%28I%20know%2C%20it%20was%20there%20already%2C%20but%20code%20should%20be%20cleaner%20every%20time%20we%20touch%20it...%29%22%2C%20%22created_at%22%3A%20%222015-11-17T14%3A56%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22null%20check%20removed%22%2C%20%22created_at%22%3A%20%222015-11-17T16%3A53%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7266099%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/willmpls%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%3AL142-176%22%7D%2C%20%22Pull%20d30424c32702e416342f6189af1fb94eab33a587%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/360%23discussion_r45069233%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20actually%20implementing%20a%20filtering%20of%20the%20%60resultValues%60.%20Implementation%20would%20be%20more%20readable%20by%20using%20%5BGuava%27s%20%60Maps.filterEntries%28%29%60%5D%28http%3A//docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/collect/Maps.html%23filterEntries%28java.util.Map%2C%2520com.google.common.base.Predicate%29%29%22%2C%20%22created_at%22%3A%20%222015-11-17T15%3A00%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%3AL142-176%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull d30424c32702e416342f6189af1fb94eab33a587 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java 70'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/360#discussion_r45067715'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java:L181-193</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> That's probably something that should be moved directly on the `Server` class. The same kind of behaviour should be used for most output writers.
- <a href='https://github.com/willmpls'><img border=0 src='https://avatars.githubusercontent.com/u/7266099?v=3' height=16 width=16'></a> getSource moved to the Server class and InfluxDbWriter updated accordingly.
- [x] <a href='#crh-comment-Pull d30424c32702e416342f6189af1fb94eab33a587 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java 45'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/360#discussion_r45068702'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java:L142-176</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> `result.getValues()` is tagged ` @Nonnull`, so the null check should be removed (I know, it was there already, but code should be cleaner every time we touch it...)
- <a href='https://github.com/willmpls'><img border=0 src='https://avatars.githubusercontent.com/u/7266099?v=3' height=16 width=16'></a> null check removed
- [x] <a href='#crh-comment-Pull d30424c32702e416342f6189af1fb94eab33a587 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java 47'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/360#discussion_r45069233'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java:L142-176</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This is actually implementing a filtering of the `resultValues`. Implementation would be more readable by using [Guava's `Maps.filterEntries()`](http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/collect/Maps.html#filterEntries(java.util.Map,%20com.google.common.base.Predicate))
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/360#issuecomment-157395294'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Looks good. I have only a few minor comments (see inline). I would appreciate if you could address them.
A unit test for the filtering of NaN values would be welcomed!
- [x] <a href='#crh-comment-Pull edc8e419b5957478a9e1f53a8fe42c16483a83a4 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/360#discussion_r45126982'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java:L88-101</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This predicate should probably be called `isNotNaN` to match its implementation.
- <a href='https://github.com/willmpls'><img border=0 src='https://avatars.githubusercontent.com/u/7266099?v=3' height=16 width=16'></a> Ah true!  Fixed.
- [x] <a href='#crh-comment-Pull edc8e419b5957478a9e1f53a8fe42c16483a83a4 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java 62'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/360#discussion_r45127215'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java:L151-187</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This condition should probably be `if (!filteredValues.isEmpty())`. Or at least correct the boundary by `> 0` or `>= 1`.
- [x] <a href='#crh-comment-Pull 9699f3c5109f2b76dff6265bc5a8574d48070f80 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java 62'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/360#discussion_r45129115'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java:L151-187</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I read that too fast ... I'd prefer moving the part about `_jmx_port` inside the `if`. That way we can use an `isEmpty()` which is a bit more clear IMHO. Does it make sense to you ?
- <a href='https://github.com/willmpls'><img border=0 src='https://avatars.githubusercontent.com/u/7266099?v=3' height=16 width=16'></a> Yep that makes perfect sense and agreed on the clarity.  Latest commit reflects the updates.  Thanks!


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/360?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/360?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/360'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>