### PR TITLE
Tag support for Kafka output writer, use tag instead of field for _jmx_port influxdb output writer

### DIFF
--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -156,8 +156,8 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 
 			// send the point if filteredValues isn't empty
 			if (!filteredValues.isEmpty()) {
+				filteredValues.put("_jmx_port", Integer.parseInt(server.getPort()));
 				Map<String, String> resultTagsToApply = buildResultTagMap(result);
-				resultTagsToApply.put("_jmx_port", server.getPort());
 				Point point = Point.measurement(result.getKeyAlias()).time(result.getEpoch(), MILLISECONDS)
 						.tag(resultTagsToApply).fields(filteredValues).build();
 				batchPoints.point(point);

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -156,8 +156,8 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 
 			// send the point if filteredValues isn't empty
 			if (!filteredValues.isEmpty()) {
-				filteredValues.put("_jmx_port", Integer.parseInt(server.getPort()));
 				Map<String, String> resultTagsToApply = buildResultTagMap(result);
+				resultTagsToApply.put("_jmx_port", server.getPort());
 				Point point = Point.measurement(result.getKeyAlias()).time(result.getEpoch(), MILLISECONDS)
 						.tag(resultTagsToApply).fields(filteredValues).build();
 				batchPoints.point(point);

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -71,19 +71,21 @@ public class KafkaWriterTests {
 		assertThat(message.message())
 				.contains("\"keyspace\":\"rootPrefix.host_123.classNameAlias.attributeName_key\"")
 				.contains("\"value\":\"1\"")
-				.contains("\"timestamp\":0");
+				.contains("\"timestamp\":0")
+				.contains("\"tags\":{\"myTagKey1\":\"myTagValue1\"");
 	}
 	
 	private static KafkaWriter getTestKafkaWriter() {
 		ImmutableList typenames = ImmutableList.of();
 		Map<String,Object> settings = new HashMap<String,Object>();
+		ImmutableMap<String, String> tags = ImmutableMap.of("myTagKey1", "myTagValue1"); 
 		settings.put("zk.connect", "host:2181");
 		settings.put("metadata.broker.list", "10.231.1.1:9180");
 		settings.put("serializer.class", "kafka.serializer.StringEncoder");
 		settings.put("debug", false);
 		settings.put("booleanAsNumber", true);
 		settings.put("topics", "myTopic");
-		return new KafkaWriter(typenames, true, "rootPrefix", true, "myTopic", settings);
+		return new KafkaWriter(typenames, true, "rootPrefix", true, "myTopic", tags, settings);
 	}
 	
 }


### PR DESCRIPTION
Support for adding arbitrary tags to the JSON output generated by the Kafka output writer.  Operates in similar fashion to the OpenTSDB output writer.

Also updating InfluxDB writer to set _jmx_port as a tag instead of field, per [open issue #371] (https://github.com/jmxtrans/jmxtrans/issues/371).
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23issuecomment-165876734%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23issuecomment-165888936%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23discussion_r48059830%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23discussion_r48060858%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23discussion_r48064475%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23discussion_r48065257%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23discussion_r48065338%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23discussion_r48065339%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23issuecomment-165876734%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good.%20Failing%20unit%20test%20should%20be%20fixed%20and%20an%20additional%20test%20on%20the%20Kafka%20writer%20should%20be%20written.%5Cr%5Cn%5Cr%5CnWould%20you%20have%20time%20to%20send%20the%20fixes%3F%22%2C%20%22created_at%22%3A%20%222015-12-18T19%3A26%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-18T20%3A16%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201d7203d0e2d53ed6320c1f82eb1e0ea6cb0918c4%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23discussion_r48060858%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20a%20change%20of%20behaviour.%20I%27d%20much%20prefer%20if%20it%20was%20controlled%20by%20a%20flag%20so%20that%20the%20current%20behaviour%20is%20preserved%20by%20default%20and%20the%20new%20behaviour%20can%20be%20enabled%20for%20users%20who%20want%20it.%5Cr%5Cn%5Cr%5CnIf%20you%20think%20that%20the%20current%20behaviour%20does%20not%20make%20sense%20and%20that%20%60_jmx_port%60%20should%20only%20be%20published%20as%20a%20tag%2C%20than%20add%20a%20warn%20log%20message%20so%20that%20users%20can%20update%20their%20configuration.%22%2C%20%22created_at%22%3A%20%222015-12-18T19%3A33%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Agreed%20that%20this%20one%20could%20be%20disruptive.%20%20I%20removed%20it%20from%20the%20latest%20commit%20and%20will%20submit%20the%20change%20as%20a%20separate%20PR%20once%20I%27ve%20re-implemented%20it.%20%20I%27ll%20add%20a%20setting/flag%20as%20you%20mentioned%20to%20allow%20users%20to%20specify%20whether%20it%27s%20added%20as%20a%20field%20or%20a%20tag.%22%2C%20%22created_at%22%3A%20%222015-12-18T20%3A07%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7266099%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/willmpls%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-18T20%3A16%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%3AL156-164%22%7D%2C%20%22Pull%201d7203d0e2d53ed6320c1f82eb1e0ea6cb0918c4%20jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java%2059%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/377%23discussion_r48059830%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%27re%20missing%20a%20unit%20test%20for%20this%20additional%20feature.%22%2C%20%22created_at%22%3A%20%222015-12-18T19%3A24%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Kafka%20tests%20updated%20in%20latest%20commit.%20%20Thanks%21%22%2C%20%22created_at%22%3A%20%222015-12-18T20%3A15%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7266099%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/willmpls%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-12-18T20%3A16%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java%3AL142-153%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 1d7203d0e2d53ed6320c1f82eb1e0ea6cb0918c4 jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java 59'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/377#discussion_r48059830'>File: jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java:L142-153</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> We're missing a unit test for this additional feature.
- <a href='https://github.com/willmpls'><img border=0 src='https://avatars.githubusercontent.com/u/7266099?v=3' height=16 width=16'></a> Kafka tests updated in latest commit.  Thanks!
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/377#issuecomment-165876734'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Looks good. Failing unit test should be fixed and an additional test on the Kafka writer should be written.
Would you have time to send the fixes?
- [x] <a href='#crh-comment-Pull 1d7203d0e2d53ed6320c1f82eb1e0ea6cb0918c4 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/377#discussion_r48060858'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java:L156-164</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This is a change of behaviour. I'd much prefer if it was controlled by a flag so that the current behaviour is preserved by default and the new behaviour can be enabled for users who want it.
If you think that the current behaviour does not make sense and that `_jmx_port` should only be published as a tag, than add a warn log message so that users can update their configuration.
- <a href='https://github.com/willmpls'><img border=0 src='https://avatars.githubusercontent.com/u/7266099?v=3' height=16 width=16'></a> Agreed that this one could be disruptive.  I removed it from the latest commit and will submit the change as a separate PR once I've re-implemented it.  I'll add a setting/flag as you mentioned to allow users to specify whether it's added as a field or a tag.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/377?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/377?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/377'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>