### PR TITLE
Add dimensions to Metrics

### DIFF
--- a/jmxtrans-output/jmxtrans-output-cloudwatch/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/pom.xml
@@ -38,9 +38,9 @@
 	<description>This module contains output writers based on CloudWatch (AWS).</description>
 
 	<properties>
-		<verify.mutationThreshold>62</verify.mutationThreshold>
-		<verify.totalBranchRate>50</verify.totalBranchRate>
-		<verify.totalLineRate>67</verify.totalLineRate>
+		<verify.mutationThreshold>45</verify.mutationThreshold>
+		<verify.totalBranchRate>66</verify.totalBranchRate>
+		<verify.totalLineRate>80</verify.totalLineRate>
 	</properties>
 
 	<dependencies>
@@ -96,6 +96,21 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -113,6 +128,13 @@
 			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>-Dno.security.manager</argLine>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/jmxtrans-output/jmxtrans-output-cloudwatch/src/main/java/com/googlecode/jmxtrans/model/output/CloudWatchWriter.java
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/src/main/java/com/googlecode/jmxtrans/model/output/CloudWatchWriter.java
@@ -26,8 +26,10 @@ import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
+import com.amazonaws.util.EC2MetadataUtils;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -42,7 +44,11 @@ import com.googlecode.jmxtrans.util.ObjectToDouble;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -55,11 +61,13 @@ import static com.google.common.base.Strings.isNullOrEmpty;
  * @author <a href="mailto:sascha.moellering@gmail.com">Sascha Moellering</a>
  */
 public class CloudWatchWriter extends BaseOutputWriter {
-
+	private static final String NAME = "name";
+	private static final String VALUE = "value";
 	private static final Logger log = LoggerFactory.getLogger(CloudWatchWriter.class);
 
 	private AmazonCloudWatchClient cloudWatchClient;
 	private String namespace;
+	private Collection<Dimension> dimensions = new ArrayList<Dimension>();
 
 	private final ObjectToDouble toDoubleConverter = new ObjectToDouble();
 
@@ -69,9 +77,16 @@ public class CloudWatchWriter extends BaseOutputWriter {
 			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
 			@JsonProperty("debug") Boolean debugEnabled,
 			@JsonProperty("namespace") String namespace,
+			@JsonProperty("dimensions") Collection<Map<String,Object>> dimensions,
 			@JsonProperty("settings") Map<String, Object> settings) {
 		super(typeNames, booleanAsNumber, debugEnabled, settings);
 		this.namespace = MoreObjects.firstNonNull(namespace, (String) getSettings().get("namespace"));
+
+		dimensions = MoreObjects.firstNonNull(dimensions, (Collection<Map<String,Object>>)settings.get("dimensions"));
+		if (dimensions != null) {
+			initDimensions(dimensions);
+		}
+
 		if (isNullOrEmpty(this.namespace)) throw new IllegalArgumentException("namespace cannot be null or empty");
 	}
 
@@ -120,6 +135,37 @@ public class CloudWatchWriter extends BaseOutputWriter {
 		cloudWatchClient.putMetricData(metricDataRequest);
 	}
 
+	private void initDimensions(Collection<Map<String,Object>> dimensions) {
+		for (Map<String, Object> dimension : dimensions) {
+			String name = null;
+			String value = null;
+
+			if (dimension.containsKey(NAME)) {
+				name = dimension.get(NAME).toString();
+			}
+			if (dimension.containsKey(VALUE)) {
+				value = dimension.get(VALUE).toString();
+			}
+			if (name != null && value != null) {
+				if (value.startsWith("$")) {
+					try {
+						Method m = EC2MetadataUtils.class.getMethod("get" + value.substring(1));
+						value = String.valueOf(m.invoke(null));
+					} catch (NoSuchMethodException e) {
+						log.warn("Could not resolve {} via a getters on {}!", value, EC2MetadataUtils.class.getName());
+					} catch (IllegalAccessException e) {
+						log.warn("Could not load {} via a getters on {}!", value, EC2MetadataUtils.class.getName());
+					} catch (InvocationTargetException e) {
+						log.warn("Could not retrieve {} via a getters on {}!", value, EC2MetadataUtils.class.getName());
+					}
+				}
+				this.dimensions.add(new Dimension().withName(name).withValue(value));
+			} else {
+				log.warn("Incomplete dimension: Missing non-null '{}' and '{}' in '{}'", NAME, VALUE, dimension);
+			}
+		}
+	}
+
 	private MetricDatum processResult(Result result, Map.Entry<String, Object> values) {
 		// Sometimes the attribute name and the key of the value are the same
 		MetricDatum metricDatum = new MetricDatum();
@@ -128,6 +174,8 @@ public class CloudWatchWriter extends BaseOutputWriter {
 		} else {
 			metricDatum.setMetricName(result.getAttributeName() + "_" + values.getKey());
 		}
+
+		metricDatum.setDimensions(dimensions);
 
 		// Converts the Objects to Double-values for CloudWatch
 		metricDatum.setValue(toDoubleConverter.apply(values.getValue()));
@@ -143,6 +191,7 @@ public class CloudWatchWriter extends BaseOutputWriter {
 		private final ImmutableList.Builder<String> typeNames = ImmutableList.builder();
 		private boolean booleanAsNumber;
 		private Boolean debugEnabled;
+		private Collection<Map<String, Object>> dimensions;
 		private String namespace;
 
 		private Builder() {
@@ -167,9 +216,14 @@ public class CloudWatchWriter extends BaseOutputWriter {
 			this.debugEnabled = debugEnabled;
 			return this;
 		}
-		
+
 		public Builder setNamespace(String namespace) {
 			this.namespace = namespace;
+			return this;
+		}
+
+		public Builder setDimensions(Collection<Map<String, Object>> dimensions) {
+			this.dimensions = dimensions;
 			return this;
 		}
 
@@ -179,7 +233,8 @@ public class CloudWatchWriter extends BaseOutputWriter {
 					booleanAsNumber,
 					debugEnabled,
 					namespace,
-					null);
+					dimensions,
+					Collections.<String, Object>emptyMap());
 		}
 
 	}

--- a/jmxtrans-output/jmxtrans-output-cloudwatch/src/test/java/com/googlecode/jmxtrans/model/output/CloudWatchWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/src/test/java/com/googlecode/jmxtrans/model/output/CloudWatchWriterTests.java
@@ -22,89 +22,76 @@
  */
 package com.googlecode.jmxtrans.model.output;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.googlecode.jmxtrans.util.JsonUtils;
 import com.googlecode.jmxtrans.model.JmxProcess;
-import com.googlecode.jmxtrans.model.Query;
-import com.googlecode.jmxtrans.model.Result;
-import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.util.JsonUtils;
+import com.kaching.platform.testing.AllowDNSResolution;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static com.amazonaws.regions.Region.getRegion;
+import static com.amazonaws.regions.Regions.AP_NORTHEAST_1;
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.ResultFixtures.dummyResults;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 /**
  * Tests for {@link com.googlecode.jmxtrans.model.output.CloudWatchWriter}.
  *
  * @author <a href="mailto:sascha.moellering@gmail.com">Sascha Moellering</a>
  */
-@RunWith(MockitoJUnitRunner.class)
+@AllowDNSResolution
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CloudWatchWriter.class, Regions.class})
 public class CloudWatchWriterTests {
 
 	@Mock private AmazonCloudWatchClient cloudWatchClient;
 	@Captor private ArgumentCaptor<PutMetricDataRequest> requestCaptor;
-	private CloudWatchWriter writer;
+	private CloudWatchWriter.Writer writer;
 
-	private Server server;
-	private Query query;
-	private ImmutableList<Result> results;
+	@Before
+	public void mockAmazonAPI() throws Exception {
+		whenNew(AmazonCloudWatchClient.class)
+				.withAnyArguments()
+				.thenReturn(cloudWatchClient);
 
-	private Map<String, Object> createValidDimension(String name, Object value) {
-		Map<String, Object> returnValue = new HashMap<String, Object>();
-		returnValue.put("name", name);
-		returnValue.put("value", value);
-		return returnValue;
-	}
-
-	private Map<String, Object> createInvalidDimension(String name, Object value) {
-		Map<String, Object> returnValue = new HashMap<String, Object>();
-		returnValue.put("key", name);
-		returnValue.put("val", value);
-		return returnValue;
+		mockStatic(Regions.class);
+		when(Regions.getCurrentRegion()).thenReturn(getRegion(AP_NORTHEAST_1));
 	}
 
 	@Before
 	public void createCloudWatchWriter() {
-		Collection<Map<String, Object>> dimensions = new ArrayList<Map<String,Object>>();
-		dimensions.add(createValidDimension("SomeKey", "SomeValue"));
-		dimensions.add(createValidDimension("InstanceId", "$InstanceId"));
-		dimensions.add(createInvalidDimension("Other", "thing"));
+		ImmutableList<Dimension> dimensions = ImmutableList.of(
+				new Dimension().withName("SomeKey").withValue("SomeValue"),
+				new Dimension().withName("InstanceId").withValue("$InstanceId")
+		);
 
-		writer = CloudWatchWriter.builder().setNamespace("testNS").setDimensions(dimensions).build();
-		writer.setCloudWatchClient(cloudWatchClient);
-	}
-
-	@Before
-	public void createServerQueryAndResult() {
-		server = Server.builder().setHost("localhost").setPort("123").build();
-		query = Query.builder()
-				.setObj("test")
-				.build();
-		Result result = new Result(1, "attributeName", "className", "objDomain", null, "typeName", ImmutableMap.of("key", (Object) 1));
-		results = ImmutableList.of(result);
+		writer = new CloudWatchWriter.Writer("testNS", cloudWatchClient, dimensions);
 	}
 
 	@Test
 	public void testValidationWithoutSettings() throws Exception {
-		writer.doWrite(server, query, results);
+		writer.doWrite(dummyServer(), dummyQuery(), dummyResults());
 		verify(cloudWatchClient).putMetricData(requestCaptor.capture());
 
 		PutMetricDataRequest request = requestCaptor.getValue();
@@ -114,8 +101,8 @@ public class CloudWatchWriterTests {
 
 		assertThat(request.getMetricData()).hasSize(1);
 		MetricDatum metricDatum = request.getMetricData().get(0);
-		assertThat(metricDatum.getMetricName()).isEqualTo("attributeName_key");
-		assertThat(metricDatum.getValue()).isEqualTo(1);
+		assertThat(metricDatum.getMetricName()).isEqualTo("ObjectPendingFinalizationCount");
+		assertThat(metricDatum.getValue()).isEqualTo(10);
 		assertThat(metricDatum.getDimensions().size()).isEqualTo(2);
 		assertThat(metricDatum.getDimensions().get(0).getName()).isEqualTo("SomeKey");
 		assertThat(metricDatum.getDimensions().get(1).getName()).isEqualTo("InstanceId");

--- a/jmxtrans-output/jmxtrans-output-cloudwatch/src/test/resources/cloud-watch.json
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/src/test/resources/cloud-watch.json
@@ -15,7 +15,15 @@
                   {
                      "@class":"com.googlecode.jmxtrans.model.output.CloudWatchWriter",
                      "settings":{
-                        "namespace":"jmx"
+                        "namespace":"jmx",
+                        "dimensions":[
+                           {
+                              "name":"InstanceId",
+                              "value":"$InstanceId"
+                           },{
+                              "name":"SomeKey",
+                              "value":"SomeValue"
+                           }]
                      }
                   }
                ]

--- a/jmxtrans-output/jmxtrans-output-core/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-core/pom.xml
@@ -118,11 +118,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.jayway.awaitility</groupId>
-			<artifactId>awaitility</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
New PR to replace #373.

This patchset adds dimensions to the posted metrics in CloudWatch.
This allows to differ between different instances posting the same metrics.

For ease of deployment, EC2 metadata templates are supported from com.amazonaws.util.EC2MetadataUtils:

{
   "obj":"net.sf.ehcache:type=CacheStatistics,CacheManager=__DEFAULT__,name=MyCache",
   "attr":[
      "CacheHits",
      "CacheMisses",
      "ObjectCount"
   ],
   "resultAlias":"EHCache",
   "outputWriters":[
      {
         "@class":"com.googlecode.jmxtrans.model.output.CloudWatchWriter",
         "settings":{
            "namespace":"jmxtrans",
            "dimensions":[
               {
                  "name":"Cache",
                  "value":"MyCache"
               },
               {
                  "name":"InstanceId",
                  "value":"$InstanceId"
               }
            ]
         }
      }
   ]
}
Supported EC2 meta values are:

$PublicKey
$AmiId
$AmiLaunchIndex
$AmiManifestPath
$AncestorAmiIds
$InstanceAction
$InstanceId
$InstanceType
$LocalHostName
$MacAddress
$PrivateIpAddress
$AvailabilityZone
$ProductCodes
$RamdiskId
$ReservationId
$SecurityGroups
$IAMInstanceProfileInfo
$InstanceInfo
$EC2InstanceRegion
$IAMSecurityCredentials
$BlockDeviceMapping
$NetworkInterfaces
$UserData
$Items
$Data
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/378?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/378'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>