### PR TITLE
 "private" methods that don't access instance data should be "static"

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/HttpUrlConnectionConfigurer.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/HttpUrlConnectionConfigurer.java
@@ -65,7 +65,7 @@ public class HttpUrlConnectionConfigurer {
 		httpURLConnection.setRequestProperty("User-Agent", userAgent);
 	}
 
-	private boolean methodIsValid(String requestMethod) {
+	private static boolean methodIsValid(String requestMethod) {
 		return requestMethod != null
 				&& requestMethod.equals("POST");
 	}

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
@@ -174,7 +174,7 @@ public class InfluxDbWriterTests {
 		assertThat(process.getName()).isEqualTo("influxDB.json");
 	}
 
-	private String buildLineProtocol(String measurement, Map<String, String> expectedTags) {
+	private static String buildLineProtocol(String measurement, Map<String, String> expectedTags) {
 		StringBuilder sb = new StringBuilder(measurement).append(",");
 		int loops = 0;
 		int tagCount = expectedTags.size();

--- a/jmxtrans-output/jmxtrans-output-jrobin/src/main/java/com/googlecode/jmxtrans/model/output/RRDToolWriter.java
+++ b/jmxtrans-output/jmxtrans-output-jrobin/src/main/java/com/googlecode/jmxtrans/model/output/RRDToolWriter.java
@@ -316,7 +316,7 @@ public class RRDToolWriter extends BaseOutputWriter {
 	/**
 	 * If dbl is NaN, then return U
 	 */
-	private String formatDouble(double dbl) {
+	private static String formatDouble(double dbl) {
 		if (Double.isNaN(dbl)) {
 			return "U";
 		}

--- a/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/OutputCapture.java
+++ b/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/OutputCapture.java
@@ -61,7 +61,7 @@ public class OutputCapture extends ExternalResource {
 		return hasLineContaining(err, content);
 	}
 
-	private Callable<Boolean> hasLineContaining(final ByteArrayOutputStream out, final String content) {
+	private static Callable<Boolean> hasLineContaining(final ByteArrayOutputStream out, final String content) {
 		return new Callable<Boolean>() {
 			@Override
 			public Boolean call() throws Exception {

--- a/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/WatchDirTest.java
+++ b/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/WatchDirTest.java
@@ -109,7 +109,7 @@ public class WatchDirTest {
 		}
 	}
 
-	private void modifyFile(File toModify) throws IOException {
+	private static void modifyFile(File toModify) throws IOException {
 		OutputStream out = null;
 		try {
 			out = new FileOutputStream(toModify);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
Please let me know if you have any questions.
Kirill Vlasov
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/389?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/389'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>