### PR TITLE
Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Query.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Query.java
@@ -186,7 +186,7 @@ public class Query {
 		}
 
 		try {
-			if (attributes.size() > 0) {
+			if (!attributes.isEmpty()) {
 				logger.debug("Executing queryName [{}] from query [{}]", queryName.getCanonicalName(), this);
 
 				AttributeList al = mbeanServer.getAttributes(queryName, attributes.toArray(new String[attributes.size()]));
@@ -255,7 +255,7 @@ public class Query {
 		Set<String> typeNames = getTypeNames();
 		if (isUseAllTypeNames()) {
 			return new UseAllTypeNameValuesStringBuilder(separator);
-		} else if (typeNames != null && typeNames.size() > 0) {
+		} else if (typeNames != null && !typeNames.isEmpty()) {
 			return new PrependingTypeNameValuesStringBuilder(separator, new ArrayList<String>(typeNames));
 		} else {
 			return new TypeNameValuesStringBuilder(separator);

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/typename/TypeNameValuesStringBuilder.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/typename/TypeNameValuesStringBuilder.java
@@ -51,7 +51,7 @@ public class TypeNameValuesStringBuilder {
 	}
 
 	protected final String doBuild(List<String> typeNames, String typeNameStr) {
-		if ((typeNames == null) || (typeNames.size() == 0)) {
+		if ((typeNames == null) || (typeNames.isEmpty())) {
 			return null;
 		}
 		Map<String, String> typeNameValueMap = TypeNameValue.extractMap(typeNameStr);

--- a/jmxtrans-output/jmxtrans-output-jrobin/src/main/java/com/googlecode/jmxtrans/model/output/RRDToolWriter.java
+++ b/jmxtrans-output/jmxtrans-output-jrobin/src/main/java/com/googlecode/jmxtrans/model/output/RRDToolWriter.java
@@ -157,7 +157,7 @@ public class RRDToolWriter extends BaseOutputWriter {
 
 		doGenerate(results);
 
-		if (dataMap.keySet().size() > 0 && dataMap.values().size() > 0) {
+		if (!dataMap.keySet().isEmpty() && !dataMap.values().isEmpty()) {
 			rrdToolUpdate(StringUtils.join(dataMap.keySet(), ':'), StringUtils.join(dataMap.values(), ':'));
 		} else {
 			log.error("Nothing was logged for query: " + query);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
Please let me know if you have any questions.
Kirill Vlasov
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/391?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/391'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>