### PR TITLE
Fields modifiers convention fixes

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/PropertyResolver.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/PropertyResolver.java
@@ -45,9 +45,9 @@ import static com.google.common.collect.Maps.transformValues;
  */
 public class PropertyResolver {
 
-	private static PropertyResolverFunc RESOLVE_PROPERTIES = new PropertyResolverFunc();
+	private static final PropertyResolverFunc RESOLVE_PROPERTIES = new PropertyResolverFunc();
 
-	private static ObjectPropertyResolverFunc RESOLVE_OBJECT_PROPERTIES = new ObjectPropertyResolverFunc();
+	private static final ObjectPropertyResolverFunc RESOLVE_OBJECT_PROPERTIES = new ObjectPropertyResolverFunc();
 
 	/**
 	 * Resolve a property from System Properties (aka ${key}) key:defval is

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
@@ -79,9 +79,9 @@ public class InfluxDbWriterTests {
 	@Captor
 	private ArgumentCaptor<BatchPoints> messageCaptor;
 	
-	private ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL = ConsistencyLevel.ALL;
-	private String DEFAULT_RETENTION_POLICY = "default";
-	private ImmutableSet<ResultAttribute> DEFAULT_RESULT_ATTRIBUTES = immutableEnumSet(EnumSet.allOf(ResultAttribute.class));
+	private static final ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL = ConsistencyLevel.ALL;
+	private static final String DEFAULT_RETENTION_POLICY = "default";
+	private static final ImmutableSet<ResultAttribute> DEFAULT_RESULT_ATTRIBUTES = immutableEnumSet(EnumSet.allOf(ResultAttribute.class));
 
 	Result result = new Result(2l, "attributeName", "className", "objDomain", "keyAlias", "typeName",
 			ImmutableMap.of("key", (Object) 1));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S00116 - Field names should comply with a naming convention, 
squid:S3008 - Static non-final field names should comply with a naming convention
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S00116
https://dev.eclipse.org/sonar/coding_rules#q=squid:S3008
Please let me know if you have any questions.
Kirill Vlasov
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/392?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/392'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>