### PR TITLE
Add support for typeNames as tags in KafkaOutput, Kafka test updates

### DIFF
--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -64,7 +64,7 @@ public class KafkaWriterTests {
 
 		assertThat(message.topic()).isEqualTo("myTopic");
 		assertThat(message.message())
-				.contains("\"keyspace\":\"rootPrefix.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount\"")
+				.contains("\"keyspace\":\"rootPrefix.host_example_net_4321.ObjectPendingFinalizationCount\"")
 				.contains("\"value\":\"10\"")
 				.contains("\"timestamp\":0")
 				.contains("\"tags\":{\"myTagKey1\":\"myTagValue1\"");
@@ -80,7 +80,7 @@ public class KafkaWriterTests {
 		settings.put("debug", false);
 		settings.put("booleanAsNumber", true);
 		settings.put("topics", "myTopic");
-		return new KafkaWriter(typenames, true, "rootPrefix", true, "myTopic", tags, settings);
+		settings.put("typeNamesAsTags", true);
+		return new KafkaWriter(typenames, true, "rootPrefix", true, "myTopic", Boolean.FALSE, tags, settings);
 	}
-	
 }


### PR DESCRIPTION
Adding "typeNamesAsTags" property to allow sending type names as tags instead of embedding them in the the metric/key name for the Kafka output writer.  When set to false or not provided behavior defaults to previous so as to not break anything.