### PR TITLE
Stop re-pooling failed JMXConnections

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -232,12 +232,11 @@ public class Server implements JmxConnectionProvider {
 			for (ObjectName queryName : query.queryNames(connection)) {
 				results.addAll(query.fetchResults(connection, queryName));
 			}
+			pool.returnObject(this, jmxConnection);
 			return results.build();
 		} catch (Exception e) {
 			pool.invalidateObject(this, jmxConnection);
 			throw e;
-		} finally {
-			pool.returnObject(this, jmxConnection);
 		}
 	}
 


### PR DESCRIPTION
If a JMXConnection fails at some point (E.g.: JMX providing JVM dies),
the JMXConnection gets invalidated. Previously, we then tried to
re-pool this failed Connection. By keeping failed Connections in the
pool, future queries will again re-use the failed, pooled connection,
and again fail and re-pool the Connection. This behaviour effectively
means that if some JMX providing JVM is temporarily unavailable (e.g.:
gets restarted), jmxtrans stops getting metrics from it, even if the
JVM comes back, as jmxtrans is stuck on the failed, pooled
connections.

Hence, we no longer re-pool failed connections. Thereby, we try to
reconnect upon the next run, and will eventually start picking up
metrics from JMX providing JVMs once they come back.

Fixes #399
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/400%23issuecomment-171153825%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/400%23issuecomment-171315062%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/400%23discussion_r49619083%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/400%23issuecomment-171153825%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20a%20lot%20for%20the%20fix%21%20And%20sorry%20to%20have%20broken%20this%20in%20the%20first%20place.%20Any%20chance%20you%20could%20add%20a%20unit%20test%2C%20so%20it%20does%20not%20get%20broken%20again%3F%22%2C%20%22created_at%22%3A%20%222016-01-13T03%3A50%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Updated%20PR%20with%20tests%22%2C%20%22created_at%22%3A%20%222016-01-13T14%3A48%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3330451%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/somechris%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c99935ff334245de334dc168c9da5cd720a531f9%20jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java%2089%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/400%23discussion_r49619083%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20you%20could%20just%20create%20an%20%60IOException%60%20here%2C%20no%20need%20to%20mock.%22%2C%20%22created_at%22%3A%20%222016-01-13T17%3A11%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java%3AL251-325%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/400#issuecomment-171153825'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Thanks a lot for the fix! And sorry to have broken this in the first place. Any chance you could add a unit test, so it does not get broken again?
- <a href='https://github.com/somechris'><img border=0 src='https://avatars.githubusercontent.com/u/3330451?v=3' height=16 width=16'></a> Updated PR with tests
- [ ] <a href='#crh-comment-Pull c99935ff334245de334dc168c9da5cd720a531f9 jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java 89'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/400#discussion_r49619083'>File: jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java:L251-325</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I think you could just create an `IOException` here, no need to mock.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/400?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/400?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/400'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>