### PR TITLE
Re-use thread pool to enforce global thread limits

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/guice/JmxTransModule.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/guice/JmxTransModule.java
@@ -32,6 +32,7 @@ import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
 import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
@@ -115,6 +116,7 @@ public class JmxTransModule extends AbstractModule {
 	}
 
 	@Provides
+	@Singleton
 	@Named("queryProcessorExecutor")
 	ThreadPoolExecutor queryProcessorExecutor() {
 		int poolSize = configuration.getQueryProcessorExecutorPoolSize();
@@ -124,6 +126,7 @@ public class JmxTransModule extends AbstractModule {
 	}
 
 	@Provides
+	@Singleton
 	@Named("resultProcessorExecutor")
 	ThreadPoolExecutor resultProcessorExecutor() {
 		int poolSize = configuration.getResultProcessorExecutorPoolSize();


### PR DESCRIPTION
Each time when a ResultProcessor, JMXTransformer (or other classes
relying on the thread pools) got instantiated, new, fresh thread pools
got created along with it.

Since each instance had their own thread pool, the global thread
number limits was not enforced, and as a result the total, global
thread number increased way beyond the set pool sizes.
(E.g.: Despite a pool limits of 10 for query and 10 for result thread
pools, configuring jmxtrans to do a single query each 3 seconds gave
2000 active threads within 50 minutes.)

By turning the thread pools into singletons, Guice takes care of
re-using the existing thread pools and thereby, limits on thread
numbers are enforced.

Fixes #401
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/402?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/402'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>