### PR TITLE
Link unstable builds in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jmxtrans is very powerful tool which uses easily generated JSON (or [YAML](https
 
 The core engine is very solid and there are writers for [Graphite](http://graphite.wikidot.com/), [StatsD](https://github.com/etsy/statsd), [Ganglia](http://ganglia.sourceforge.net/), [cacti/rrdtool](http://www.cacti.net/), [OpenTSDB](http://opentsdb.net/), text files, and stdout. Feel free to suggest more on the discussion group or issue tracker.
 
-  * [Download a recent stable build](http://central.maven.org/maven2/org/jmxtrans/jmxtrans/)
+  * [Download a recent stable build](http://central.maven.org/maven2/org/jmxtrans/jmxtrans/) (or an [unstable one](https://oss.sonatype.org/content/repositories/snapshots/org/jmxtrans/jmxtrans/))
   * See the [Wiki](https://github.com/jmxtrans/jmxtrans/wiki) for full documentation.
   * Join the [Google Group](http://groups.google.com/group/jmxtrans) if you have anything to discuss or [follow the commits](http://groups.google.com/group/jmxtrans-commits). Please don't email Jon directly because he just doesn't have enough time to answer every question individually.
   * People are [talking - this is me! (skip to 21:45)](http://www.justin.tv/kctv88/b/290736874) and [talking](http://www.slideshare.net/cyrille.leclerc/paris-devops-monitoring-and-feature-toggle-pattern-with-jmx) and [talking (skip to 34:40)](http://www.justin.tv/kctv88/b/288229232) and [(french)](http://www.slideshare.net/henri.gomez/devops-retour-dexprience-marsjug-du-29-juin-2011 taking) about it.


### PR DESCRIPTION
Unstable builds were hard to find, as they were not linked in the
docs. By adding them to the README, we make sure people are aware that
they do not need to run their own builds if they want to run bleeding
edge.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/403?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/403'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>