### PR TITLE
Add error message on rejected execution

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jmx/ProcessQueryThread.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jmx/ProcessQueryThread.java
@@ -25,11 +25,15 @@ package com.googlecode.jmxtrans.jmx;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
+import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
 
+@ThreadSafe
+@ToString(exclude = {"resultProcessor"})
 public class ProcessQueryThread implements Runnable {
 
 	private final Logger log = LoggerFactory.getLogger(getClass());


### PR DESCRIPTION
If an executor service rejects an execution (all threads busy and work queue full) an error message is sent to the logs.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/409?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/409'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>