### PR TITLE
use standard tcp and udp writer for OpenTSDB

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/JexlNamingStrategy.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/JexlNamingStrategy.java
@@ -25,6 +25,7 @@ package com.googlecode.jmxtrans.model.naming;
 import com.googlecode.jmxtrans.model.NamingStrategy;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.naming.typename.TypeNameValue;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.jexl2.Expression;
 import org.apache.commons.jexl2.JexlContext;
 import org.apache.commons.jexl2.JexlEngine;
@@ -55,6 +56,8 @@ import java.util.Map;
  * <dd>the full Result object.</dd>
  * </dl>
  */
+
+@EqualsAndHashCode
 public class JexlNamingStrategy implements NamingStrategy {
 	private static final Logger LOG = LoggerFactory.getLogger(JexlNamingStrategy.class);
 

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriter.java
@@ -28,27 +28,18 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
-import com.googlecode.jmxtrans.model.NamingStrategy;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.ValidationException;
-import com.googlecode.jmxtrans.model.naming.ClassAttributeNamingStrategy;
-import com.googlecode.jmxtrans.model.naming.JexlNamingStrategy;
-import com.googlecode.jmxtrans.model.naming.typename.TypeNameValue;
-import org.apache.commons.jexl2.JexlException;
-import org.apache.commons.lang.StringUtils;
+import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
-
-import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
 
 /**
  * Originally written by Balazs Kossovics <bko@witbe.net>.  Common base class for OpenTSDBWriter and TCollectorWriter.
@@ -64,13 +55,8 @@ public abstract class OpenTSDBGenericWriter extends BaseOutputWriter {
 
 	protected final String host;
 	protected final Integer port;
-	protected final ImmutableMap<String, String> tags;
-	protected final String tagName;
-	protected final NamingStrategy metricNameStrategy;
 
-	protected final boolean mergeTypeNamesTags;
-	protected final boolean addHostnameTag;
-	protected final String hostnameTag;
+	protected final OpenTSDBMessageFormatter messageFormatter;
 
 	@JsonCreator
 	public OpenTSDBGenericWriter(
@@ -86,41 +72,30 @@ public abstract class OpenTSDBGenericWriter extends BaseOutputWriter {
 			@JsonProperty("addHostnameTag") Boolean addHostnameTag,
 			@JsonProperty("settings") Map<String, Object> settings) throws LifecycleException, UnknownHostException {
 		super(typeNames, booleanAsNumber, debugEnabled, settings);
+
 		this.host = MoreObjects.firstNonNull(host, (String) getSettings().get(HOST));
 		this.port = MoreObjects.firstNonNull(port, Settings.getIntegerSetting(getSettings(), PORT, null));
-		this.tags = ImmutableMap.copyOf(firstNonNull(
-				tags,
-				(Map<String, String>) getSettings().get("tags"),
-				ImmutableMap.<String, String>of()));
-		this.tagName = firstNonNull(tagName, (String) getSettings().get("tagName"), "type");
-		this.mergeTypeNamesTags = MoreObjects.firstNonNull(
-				mergeTypeNamesTags,
-				Settings.getBooleanSetting(this.getSettings(), "mergeTypeNamesTags", DEFAULT_MERGE_TYPE_NAMES_TAGS));
 
-		String jexlExpr = metricNamingExpression;
-		if (jexlExpr == null) {
-			jexlExpr = Settings.getStringSetting(this.getSettings(), "metricNamingExpression", null);
-		}
-		if (jexlExpr != null) {
-			try {
-				this.metricNameStrategy = new JexlNamingStrategy(jexlExpr);
-			} catch (JexlException jexlExc) {
-				throw new LifecycleException("failed to setup naming strategy", jexlExc);
-			}
-		} else {
-			this.metricNameStrategy = new ClassAttributeNamingStrategy();
+		if (metricNamingExpression == null) {
+			metricNamingExpression = Settings.getStringSetting(this.getSettings(), "metricNamingExpression", null);
 		}
 
-		this.addHostnameTag = firstNonNull(
+		addHostnameTag = firstNonNull(
 				addHostnameTag,
 				Settings.getBooleanSetting(this.getSettings(), "addHostnameTag", this.getAddHostnameTagDefault()),
 				getAddHostnameTagDefault());
 
-		if (this.addHostnameTag) {
-			hostnameTag = InetAddress.getLocalHost().getHostName();
-		} else {
-			hostnameTag = null;
-		}
+		messageFormatter = new OpenTSDBMessageFormatter(typeNames, ImmutableMap.copyOf(
+				firstNonNull(
+						tags,
+						(Map<String, String>) getSettings().get("tags"),
+						ImmutableMap.<String, String>of())),
+				firstNonNull(tagName, (String) getSettings().get("tagName"), "type"),
+				metricNamingExpression,
+				MoreObjects.firstNonNull(
+						mergeTypeNamesTags,
+						Settings.getBooleanSetting(this.getSettings(), "mergeTypeNamesTags", DEFAULT_MERGE_TYPE_NAMES_TAGS)),
+				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);
 	}
 
 	/**
@@ -162,129 +137,6 @@ public abstract class OpenTSDBGenericWriter extends BaseOutputWriter {
 	}
 
 	/**
-	 * Add tags to the given result string, including a "host" tag with the name of the server and all of the tags
-	 * defined in the "settings" entry in the configuration file within the "tag" element.
-	 *
-	 * @param resultString - the string containing the metric name, timestamp, value, and possibly other content.
-	 */
-	void addTags(StringBuilder resultString) {
-		if (addHostnameTag && hostnameTag != null) {
-			addTag(resultString, "host", hostnameTag);
-		}
-
-		if (tags != null) {
-			// Add the constant tag names and values.
-			for (Map.Entry<String, String> tagEntry : tags.entrySet()) {
-				addTag(resultString, tagEntry.getKey(), tagEntry.getValue());
-			}
-		}
-	}
-
-	/**
-	 * Add one tag, with the provided name and value, to the given result string.
-	 *
-	 * @param resultString - the string containing the metric name, timestamp, value, and possibly other content.
-	 * @return String - the new result string with the tag appended.
-	 */
-	void addTag(StringBuilder resultString, String tagName, String tagValue) {
-		resultString.append(" ");
-		resultString.append(sanitizeString(tagName));
-		resultString.append("=");
-		resultString.append(sanitizeString(tagValue));
-	}
-
-	/**
-	 * Format the result string given the class name and attribute name of the source value, the timestamp, and the
-	 * value.
-	 *
-	 * @param epoch - the timestamp of the metric.
-	 * @param value - value of the attribute to use as the metric value.
-	 * @return String - the formatted result string.
-	 */
-	void formatResultString(StringBuilder resultString, String metricName, long epoch, Object value) {
-		resultString.append(sanitizeString(metricName));
-		resultString.append(" ");
-		resultString.append(Long.toString(epoch));
-		resultString.append(" ");
-		resultString.append(sanitizeString(value.toString()));
-	}
-
-	/**
-	 * Parse one of the results of a Query and return a list of strings containing metric details ready for sending to
-	 * OpenTSDB.
-	 *
-	 * @param result - one results from the Query.
-	 * @return List<String> - the list of strings containing metric details ready for sending to OpenTSDB.
-	 */
-	List<String> resultParser(Result result) {
-		List<String> resultStrings = new LinkedList<String>();
-		Map<String, Object> values = result.getValues();
-
-		String attributeName = result.getAttributeName();
-
-		if (values.containsKey(attributeName) && values.size() == 1) {
-			processOneMetric(resultStrings, result, values.get(attributeName), null, null);
-		} else {
-			for (Map.Entry<String, Object> valueEntry : values.entrySet()) {
-				processOneMetric(resultStrings, result, valueEntry.getValue(), tagName, valueEntry.getKey());
-			}
-		}
-		return resultStrings;
-	}
-
-	/**
-	 * Process a single metric from the given JMX query result with the specified value.
-	 */
-	protected void processOneMetric(List<String> resultStrings, Result result, Object value, String addTagName,
-									String addTagValue) {
-		String metricName = this.metricNameStrategy.formatName(result);
-
-		//
-		// Skip any non-numeric values since OpenTSDB only supports numeric metrics.
-		//
-		if (isNumeric(value)) {
-			StringBuilder resultString = new StringBuilder();
-
-			formatResultString(resultString, metricName, result.getEpoch() / 1000L, value);
-			addTags(resultString);
-
-			if (addTagName != null) {
-				addTag(resultString, addTagName, addTagValue);
-			}
-
-			if (!getTypeNames().isEmpty()) {
-				this.addTypeNamesTags(resultString, result);
-			}
-
-			resultStrings.add(resultString.toString());
-		} else {
-			log.debug("Skipping non-numeric value for metric {}; value={}", metricName, value);
-		}
-	}
-
-	/**
-	 * Add the tag(s) for typeNames.
-	 *
-	 * @param result       - the result of the JMX query.
-	 * @param resultString - current form of the metric string.
-	 * @return String - the updated metric string with the necessary tag(s) added.
-	 */
-	protected void addTypeNamesTags(StringBuilder resultString, Result result) {
-		if (mergeTypeNamesTags) {
-			// Produce a single tag with all the TypeName keys concatenated and all the values joined with '_'.
-			addTag(resultString, StringUtils.join(getTypeNames(), ""), getConcatedTypeNameValues(result.getTypeName()));
-		} else {
-			Map<String, String> typeNameMap = TypeNameValue.extractMap(result.getTypeName());
-			for (String oneTypeName : getTypeNames()) {
-				String value = typeNameMap.get(oneTypeName);
-				if (value == null)
-					value = "";
-				addTag(resultString, oneTypeName, value);
-			}
-		}
-	}
-
-	/**
 	 * Write the results of the query.
 	 *
 	 * @param server
@@ -294,11 +146,9 @@ public abstract class OpenTSDBGenericWriter extends BaseOutputWriter {
 	@Override
 	public void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
 		this.startOutput();
-		for (Result result : results) {
-			for (String resultString : resultParser(result)) {
-				log.debug("Sending result: {}", resultString);
-				this.sendOutput(resultString);
-			}
+		for (String formattedResult : messageFormatter.formatResults(results)) {
+				log.debug("Sending result: {}", formattedResult);
+				this.sendOutput(formattedResult);
 		}
 		this.finishOutput();
 	}
@@ -324,19 +174,4 @@ public abstract class OpenTSDBGenericWriter extends BaseOutputWriter {
 		this.shutdownSender();
 	}
 
-	/**
-	 * VALID CHARACTERS:
-	 * METRIC, TAGNAME, AND TAG-VALUE:
-	 * [-_./a-zA-Z0-9]+
-	 * <p/>
-	 * <p/>
-	 * SANITIZATION:
-	 * - Discard Quotes.
-	 * - Replace all other invalid characters with '_'.
-	 */
-	protected String sanitizeString(String unsanitized) {
-		return unsanitized.
-				replaceAll("[\"']", "").
-				replaceAll("[^-_./a-zA-Z0-9]", "_");
-	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
@@ -74,6 +74,7 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 			@JsonProperty("settings") Map<String, Object> settings) throws LifecycleException, UnknownHostException {
 		super(typeNames, booleanAsNumber, debugEnabled, host, port, tags, tagName, mergeTypeNamesTags, metricNamingExpression,
 				addHostnameTag, settings);
+		log.warn("OpenTSDBWriter is deprecated. Please use OpenTSDBWriterFactory instead.");
 		if (host == null) {
 			host = (String) getSettings().get(HOST);
 		}
@@ -112,15 +113,9 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 		socket = pool.borrowObject(address);
 		writer = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), UTF_8), true);
 
-		for (Result result : results) {
-			log.debug("Query result: {}", result);
-			Map<String, Object> resultValues = result.getValues();
-			if (resultValues != null) {
-				for (String resultString : resultParser(result)) {
-					log.debug("OpenTSDB Message: {}", resultString);
-					writer.write("put " + resultString + "\n");
-				}
-			}
+		for (String formattedResult : messageFormatter.formatResults(results)) {
+			log.debug("OpenTSDB Message: {}", formattedResult);
+			writer.write("put " + formattedResult + "\n");
 		}
 
 	} catch (ConnectException e) {

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java
@@ -20,35 +20,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.model.naming;
+package com.googlecode.jmxtrans.model.output;
 
-import com.googlecode.jmxtrans.model.NamingStrategy;
+import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.output.support.WriterBasedOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
 
-/**
- * Strategy for naming metrics, tags, and the like given a result.
- */
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+import java.io.Writer;
 
-@EqualsAndHashCode
-public class ClassAttributeNamingStrategy implements NamingStrategy {
-	@Getter @Setter protected String delimiter = ".";
+@ThreadSafe
+public class OpenTSDBWriter2 implements WriterBasedOutputWriter {
+
+	private final OpenTSDBMessageFormatter messageFormatter;
+
+	public OpenTSDBWriter2(OpenTSDBMessageFormatter messageFormatter) {
+		this.messageFormatter = messageFormatter;
+	}
 
 	@Override
-	public String formatName(Result result) {
-		StringBuilder formatted = new StringBuilder();
-		String attName = result.getAttributeName();
-		String className = result.getKeyAlias();
+	public void write(@Nonnull final Writer writer, @Nonnull Server server, @Nonnull Query query, @Nonnull Iterable<Result> results) throws IOException {
 
-		if (className == null)
-			className = result.getClassName();
-
-		formatted.append(className);
-		formatted.append(delimiter);
-		formatted.append(attName);
-
-		return formatted.toString();
+		for(String resultString : messageFormatter.formatResults(results)) {
+			writer.write("put " + resultString + "\n");
+		}
 	}
+
+
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
@@ -1,0 +1,90 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
+import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.TcpOutputWriterBuilder;
+import com.googlecode.jmxtrans.model.output.support.WriterPoolOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+@ThreadSafe
+@EqualsAndHashCode
+@ToString
+public class OpenTSDBWriterFactory implements OutputWriterFactory {
+
+	@Nonnull private final boolean booleanAsNumber;
+	@Nonnull private final InetSocketAddress server;
+	@Nonnull private final OpenTSDBMessageFormatter messageFormatter;
+
+	@JsonCreator
+	public OpenTSDBWriterFactory(
+			@JsonProperty("typeNames") ImmutableList<String> typeNames,
+			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
+			@JsonProperty("host") String host,
+			@JsonProperty("port") Integer port,
+			@JsonProperty("tags") Map<String, String> tags,
+			@JsonProperty("tagName") String tagName,
+			@JsonProperty("mergeTypeNamesTags") Boolean mergeTypeNamesTags,
+			@JsonProperty("metricNamingExpression") String metricNamingExpression,
+			@JsonProperty("addHostnameTag") Boolean addHostnameTag) throws LifecycleException, UnknownHostException {
+
+		this.booleanAsNumber = booleanAsNumber;
+		this.server = new InetSocketAddress(
+				firstNonNull(host, "localhost"),
+				firstNonNull(port, 3030));
+
+		ImmutableMap<String, String> immutableTags =
+				tags == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(tags);
+
+		messageFormatter = new OpenTSDBMessageFormatter(typeNames, immutableTags, tagName,
+				metricNamingExpression, mergeTypeNamesTags,
+				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);
+	}
+
+	@Override
+	public ResultTransformerOutputWriter<WriterPoolOutputWriter<OpenTSDBWriter2>> create() {
+		return ResultTransformerOutputWriter.booleanToNumber(
+				booleanAsNumber,
+				TcpOutputWriterBuilder.builder(
+						server,
+						new OpenTSDBWriter2(messageFormatter))
+						.build());
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java
@@ -72,6 +72,7 @@ public class TCollectorUDPWriter extends OpenTSDBGenericWriter {
 			@JsonProperty("settings") Map<String, Object> settings) throws LifecycleException, UnknownHostException {
 		super(typeNames, booleanAsNumber, debugEnabled, host, port, tags, tagName, mergeTypeNamesTags, metricNamingExpression,
 				addHostnameTag, settings);
+		log.warn("TCollectorUDPWriter is deprecated. Please use TCollectorUDPWriterFactory instead.");
 	}
 
 	/**
@@ -92,11 +93,9 @@ public class TCollectorUDPWriter extends OpenTSDBGenericWriter {
 	@Override
 	public void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
 		this.startOutput();
-		for (Result result : results) {
-			for (String resultString : resultParser(result)) {
-				log.debug("TCollectorUDP Message: {}", resultString);
-				this.sendOutput(resultString);
-			}
+		for (String resultString : messageFormatter.formatResults(results)){
+			log.debug("TCollectorUDP Message: {}", resultString);
+			this.sendOutput(resultString);
 		}
 		this.finishOutput();
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java
@@ -20,35 +20,34 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.model.naming;
+package com.googlecode.jmxtrans.model.output;
 
-import com.googlecode.jmxtrans.model.NamingStrategy;
+import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.output.support.WriterBasedOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
 
-/**
- * Strategy for naming metrics, tags, and the like given a result.
- */
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+import java.io.Writer;
 
-@EqualsAndHashCode
-public class ClassAttributeNamingStrategy implements NamingStrategy {
-	@Getter @Setter protected String delimiter = ".";
+@ThreadSafe
+public class TCollectorUDPWriter2 implements WriterBasedOutputWriter {
+
+	@Nonnull private final OpenTSDBMessageFormatter messageFormatter;
+
+	public TCollectorUDPWriter2(OpenTSDBMessageFormatter messageFormatter) {
+		this.messageFormatter = messageFormatter;
+	}
+
 
 	@Override
-	public String formatName(Result result) {
-		StringBuilder formatted = new StringBuilder();
-		String attName = result.getAttributeName();
-		String className = result.getKeyAlias();
+	public void write(@Nonnull final Writer writer, @Nonnull Server server, @Nonnull Query query, @Nonnull Iterable<Result> results) throws IOException {
 
-		if (className == null)
-			className = result.getClassName();
-
-		formatted.append(className);
-		formatted.append(delimiter);
-		formatted.append(attName);
-
-		return formatted.toString();
+		for(String resultString : messageFormatter.formatResults(results)) {
+			writer.write(resultString);
+		}
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java
@@ -1,0 +1,89 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
+import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.UdpOutputWriterBuilder;
+import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+@ThreadSafe
+@EqualsAndHashCode
+@ToString
+public class TCollectorUDPWriterFactory implements OutputWriterFactory {
+
+	@Nonnull private final boolean booleanAsNumber;
+	@Nonnull private final InetSocketAddress server;
+	@Nonnull private final OpenTSDBMessageFormatter messageFormatter;
+
+	@JsonCreator
+	public TCollectorUDPWriterFactory(
+			@JsonProperty("typeNames") ImmutableList<String> typeNames,
+			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
+			@JsonProperty("host") String host,
+			@JsonProperty("port") Integer port,
+			@JsonProperty("tags") Map<String, String> tags,
+			@JsonProperty("tagName") String tagName,
+			@JsonProperty("mergeTypeNamesTags") Boolean mergeTypeNamesTags,
+			@JsonProperty("metricNamingExpression") String metricNamingExpression,
+			@JsonProperty("addHostnameTag") Boolean addHostnameTag) throws LifecycleException, UnknownHostException {
+
+		this.booleanAsNumber = booleanAsNumber;
+		this.server = new InetSocketAddress(
+				firstNonNull(host, "localhost"),
+				firstNonNull(port, 3030));
+
+		ImmutableMap<String, String> immutableTags =
+				tags == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(tags);
+
+		messageFormatter = new OpenTSDBMessageFormatter(typeNames, immutableTags, tagName,
+				metricNamingExpression, mergeTypeNamesTags,
+				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);
+	}
+	@Override
+	public OutputWriter create() {
+		return ResultTransformerOutputWriter.booleanToNumber(
+				booleanAsNumber,
+				UdpOutputWriterBuilder.builder(
+						server,
+						new TCollectorUDPWriter2(messageFormatter))
+						.build());
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
@@ -1,0 +1,246 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output.support.opentsdb;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.model.NamingStrategy;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.naming.ClassAttributeNamingStrategy;
+import com.googlecode.jmxtrans.model.naming.JexlNamingStrategy;
+import com.googlecode.jmxtrans.model.naming.typename.TypeNameValue;
+import com.googlecode.jmxtrans.model.naming.typename.TypeNameValuesStringBuilder;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.commons.jexl2.JexlException;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.UnknownHostException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.FluentIterable.from;
+import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
+
+@EqualsAndHashCode
+@ToString
+public class OpenTSDBMessageFormatter {
+
+	private static final Logger log = LoggerFactory.getLogger(OpenTSDBMessageFormatter.class);
+	public static final String DEFAULT_TAG_NAME = "type";
+
+	private final ImmutableList<String> typeNames;
+	private final ImmutableMap<String, String> tags;
+	private final String tagName;
+	private final NamingStrategy metricNameStrategy;
+
+
+	private final boolean mergeTypeNamesTags;
+	private final String hostnameTag;
+
+	public OpenTSDBMessageFormatter(@Nonnull ImmutableList<String> typeNames,
+									@Nonnull ImmutableMap<String, String> tags) throws LifecycleException, UnknownHostException {
+		this(typeNames, tags, DEFAULT_TAG_NAME, null, true, "localhost");
+	}
+
+	public OpenTSDBMessageFormatter(@Nonnull ImmutableList<String> typeNames,
+									@Nonnull ImmutableMap<String, String> tags,
+									@Nonnull String tagName,
+									@Nullable String metricNamingExpression,
+									boolean mergeTypeNamesTags,
+									@Nullable String hostnameTag) throws UnknownHostException, LifecycleException {
+		this.typeNames = typeNames;
+		this.tags = tags;
+		this.tagName = tagName;
+		if (metricNamingExpression != null) {
+			try {
+				metricNameStrategy = new JexlNamingStrategy(metricNamingExpression);
+			} catch (JexlException jexlExc) {
+				throw new LifecycleException("failed to setup naming strategy", jexlExc);
+			}
+		} else {
+			metricNameStrategy = new ClassAttributeNamingStrategy();
+		}
+		this.mergeTypeNamesTags = mergeTypeNamesTags;
+		this.hostnameTag = hostnameTag;
+	}
+
+
+	/**
+	 * Add tags to the given result string, including a "host" tag with the name of the server and all of the tags
+	 * defined in the "settings" entry in the configuration file within the "tag" element.
+	 *
+	 * @param resultString - the string containing the metric name, timestamp, value, and possibly other content.
+	 */
+	void addTags(StringBuilder resultString) {
+		if (hostnameTag != null) {
+			addTag(resultString, "host", hostnameTag);
+		}
+
+		// Add the constant tag names and values.
+		for (Map.Entry<String, String> tagEntry : tags.entrySet()) {
+			addTag(resultString, tagEntry.getKey(), tagEntry.getValue());
+		}
+	}
+
+	/**
+	 * Add one tag, with the provided name and value, to the given result string.
+	 *
+	 * @param resultString - the string containing the metric name, timestamp, value, and possibly other content.
+	 * @return String - the new result string with the tag appended.
+	 */
+	void addTag(StringBuilder resultString, String tagName, String tagValue) {
+		resultString.append(" ");
+		resultString.append(sanitizeString(tagName));
+		resultString.append("=");
+		resultString.append(sanitizeString(tagValue));
+	}
+
+	/**
+	 * Format the result string given the class name and attribute name of the source value, the timestamp, and the
+	 * value.
+	 *
+	 * @param epoch - the timestamp of the metric.
+	 * @param value - value of the attribute to use as the metric value.
+	 * @return String - the formatted result string.
+	 */
+	private void formatResultString(StringBuilder resultString, String metricName, long epoch, Object value) {
+		resultString.append(sanitizeString(metricName));
+		resultString.append(" ");
+		resultString.append(Long.toString(epoch));
+		resultString.append(" ");
+		resultString.append(sanitizeString(value.toString()));
+	}
+
+	/**
+	 * Parse one of the results of a Query and return a list of strings containing metric details ready for sending to
+	 * OpenTSDB.
+	 *
+	 * @param result - one results from the Query.
+	 * @return List<String> - the list of strings containing metric details ready for sending to OpenTSDB.
+	 */
+	private List<String> formatResult(Result result) {
+		List<String> resultStrings = new LinkedList<String>();
+		Map<String, Object> values = result.getValues();
+
+		String attributeName = result.getAttributeName();
+
+		if (values.containsKey(attributeName) && values.size() == 1) {
+			processOneMetric(resultStrings, result, values.get(attributeName), null, null);
+		} else {
+			for (Map.Entry<String, Object> valueEntry : values.entrySet()) {
+				processOneMetric(resultStrings, result, valueEntry.getValue(), tagName, valueEntry.getKey());
+			}
+		}
+		return resultStrings;
+	}
+
+	public Iterable<String> formatResults(Iterable<Result> results) {
+		return from(results).transformAndConcat(new Function<Result, List<String>>() {
+
+			@Override
+			public List<String> apply(Result input) {
+				return formatResult(input);
+			}
+
+		}).toList();
+	}
+
+	/**
+	 * Process a single metric from the given JMX query result with the specified value.
+	 */
+	protected void processOneMetric(List<String> resultStrings, Result result, Object value, String addTagName,
+									String addTagValue) {
+		String metricName = this.metricNameStrategy.formatName(result);
+
+		//
+		// Skip any non-numeric values since OpenTSDB only supports numeric metrics.
+		//
+		if (isNumeric(value)) {
+			StringBuilder resultString = new StringBuilder();
+
+			formatResultString(resultString, metricName, result.getEpoch() / 1000L, value);
+			addTags(resultString);
+
+			if (addTagName != null) {
+				addTag(resultString, addTagName, addTagValue);
+			}
+
+			if (!typeNames.isEmpty()) {
+				this.addTypeNamesTags(resultString, result);
+			}
+
+			resultStrings.add(resultString.toString());
+		} else {
+			log.debug("Skipping non-numeric value for metric {}; value={}", metricName, value);
+		}
+	}
+
+	/**
+	 * Add the tag(s) for typeNames.
+	 *
+	 * @param result       - the result of the JMX query.
+	 * @param resultString - current form of the metric string.
+	 * @return String - the updated metric string with the necessary tag(s) added.
+	 */
+	protected void addTypeNamesTags(StringBuilder resultString, Result result) {
+		if (mergeTypeNamesTags) {
+			// Produce a single tag with all the TypeName keys concatenated and all the values joined with '_'.
+			String typeNameValues = TypeNameValuesStringBuilder.getDefaultBuilder().build(typeNames, result.getTypeName());
+			addTag(resultString, StringUtils.join(typeNames, ""), typeNameValues);
+		} else {
+			Map<String, String> typeNameMap = TypeNameValue.extractMap(result.getTypeName());
+			for (String oneTypeName : typeNames) {
+				String value = typeNameMap.get(oneTypeName);
+				if (value == null)
+					value = "";
+				addTag(resultString, oneTypeName, value);
+			}
+		}
+	}
+
+
+	/**
+	 * VALID CHARACTERS:
+	 * METRIC, TAGNAME, AND TAG-VALUE:
+	 * [-_./a-zA-Z0-9]+
+	 * <p/>
+	 * <p/>
+	 * SANITIZATION:
+	 * - Discard Quotes.
+	 * - Replace all other invalid characters with '_'.
+	 */
+	protected String sanitizeString(String unSanitized) {
+		return unSanitized.
+				replaceAll("[\"']", "").
+				replaceAll("[^-_./a-zA-Z0-9]", "_");
+	}
+
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2Test.java
@@ -1,0 +1,67 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class OpenTSDBWriter2Test {
+
+	private OpenTSDBMessageFormatter openTSDBMessageFormatter;
+	private OpenTSDBWriter2 writer;
+	private Writer outputWriter;
+	private Result result;
+
+	@Before
+	public void setup() {
+		openTSDBMessageFormatter = mock(OpenTSDBMessageFormatter.class);
+		writer = new OpenTSDBWriter2(openTSDBMessageFormatter);
+		outputWriter = mock(Writer.class);
+		result = mock(Result.class);
+	}
+
+	@Test
+	public void testMultipleSend() throws IOException {
+
+		ImmutableList<Result> results = ImmutableList.of(result, result);
+		List<String> resultsString = ImmutableList.of("Result1", "Result2");
+
+		Mockito.when(openTSDBMessageFormatter.formatResults(results)).thenReturn(resultsString);
+
+		writer.write(outputWriter, null, null, results);
+
+		Mockito.verify(outputWriter).write("put Result1\n");
+		Mockito.verify(outputWriter).write("put Result2\n");
+	}
+
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2Test.java
@@ -1,0 +1,64 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+
+public class TCollectorUDPWriter2Test {
+
+	private OpenTSDBMessageFormatter openTSDBMessageFormatter;
+	private TCollectorUDPWriter2 writer;
+	private Writer outputWriter;
+	private Result result;
+
+	@Before
+	public void setup() {
+		openTSDBMessageFormatter = Mockito.mock(OpenTSDBMessageFormatter.class);
+		writer = new TCollectorUDPWriter2(openTSDBMessageFormatter);
+		outputWriter = Mockito.mock(Writer.class);
+		result = Mockito.mock(Result.class);
+	}
+
+	@Test
+	public void testMultipleSend() throws IOException {
+
+		ImmutableList<Result> results = ImmutableList.of(result, result);
+		List<String> resultsString = ImmutableList.of("Result1", "Result2");
+
+		Mockito.when(openTSDBMessageFormatter.formatResults(results)).thenReturn(resultsString);
+
+		writer.write(outputWriter, null, null, results);
+
+		Mockito.verify(outputWriter).write("Result1");
+		Mockito.verify(outputWriter).write("Result2");
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java
@@ -1,0 +1,262 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output.support.opentsdb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.net.UnknownHostException;
+import java.util.Iterator;
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newHashMap;
+
+public class OpenTSDBMessageFormatterTest {
+
+	protected Query mockQuery;
+	protected Result mockResult;
+
+	@Before
+	public void setupTest() {
+		this.mockQuery = Mockito.mock(Query.class);
+		this.mockResult = Mockito.mock(Result.class);
+
+		// Setup common mock interactions.
+		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("x-att1-x", (Object) "120021"));
+		Mockito.when(this.mockResult.getAttributeName()).thenReturn("X-ATT-X");
+		Mockito.when(this.mockResult.getClassName()).thenReturn("X-DOMAIN.PKG.CLASS-X");
+		Mockito.when(this.mockResult.getTypeName()).
+				thenReturn("Type=x-type-x,Group=x-group-x,Other=x-other-x,Name=x-name-x");
+
+	}
+
+	private OpenTSDBMessageFormatter createDefaultFormatter() throws LifecycleException, UnknownHostException {
+		return new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"), ImmutableMap.<String, String>of());
+	}
+
+	@Test
+	public void testMergedTypeNameValues() throws Exception {
+		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
+
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+
+		Assert.assertEquals(1, Iterables.size(strings));
+		String resultString = strings.iterator().next();
+		Assert.assertTrue(resultString.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
+		Assert.assertTrue(resultString.matches(".*\\btype=x-att1-x\\b.*"));
+		Assert.assertTrue(resultString.matches(".*\\bTypeGroupNameMissing=x-type-x_x-group-x_x-name-x\\b.*"));
+	}
+
+	@Test
+	public void testNonMergedTypeNameValues() throws Exception {
+
+		OpenTSDBMessageFormatter formatter =
+				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
+						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, null, false, null);
+
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+
+		Assert.assertEquals(1, Iterables.size(strings));
+		String resultString = strings.iterator().next();
+		Assert.assertTrue(resultString.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
+		Assert.assertTrue(resultString.matches(".*\\btype=x-att1-x\\b.*"));
+		Assert.assertTrue(resultString.matches(".*\\bType=x-type-x\\b.*"));
+		Assert.assertTrue(resultString.matches(".*\\bGroup=x-group-x\\b.*"));
+		Assert.assertTrue(resultString.matches(".*\\bName=x-name-x\\b.*"));
+		Assert.assertTrue(resultString.matches(".*\\bMissing=(\\s.*|$)"));
+	}
+
+	@Test
+	public void testEmptyTagSetting() throws Exception {
+
+		OpenTSDBMessageFormatter formatter =
+				new OpenTSDBMessageFormatter(ImmutableList.<String>of(), ImmutableMap.<String, String>of());
+
+		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
+
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+
+		Assert.assertEquals(1, Iterables.size(strings));
+		Assert.assertTrue(
+				strings.iterator().next().matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021 host=[^ ]*$"));
+	}
+
+	@Test
+	public void testMultipleTags() throws Exception {
+
+		Map<String, String> tagMap;
+
+		// Verify tag map with multiple values.
+		tagMap = newHashMap();
+		tagMap.put("x-tag1-x", "x-tag1val-x");
+		tagMap.put("x-tag2-x", "x-tag2val-x");
+		tagMap.put("x-tag3-x", "x-tag3val-x");
+
+		OpenTSDBMessageFormatter formatter =
+				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"), ImmutableMap.copyOf(tagMap));
+
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+
+		Assert.assertEquals(1, Iterables.size(strings));
+
+		String metricString = strings.iterator().next();
+
+		Assert.assertTrue(metricString.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
+		Assert.assertTrue(metricString.matches(".*\\bhost=.*"));
+		Assert.assertTrue(metricString.matches(".*\\bx-tag1-x=x-tag1val-x\\b.*"));
+		Assert.assertTrue(metricString.matches(".*\\bx-tag2-x=x-tag2val-x\\b.*"));
+		Assert.assertTrue(metricString.matches(".*\\bx-tag3-x=x-tag3val-x\\b.*"));
+
+	}
+
+	@Test
+	public void testAddHostnameTag() throws Exception {
+
+		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+
+		Assert.assertEquals(1, Iterables.size(strings));
+		Assert.assertTrue(strings.iterator().next().matches(".*host=.*"));
+
+	}
+
+	@Test
+	public void testDontAddHostnameTag() throws Exception {
+
+		OpenTSDBMessageFormatter formatter =
+				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
+						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, null, true, null);
+
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+
+		Assert.assertEquals(1, Iterables.size(strings));
+		Assert.assertFalse(strings.iterator().next().matches(".*host=.*"));
+
+	}
+
+	@Test
+	public void testEmptyResultValues() throws Exception {
+
+		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
+
+		ImmutableMap<String, Object> values = ImmutableMap.of();
+		Mockito.when(this.mockResult.getValues()).thenReturn(values);
+
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+
+		Assert.assertEquals(0, Iterables.size(strings));
+
+	}
+
+	@Test
+	public void testOneValueMatchingAttribute() throws Exception {
+
+		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
+
+		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
+
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+
+		Assert.assertEquals(1, Iterables.size(strings));
+		String resultString = strings.iterator().next();
+
+		Assert.assertTrue(resultString.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
+		Assert.assertTrue(resultString.matches(".*\\bhost=.*"));
+		Assert.assertFalse(resultString.matches(".*\\btype=.*"));
+
+	}
+
+	@Test
+	public void testMultipleValuesWithMatchingAttribute() throws Exception {
+
+		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
+
+		Mockito.when(this.mockResult.getValues()).
+				thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021", "XX-ATT-XX", (Object) "210012"));
+
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+
+		Assert.assertEquals(2, Iterables.size(strings));
+		Iterator<String> resultStringIterator = strings.iterator();
+		String resultString1 = resultStringIterator.next();
+		String resultString2 = resultStringIterator.next();
+
+		String xLine;
+		String xxLine;
+		if (resultString1.contains("XX-ATT-XX")) {
+			xxLine = resultString1;
+			xLine = resultString2;
+		} else {
+			xLine = resultString1;
+			xxLine = resultString2;
+		}
+
+		Assert.assertTrue(xLine.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
+		Assert.assertTrue(xLine.matches(".*\\btype=X-ATT-X\\b.*"));
+
+		Assert.assertTrue(xxLine.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 210012.*"));
+		Assert.assertTrue(xxLine.matches(".*\\btype=XX-ATT-XX\\b.*"));
+
+	}
+
+	@Test
+	public void testNonNumericValue() throws Exception {
+
+		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
+		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "THIS-IS-NOT-A-NUMBER"));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Assert.assertEquals(0, Iterables.size(strings));
+
+	}
+
+	@Test
+	public void testJexlNaming() throws Exception {
+
+		OpenTSDBMessageFormatter formatter =
+				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
+						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, "'xx-jexl-constant-name-xx'", true, null);
+
+
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Assert.assertEquals(1, Iterables.size(strings));
+		Assert.assertTrue(strings.iterator().next().matches("^xx-jexl-constant-name-xx 0 120021.*"));
+
+	}
+
+	@Test(expected = LifecycleException.class)
+	public void testInvalidJexlNaming() throws Exception {
+
+		new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
+						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, "invalid expression here", true, null);
+
+	}
+
+}


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50539851%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50539931%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540051%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540158%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540293%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540377%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540475%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540517%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540538%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540619%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540677%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540747%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540988%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50541352%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50547854%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540538%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Class%20could%20be%20marked%20%60%40Threadsafe%60%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A16%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java%3AL1-52%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java%2043%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540293%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20be%20annotated%20with%20%60%40Threadsafe%60%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A13%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java%3AL1-84%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540517%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60messageFormatter%60%20could%20be%20%60final%60%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A15%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java%3AL1-52%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540619%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60TCollectorUDPWriter2%60%20should%20implement%20a%20reasonable%20%60equals%28%29%60%20and%20%60hashCode%28%29%60%20for%20deduplication.%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A16%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java%3AL1-52%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540747%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20implement%20a%20reasonable%20%60equals%28%29%60%20and%20%60hashCode%28%29%60%20for%20deduplication.%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A18%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22For%20the%20messageFormatter%20%3F%20%22%2C%20%22created_at%22%3A%20%222016-01-22T15%3A18%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/500180%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/AlbanSeurat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java%3AL1-243%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540377%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Static%20analysis%20should%20be%20able%20to%20detect%20it%20in%20this%20case%2C%20but%20marking%20fields%20as%20%60%40Nonnull%60would%20be%20nice.%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A14%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java%3AL1-84%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50539931%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20class%20could%20be%20annotated%20with%20%60%40Threadsafe%60%20%28JSR%20305%29%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A10%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java%3AL1-56%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540051%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20add%20a%20deprecation%20warning%20%28as%20a%20log%20message%29%20in%20the%20constructor%3F%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A11%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java%3AL112-121%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540158%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60OpenTSDBWriter2%60%20should%20implement%20a%20reasonable%20%60equals%28%29%60%20and%20%60hashCode%28%29%60%20for%20OutputWriter%20deduplication%20%28lombok%20is%20your%20friend%29.%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A12%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java%3AL1-56%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540475%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20log%20a%20deprecation%20warning%20in%20the%20constructor%3F%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A15%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java%3AL92-101%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2Test.java%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540988%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Just%20for%20fun%20...%20I%27d%20fid%20it%20more%20readable%20to%20have%20a%20static%20import%20of%20%60Mockito.mock%28%29%60%20%28this%20is%20a%20complete%20detail%2C%20feel%20free%20to%20ignore%29.%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A20%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2Test.java%3AL1-66%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50539851%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60messageFormatter%60%20could%20be%20%60final%60%20%28sorry%2C%20one%20of%20my%20pet%20peeve%29%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A09%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java%3AL1-56%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50541352%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20have%20a%20look%20at%20%60QueryFixtures%60%20and%20%60ResultFixtures%60%20and%20see%20if%20you%20can%20use%20them%20instead%20of%20a%20mock%3F%20There%20is%20not%20much%20value%20there%20yet%2C%20but%20I%20hope%20to%20extract%20a%20few%20corner%20cases%20as%20fixtures%20and%20reuse%20them%20for%20all%20tests.%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A23%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java%3AL1-263%22%7D%2C%20%22Pull%20815b88b80c45de3dcc3b2f5cfa951f546b5cba6e%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/413%23discussion_r50540677%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%40Nonnull%60%22%2C%20%22created_at%22%3A%20%222016-01-22T14%3A17%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java%3AL1-84%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java 40'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50539851'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java:L1-56</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> `messageFormatter` could be `final` (sorry, one of my pet peeve)
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50539931'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java:L1-56</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This class could be annotated with `@Threadsafe` (JSR 305)
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java 1'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540051'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java:L112-121</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Could you add a deprecation warning (as a log message) in the constructor?
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540158'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java:L1-56</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> `OpenTSDBWriter2` should implement a reasonable `equals()` and `hashCode()` for OutputWriter deduplication (lombok is your friend).
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java 43'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540293'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java:L1-84</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Could be annotated with `@Threadsafe`
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java 46'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540377'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java:L1-84</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Static analysis should be able to detect it in this case, but marking fields as `@Nonnull`would be nice.
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540475'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java:L92-101</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Could you log a deprecation warning in the constructor?
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540517'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java:L1-52</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> `messageFormatter` could be `final`
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540538'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java:L1-52</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Class could be marked `@Threadsafe`
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540619'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java:L1-52</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> `TCollectorUDPWriter2` should implement a reasonable `equals()` and `hashCode()` for deduplication.
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java 47'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540677'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java:L1-84</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> `@Nonnull`
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java 50'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540747'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java:L1-243</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Should implement a reasonable `equals()` and `hashCode()` for deduplication.
- <a href='https://github.com/AlbanSeurat'><img border=0 src='https://avatars.githubusercontent.com/u/500180?v=3' height=16 width=16'></a> For the messageFormatter ?
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2Test.java 45'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50540988'>File: jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2Test.java:L1-66</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Just for fun ... I'd fid it more readable to have a static import of `Mockito.mock()` (this is a complete detail, feel free to ignore).
- [ ] <a href='#crh-comment-Pull 815b88b80c45de3dcc3b2f5cfa951f546b5cba6e jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/413#discussion_r50541352'>File: jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java:L1-263</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Could you have a look at `QueryFixtures` and `ResultFixtures` and see if you can use them instead of a mock? There is not much value there yet, but I hope to extract a few corner cases as fixtures and reuse them for all tests.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/413?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/413?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/413'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>