### PR TITLE
Now uses scm-publish to upload maven site

### DIFF
--- a/jmxtrans-core/pom.xml
+++ b/jmxtrans-core/pom.xml
@@ -175,16 +175,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-examples/pom.xml
+++ b/jmxtrans-examples/pom.xml
@@ -105,16 +105,6 @@
 
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-cloudwatch/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/pom.xml
@@ -116,16 +116,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-core/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-core/pom.xml
@@ -172,16 +172,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-ganglia/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-ganglia/pom.xml
@@ -83,16 +83,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-influxdb/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-influxdb/pom.xml
@@ -85,16 +85,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-jrobin/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-jrobin/pom.xml
@@ -90,16 +90,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-log4j/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-log4j/pom.xml
@@ -93,16 +93,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/jmxtrans-output-velocity/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-velocity/pom.xml
@@ -74,16 +74,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>jmxtrans-output/${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-output/pom.xml
+++ b/jmxtrans-output/pom.xml
@@ -61,19 +61,4 @@
 		<module>jmxtrans-output-influxdb</module>
 	</modules>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/jmxtrans-test-utils/pom.xml
+++ b/jmxtrans-test-utils/pom.xml
@@ -77,16 +77,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-                        ${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans-utils/pom.xml
+++ b/jmxtrans-utils/pom.xml
@@ -100,16 +100,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -166,16 +166,6 @@
 
 		<plugins>
 			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<configuration>
-					<merge>true</merge>
-					<message>Creating site for ${project.name}
-						${project.version}</message>
-					<path>${project.artifactId}</path>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>
 				<artifactId>checksum-maven-plugin</artifactId>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,11 @@
 			<id>ossrh</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
+		<site>
+			<id>github</id>
+			<url>scm:git:https://github.com/jmxtrans/jmxtrans</url>
+		</site>
 	</distributionManagement>
-
 	<properties>
 		<!--
 			Maximum number of checkstyle violations allowed. Build will fail
@@ -609,26 +612,6 @@
 					</executions>
 				</plugin>
 				<plugin>
-					<groupId>com.github.github</groupId>
-					<artifactId>site-maven-plugin</artifactId>
-					<!--
-						version 0.11 seem to have some problem to publish, let's wait until 0.12 to upgrade
-					-->
-					<version>0.10</version>
-					<configuration>
-						<message>Creating site for ${project.name}
-							${project.version}</message>
-					</configuration>
-					<executions>
-						<execution>
-							<goals>
-								<goal>site</goal>
-							</goals>
-							<phase>site</phase>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
 					<groupId>com.mycila</groupId>
 					<artifactId>license-maven-plugin</artifactId>
 					<version>2.11</version>
@@ -846,6 +829,42 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-scm-publish-plugin</artifactId>
+					<version>1.1</version>
+					<configuration>
+						<checkoutDirectory>${session.executionRootDirectory}/target/scmpublish-checkout/</checkoutDirectory>
+						<content>${session.executionRootDirectory}/target/staging/</content>
+						<providerImplementations>
+							<git>jgit</git>
+						</providerImplementations>
+						<scmBranch>gh-pages</scmBranch>
+						<serverId>github</serverId>
+					</configuration>
+					<dependencies>
+						<dependency>
+							<groupId>org.apache.maven.scm</groupId>
+							<artifactId>maven-scm-api</artifactId>
+							<version>1.9.4</version>
+						</dependency>
+						<dependency>
+							<groupId>org.apache.maven.scm</groupId>
+							<artifactId>maven-scm-provider-jgit</artifactId>
+							<version>1.9.4</version>
+							<!-- required in order to hide password value in command logging on travis -->
+						</dependency>
+					</dependencies>
+					<executions>
+						<execution>
+							<id>sitestage</id>
+							<goals>
+								<goal>publish-scm</goal>
+							</goals>
+							<phase>site-deploy</phase>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
 					<version>2.4.1</version>
 				</plugin>
@@ -853,6 +872,18 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-site-plugin</artifactId>
 					<version>3.4</version>
+					<configuration>
+						<skipDeploy>true</skipDeploy>
+					</configuration>
+					<executions>
+						<execution>
+							<id>stage-for-scm-publish</id>
+							<goals>
+								<goal>stage</goal>
+							</goals>
+							<phase>post-site</phase>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -912,6 +943,7 @@
 					<artifactId>cobertura-maven-plugin</artifactId>
 					<version>2.7</version>
 					<configuration>
+						<aggregate>true</aggregate>
 						<check>
 							<branchRate>0</branchRate>
 							<lineRate>0</lineRate>
@@ -923,10 +955,18 @@
 					</configuration>
 					<executions>
 						<execution>
+							<id>cobertura-clean</id>
 							<goals>
 								<goal>clean</goal>
+							</goals>
+							<phase>clean</phase>
+						</execution>
+						<execution>
+							<id>cobertura-check</id>
+							<goals>
 								<goal>check</goal>
 							</goals>
+							<phase>verify</phase>
 						</execution>
 					</executions>
 				</plugin>
@@ -997,10 +1037,6 @@
 			<plugin>
 				<groupId>com.github.ekryd.sortpom</groupId>
 				<artifactId>sortpom-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>com.mycila</groupId>
@@ -1114,6 +1150,14 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
 				<version>2.7</version>
+				<inherited>true</inherited>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>cobertura</report>
+						</reports>
+					</reportSet>
+				</reportSets>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This is basically a reimplementation of #299. This should be more stable (and more standard) than the Maven GitHub plugins.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/414?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/414'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>