### PR TITLE
#419 Refactor guice config for Server

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/guice/JmxTransModule.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/guice/JmxTransModule.java
@@ -35,13 +35,13 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
+import com.google.inject.name.Names;
 import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
 import com.googlecode.jmxtrans.connections.DatagramSocketFactory;
 import com.googlecode.jmxtrans.connections.SocketFactory;
-import com.googlecode.jmxtrans.connections.JMXConnection;
 import com.googlecode.jmxtrans.connections.MBeanServerConnectionFactory;
-import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.monitoring.ManagedGenericKeyedObjectPool;
+import org.apache.commons.pool.KeyedObjectPool;
 import org.apache.commons.pool.KeyedPoolableObjectFactory;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.quartz.Scheduler;
@@ -83,7 +83,7 @@ public class JmxTransModule extends AbstractModule {
 				.toInstance(getObjectPool(new SocketFactory(), SocketFactory.class.getSimpleName()));
 		bind(new TypeLiteral<GenericKeyedObjectPool<SocketAddress, DatagramSocket>>(){})
 				.toInstance(getObjectPool(new DatagramSocketFactory(), DatagramSocketFactory.class.getSimpleName()));
-		bind(new TypeLiteral<GenericKeyedObjectPool<Server, JMXConnection>>(){})
+		bind(KeyedObjectPool.class).annotatedWith(Names.named("mbeanPool"))
 				.toInstance(getObjectPool(new MBeanServerConnectionFactory(), MBeanServerConnectionFactory.class.getSimpleName()));
 	}
 
@@ -148,7 +148,7 @@ public class JmxTransModule extends AbstractModule {
 				.build();
 	}
 
-	private <K, V> GenericKeyedObjectPool getObjectPool(KeyedPoolableObjectFactory<K, V> factory, String poolName) {
+	private <K, V> GenericKeyedObjectPool<K, V> getObjectPool(KeyedPoolableObjectFactory<K, V> factory, String poolName) {
 		GenericKeyedObjectPool<K, V> pool = new GenericKeyedObjectPool<K, V>(factory);
 		pool.setTestOnBorrow(true);
 		pool.setMaxActive(-1);

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -33,6 +33,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.name.Named;
 import com.googlecode.jmxtrans.connections.JMXConnection;
 import com.googlecode.jmxtrans.connections.JmxConnectionProvider;
 import com.sun.tools.attach.VirtualMachine;
@@ -41,7 +42,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
-import org.apache.commons.pool.impl.GenericKeyedObjectPool;
+import org.apache.commons.pool.KeyedObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,7 +155,7 @@ public class Server implements JmxConnectionProvider {
 
 	@Nonnull @Getter private final Iterable<OutputWriter> outputWriters;
 
-	private final GenericKeyedObjectPool<Server, JMXConnection> pool;
+	private final KeyedObjectPool<JmxConnectionProvider, JMXConnection> pool;
 	@Nonnull @Getter private final ImmutableList<OutputWriterFactory> outputWriterFactories;
 
 	@JsonCreator
@@ -173,7 +174,7 @@ public class Server implements JmxConnectionProvider {
 			@JsonProperty("local") boolean local,
 			@JsonProperty("queries") List<Query> queries,
 			@JsonProperty("outputWriters") List<OutputWriterFactory> outputWriters,
-			@JacksonInject GenericKeyedObjectPool<Server, JMXConnection> pool) {
+			@JacksonInject @Named("mbeanPool") KeyedObjectPool<JmxConnectionProvider, JMXConnection> pool) {
 
 		checkArgument(pid != null || url != null || host != null,
 				"You must provide the pid or the [url|host and port]");
@@ -427,7 +428,7 @@ public class Server implements JmxConnectionProvider {
 		@Setter private boolean local;
 		private final List<OutputWriterFactory> outputWriters = new ArrayList<OutputWriterFactory>();
 		private final List<Query> queries = new ArrayList<Query>();
-		@Setter private GenericKeyedObjectPool<Server, JMXConnection> pool;
+		@Setter private KeyedObjectPool<JmxConnectionProvider, JMXConnection> pool;
 
 		private Builder() {}
 

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerIT.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerIT.java
@@ -46,8 +46,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 @AllowDNSResolution
 @AllowLocalFileAccess(paths = "*")
-@Category({RequiresIO.class})
-public class JmxTransformerTest {
+@Category({IntegrationTest.class, RequiresIO.class})
+public class JmxTransformerIT {
 	@Rule public OutputCapture output = new OutputCapture();
 	@Rule public MonitorableApp app = new MonitorableApp(12345);
 	private JmxTransformer jmxTransformer;

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java
@@ -46,8 +46,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 @AllowDNSResolution
 @AllowLocalFileAccess(paths = "*")
-@Category({IntegrationTest.class, RequiresIO.class})
-public class JmxTransformerIT {
+@Category({RequiresIO.class})
+public class JmxTransformerTest {
 	@Rule public OutputCapture output = new OutputCapture();
 	@Rule public MonitorableApp app = new MonitorableApp(12345);
 	private JmxTransformer jmxTransformer;
@@ -68,8 +68,8 @@ public class JmxTransformerIT {
 
 	@Test
 	public void metricsAreSentToStdout() throws Exception {
-		await().atMost(2, SECONDS).until(output.stdoutHasLineContaining("Value=1"));
-		await().atMost(2, SECONDS).until(output.stdoutHasLineContaining("Value=2"));
+		await().atMost(5, SECONDS).until(output.stdoutHasLineContaining("Value=1"));
+		await().atMost(5, SECONDS).until(output.stdoutHasLineContaining("Value=2"));
 	}
 
 	@After

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
@@ -23,6 +23,7 @@
 package com.googlecode.jmxtrans.model;
 
 import com.googlecode.jmxtrans.connections.JMXConnection;
+import com.googlecode.jmxtrans.connections.JmxConnectionProvider;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.kaching.platform.testing.AllowDNSResolution;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
@@ -189,7 +190,7 @@ public class ServerTests {
 	@Test
 	public void testConnectionRepoolingOk() throws Exception {
 		@SuppressWarnings("unchecked")
-		GenericKeyedObjectPool<Server, JMXConnection> pool = mock(GenericKeyedObjectPool.class);
+		GenericKeyedObjectPool<JmxConnectionProvider, JMXConnection> pool = mock(GenericKeyedObjectPool.class);
 
 		Server server = Server.builder()
 				.setHost("host.example.net")
@@ -220,7 +221,7 @@ public class ServerTests {
 	@Test
 	public void testConnectionRepoolingSkippedOnError() throws Exception {
 		@SuppressWarnings("unchecked")
-		GenericKeyedObjectPool<Server, JMXConnection> pool = mock(GenericKeyedObjectPool.class);
+		GenericKeyedObjectPool<JmxConnectionProvider, JMXConnection> pool = mock(GenericKeyedObjectPool.class);
 
 		Server server = Server.builder()
 				.setHost("host.example.net")

--- a/pom.xml
+++ b/pom.xml
@@ -461,12 +461,6 @@
 				<scope>runtime</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.remoting3</groupId>
-				<artifactId>remoting-jmx</artifactId>
-				<version>1.0.1.Final</version>
-				<scope>runtime</scope>
-			</dependency>
-			<dependency>
 				<!--
 					There is no compile time dependency on jboss remoting. There might be a runtime dependency that I did not
 					identify yet, so let's keep it for the moment. After further analysis, we might be able to remove it.
@@ -785,6 +779,23 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-failsafe-plugin</artifactId>
+					<version>2.19.1</version>
+					<configuration>
+						<groups>com.googlecode.jmxtrans.test.IntegrationTest</groups>
+						<argLine>-Djava.security.manager=com.kaching.platform.testing.LessIOSecurityManager</argLine>
+					</configuration>
+					<executions>
+						<execution>
+							<goals>
+								<goal>integration-test</goal>
+								<goal>verify</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-gpg-plugin</artifactId>
 					<version>1.6</version>
 					<executions>
@@ -1071,6 +1082,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -783,7 +783,6 @@
 					<version>2.19.1</version>
 					<configuration>
 						<groups>com.googlecode.jmxtrans.test.IntegrationTest</groups>
-						<argLine>-Djava.security.manager=com.kaching.platform.testing.LessIOSecurityManager</argLine>
 					</configuration>
 					<executions>
 						<execution>


### PR DESCRIPTION
Fixes for #419 

Jackson doesn't seem to properly handle generics so it won't find any `TypeLiteral` bindings.  I refactored this to use an explicit binding with a @Named parameter.

The `JmxTransfomerIT` test wasn't running as part of the build (and would have caught this) so I renamed it to to actually run during the build.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/420%23discussion_r51572466%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/420%23issuecomment-178777648%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/420%23issuecomment-178812723%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/420%23discussion_r51637222%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/420%23discussion_r51637316%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/420%23issuecomment-178831625%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/420%23discussion_r51696035%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/420%23issuecomment-178777648%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20like%20the%20CloudWatchWriterIT%20is%20not%20compatible%20with%20the%20LessIOSecurityManager%22%2C%20%22created_at%22%3A%20%222016-02-02T19%3A34%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Looks%20like%20the%20CloudWatchWriterIT%20is%20not%20compatible%20with%20the%20LessIOSecurityManager%5Cr%5Cn%5Cr%5Cn%40gehel%20what%20are%20your%20thoughts%20here%3F%20%20The%20LessIOSecurityManager%20doesn%27t%20seem%20to%20play%20nice%20with%20Powermock%20%28javassist%29%20or%20custom%20test%20runners%20%28either%20the%20PowerMockRunner%20or%20MockitoJUnitRunner%29.%5Cr%5Cn%5Cr%5CnOne%20solution%20that%20I%20prototyped%20was%20to%20allow%20Guice%20in%20the%20OutputWriters%20so%20that%20we%20could%20properly%20use%20DI%2C%20instead%20of%20doing%20things%20like%20creating%20the%20%60AmazonCloudWatchClient%60%20directly%20in%20code.%5Cr%5Cn%5Cr%5CnMy%20thought%20was%20we%20could%20leverage%20the%20java%20ServiceProvider%20infrastructure%20to%20allow%20the%20different%20output%20writers%20%28or%20really%20any%20maven%20submodule%20component%29%20to%20contribute%20Guice%20modules.%5Cr%5Cn%5Cr%5CnEach%20sub-module%20could%20optionally%20implement%20the%20following%20SPI%20interface%3A%5Cr%5Cn%5Cr%5Cn%60%60%60java%5Cr%5Cnimport%20com.google.inject.Module%3B%5Cr%5Cn%5Cr%5Cnpublic%20interface%20ModuleProvider%20%7B%5Cr%5Cn%5Cr%5Cn%5CtModule%20getModule%28%29%3B%5Cr%5Cn%5Cr%5Cn%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnThe%20modules%20would%20then%20be%20loaded%20from%20the%20ServiceLoader%3A%5Cr%5Cn%5Cr%5Cn%60%60%60java%5Cr%5Cn%40Nonnull%5Cr%5Cnpublic%20static%20Injector%20createInjector%28%40Nonnull%20JmxTransConfiguration%20configuration%29%20%7B%5Cr%5Cn%5Ctreturn%20Guice.createInjector%28%5Cr%5Cn%5Ct%5CtcreateModules%28configuration%29%5Cr%5Cn%5Ct%29%3B%5Cr%5Cn%7D%5Cr%5Cn%5Cr%5Cnpublic%20static%20Collection%3CModule%3E%20createModules%28%40Nonnull%20JmxTransConfiguration%20configuration%29%20%7B%5Cr%5Cn%5CtList%3CModule%3E%20modules%20%3D%20new%20ArrayList%3CModule%3E%28%29%3B%5Cr%5Cn%5Cr%5Cn%5Ctmodules.add%28new%20JmxTransModule%28configuration%29%29%3B%5Cr%5Cn%5Ctmodules.add%28%5Cr%5Cn%5Ct%5Ctnew%20ObjectMapperModule%28%29%5Cr%5Cn%5Ct%5Ct%5Ct.registerModule%28new%20GuavaModule%28%29%29%5Cr%5Cn%5Ct%29%3B%5Cr%5Cn%5Cr%5Cn%5Ctfor%20%28ModuleProvider%20moduleProvider%20%3A%20ServiceLoader.load%28ModuleProvider.class%29%29%20%7B%5Cr%5Cn%5Ct%5Ctmodules.add%28moduleProvider.getModule%28%29%29%3B%5Cr%5Cn%5Ct%7D%5Cr%5Cn%5Cr%5Cn%5Ctreturn%20modules%3B%5Cr%5Cn%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnThoughts%3F%22%2C%20%22created_at%22%3A%20%222016-02-02T20%3A49%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22Adding%20a%20SPI%20integration%20is%20probably%20for%20another%20PR.%20The%20issue%20with%20PowerMock%20should%20be%20solved%20by%20removing%20PowerMock.%20The%20fact%20that%20we%20need%20PowerMock%20is%20a%20sign%20of%20a%20bad%20design.%5Cr%5Cn%5Cr%5CnNot%20having%20LessIOSecurityManager%20for%20integration%20tests%20is%20fine.%20We%20do%20expect%20integration%20tests%20to%20have%20IO.%5Cr%5Cn%5Cr%5CnI%20don%27t%20really%20have%20any%20issue%20with%20%60AmazonCloudWatchClient%60%20being%20created%20by%20code.%20It%20is%20more%20or%20less%20nicely%20isolated%20in%20its%20own%20factory.%20I%20would%20have%20much%20more%20concern%20having%20it%20in%20the%20global%20Guice%20scope.%20It%20is%20used%20only%20by%20a%20specific%20module%2C%20it%20should%20not%20be%20accessible%20from%20outside%20of%20it.%20So%20let%27s%20say%20that%20I%20don%27t%20really%20see%20a%20reason%20to%20have%20an%20SPI%20integration.%5Cr%5Cn%5Cr%5CnI%27m%20happy%20to%20continue%20this%20conversation.%20You%20might%20be%20able%20to%20convince%20me%20...%22%2C%20%22created_at%22%3A%20%222016-02-02T21%3A29%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20b7fdc395ef905c492e52b9c86660a821520527fb%20pom.xml%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/420%23discussion_r51637222%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Are%20you%20sure%20about%20removing%20this%20dependency%3F%22%2C%20%22created_at%22%3A%20%222016-02-02T21%3A22%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20a%20duplicate%2C%20see%20the%20one%20directly%20above%20it.%22%2C%20%22created_at%22%3A%20%222016-02-02T21%3A23%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22My%20bad%20...%22%2C%20%22created_at%22%3A%20%222016-02-03T09%3A23%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pom.xml%3AL461-467%22%7D%2C%20%22Pull%2076a30dc69bc882268aa7321dfc72e76f55f21dde%20jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/420%23discussion_r51572466%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20correct%20fix%20should%20be%20to%20configure%20%5BMaven%20Failsafe%20plugin%5D%28https%3A//maven.apache.org/surefire/maven-failsafe-plugin/%29.%20I%27d%20like%20to%20make%20sure%20that%20unit%20tests%20are%20actually%20testing%20small%20units%20and%20are%20fast.%20As%20we%20are%20also%20using%20%5BPIT%5D%28http%3A//pitest.org/%29%2C%20it%20is%20specially%20important%20that%20unit%20tests%20are%20fast.%5Cr%5Cn%5Cr%5CnCould%20you%20rollback%20this%20specific%20change%20and%20open%20an%20issue%20to%20add%20an%20integration%20test%20phase%20to%20the%20build%20%3F%22%2C%20%22created_at%22%3A%20%222016-02-02T14%3A13%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java%3AL46-54%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 76a30dc69bc882268aa7321dfc72e76f55f21dde jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/420#discussion_r51572466'>File: jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java:L46-54</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> The correct fix should be to configure [Maven Failsafe plugin](https://maven.apache.org/surefire/maven-failsafe-plugin/). I'd like to make sure that unit tests are actually testing small units and are fast. As we are also using [PIT](http://pitest.org/), it is specially important that unit tests are fast.
Could you rollback this specific change and open an issue to add an integration test phase to the build ?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/420#issuecomment-178777648'>General Comment</a></b>
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> Looks like the CloudWatchWriterIT is not compatible with the LessIOSecurityManager
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> > Looks like the CloudWatchWriterIT is not compatible with the LessIOSecurityManager
@gehel what are your thoughts here?  The LessIOSecurityManager doesn't seem to play nice with Powermock (javassist) or custom test runners (either the PowerMockRunner or MockitoJUnitRunner).
One solution that I prototyped was to allow Guice in the OutputWriters so that we could properly use DI, instead of doing things like creating the `AmazonCloudWatchClient` directly in code.
My thought was we could leverage the java ServiceProvider infrastructure to allow the different output writers (or really any maven submodule component) to contribute Guice modules.
Each sub-module could optionally implement the following SPI interface:
```java
import com.google.inject.Module;
public interface ModuleProvider {
Module getModule();
}
```
The modules would then be loaded from the ServiceLoader:
```java
@Nonnull
public static Injector createInjector(@Nonnull JmxTransConfiguration configuration) {
return Guice.createInjector(
createModules(configuration)
);
}
public static Collection<Module> createModules(@Nonnull JmxTransConfiguration configuration) {
List<Module> modules = new ArrayList<Module>();
modules.add(new JmxTransModule(configuration));
modules.add(
new ObjectMapperModule()
.registerModule(new GuavaModule())
);
for (ModuleProvider moduleProvider : ServiceLoader.load(ModuleProvider.class)) {
modules.add(moduleProvider.getModule());
}
return modules;
}
```
Thoughts?
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Adding a SPI integration is probably for another PR. The issue with PowerMock should be solved by removing PowerMock. The fact that we need PowerMock is a sign of a bad design.
Not having LessIOSecurityManager for integration tests is fine. We do expect integration tests to have IO.
I don't really have any issue with `AmazonCloudWatchClient` being created by code. It is more or less nicely isolated in its own factory. I would have much more concern having it in the global Guice scope. It is used only by a specific module, it should not be accessible from outside of it. So let's say that I don't really see a reason to have an SPI integration.
I'm happy to continue this conversation. You might be able to convince me ...
- [ ] <a href='#crh-comment-Pull b7fdc395ef905c492e52b9c86660a821520527fb pom.xml 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/420#discussion_r51637222'>File: pom.xml:L461-467</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Are you sure about removing this dependency?
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> It is a duplicate, see the one directly above it.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> My bad ...


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/420?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/420?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/420'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>