### PR TITLE
Verify RPM/Deb Behavior with Docker Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   - $HOME/.m2
 install:
   - mvn compile -DskipTests=true -Dmaven.javadoc.skip=true -Dcobertura.skip=true -B -V
-script: travis_wait ./travis-script.sh
+script: travis_wait 120 ./travis-script.sh
 after_success:
   - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && mvn site site:stage scm-publish:publish-scm --settings ${HOME}/travis/settings.xml -B -V
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   - $HOME/.m2
 install:
   - mvn compile -DskipTests=true -Dmaven.javadoc.skip=true -Dcobertura.skip=true -B -V
-script: ./travis-script.sh
+script: travis_wait ./travis-script.sh
 after_success:
   - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && mvn site site:stage scm-publish:publish-scm --settings ${HOME}/travis/settings.xml -B -V
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 sudo: false
 before_install: "git clone -b travis `git config --get remote.origin.url` ${HOME}/travis"
+services:
+  - docker
 addons:
   apt:
     packages:

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -35,10 +35,19 @@
     <artifactId>jmxtrans-docker-test</artifactId>
 
     <properties>
+        <deb.install.artifact>org.jmxtrans:jmxtrans:deb</deb.install.artifact>
+        <deb.install.file>jmxtrans.deb</deb.install.file>
+        <deb.run.cmd>debconf-set-selections &lt;&lt;&lt; "jmxtrans jmxtrans/jvm_heap_size string 512"; dpkg -i /maven/${deb.install.file}; /etc/init.d/jmxtrans start; /maven/verify.sh</deb.run.cmd>
+
         <docker.skip>true</docker.skip>
         <docker.verbose>true</docker.verbose>
+
+        <rpm.install.artifact>org.jmxtrans:jmxtrans:rpm</rpm.install.artifact>
+        <rpm.install.file>jmxtrans.rpm</rpm.install.file>
+        <rpm.run.cmd>rpm -ivh --nosignature --nodeps /maven/${rpm.install.file}; /etc/init.d/jmxtrans start; /maven/verify.sh</rpm.run.cmd>
+
         <verification.message>installation verified</verification.message>
-        <verification.wait.time>30000</verification.wait.time>
+        <verification.wait.time>60000</verification.wait.time>
     </properties>
 
     <build>
@@ -82,12 +91,6 @@
     <profiles>
         <profile>
             <id>deb</id>
-
-            <properties>
-                <deb.install.artifact>org.jmxtrans:jmxtrans:deb</deb.install.artifact>
-                <deb.install.file>jmxtrans.deb</deb.install.file>
-                <deb.run.cmd>dpkg -i /maven/${deb.install.file}; /etc/init.d/jmxtrans start; /maven/verify.sh</deb.run.cmd>
-            </properties>
 
             <dependencies>
                 <dependency>
@@ -166,12 +169,6 @@
         <profile>
             <id>docker.debian</id>
 
-            <properties>
-                <deb.install.artifact>org.jmxtrans:jmxtrans:deb</deb.install.artifact>
-                <deb.install.file>jmxtrans.deb</deb.install.file>
-                <deb.run.cmd>dpkg -i /maven/${deb.install.file}; /etc/init.d/jmxtrans start; /maven/verify.sh</deb.run.cmd>
-            </properties>
-
             <dependencies>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
@@ -248,12 +245,6 @@
 
         <profile>
             <id>rpm</id>
-
-            <properties>
-                <rpm.install.artifact>org.jmxtrans:jmxtrans:rpm</rpm.install.artifact>
-                <rpm.install.file>jmxtrans.rpm</rpm.install.file>
-                <rpm.run.cmd>rpm -ivh --nosignature --nodeps /maven/${rpm.install.file}; /etc/init.d/jmxtrans start; /maven/verify.sh</rpm.run.cmd>
-            </properties>
 
             <dependencies>
                 <dependency>

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -35,6 +35,7 @@
     <artifactId>jmxtrans-docker-test</artifactId>
 
     <properties>
+        <docker.skip>true</docker.skip>
         <docker.verbose>true</docker.verbose>
         <verification.message>installation verified</verification.message>
         <verification.wait.time>30000</verification.wait.time>

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -123,7 +123,7 @@
                                         </runCmds>
                                     </build>
                                     <run>
-                                        <cmd>
+                                Move         <cmd>
                                             <exec>
                                                 <arg>/bin/bash</arg>
                                                 <arg>-c</arg>
@@ -166,6 +166,40 @@
                                         </wait>
                                     </run>
                                 </image>
+
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>docker.debian</id>
+
+            <properties>
+                <deb.install.artifact>org.jmxtrans:jmxtrans:deb</deb.install.artifact>
+                <deb.install.file>jmxtrans.deb</deb.install.file>
+                <deb.run.cmd>dpkg -i /maven/${deb.install.file}; /etc/init.d/jmxtrans start; /maven/verify.sh</deb.run.cmd>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>jmxtrans</artifactId>
+                    <version>${project.version}</version>
+                    <type>deb</type>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jolokia</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+
+                        <configuration>
+                            <images combine.children="append">
 
                                 <image>
                                     <name>debian-8.3/${project.artifactId}:${project.version}</name>

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -198,12 +198,7 @@
                                             <basedir>/</basedir>
                                         </assembly>
 
-                                        <from>debian:8.3</from>
-                                        <runCmds>
-                                            <run>apt-get clean</run>
-                                            <run>apt-get update</run>
-                                            <run>apt-get -y install openjdk-7-jre</run>
-                                        </runCmds>
+                                        <from>jmxtrans/testing:debian8.3-0</from>
                                     </build>
                                     <run>
                                         <cmd>
@@ -228,12 +223,7 @@
                                             <basedir>/</basedir>
                                         </assembly>
 
-                                        <from>debian:7.9</from>
-                                        <runCmds>
-                                            <run>apt-get clean</run>
-                                            <run>apt-get update</run>
-                                            <run>apt-get -y install openjdk-7-jre</run>
-                                        </runCmds>
+                                        <from>jmxtrans/testing:debian7.9-0</from>
                                     </build>
                                     <run>
                                         <cmd>

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -123,7 +123,7 @@
                                         </runCmds>
                                     </build>
                                     <run>
-                                Move         <cmd>
+                                        <cmd>
                                             <exec>
                                                 <arg>/bin/bash</arg>
                                                 <arg>-c</arg>

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -68,6 +68,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <!-- There is no Java code in this project, let's skip PIT -->
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -108,6 +108,7 @@
 
                                         <from>ubuntu:14.04.3</from>
                                         <runCmds>
+                                            <run>apt-get clean</run>
                                             <run>apt-get update</run>
                                             <run>apt-get -y install openjdk-7-jre</run>
                                         </runCmds>
@@ -137,6 +138,7 @@
 
                                         <from>ubuntu:12.04.5</from>
                                         <runCmds>
+                                            <run>apt-get clean</run>
                                             <run>apt-get update</run>
                                             <run>apt-get -y install openjdk-7-jre</run>
                                         </runCmds>
@@ -166,6 +168,7 @@
 
                                         <from>debian:8.3</from>
                                         <runCmds>
+                                            <run>apt-get clean</run>
                                             <run>apt-get update</run>
                                             <run>apt-get -y install openjdk-7-jre</run>
                                         </runCmds>
@@ -195,6 +198,7 @@
 
                                         <from>debian:7.9</from>
                                         <runCmds>
+                                            <run>apt-get clean</run>
                                             <run>apt-get update</run>
                                             <run>apt-get -y install openjdk-7-jre</run>
                                         </runCmds>

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -44,9 +44,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jolokia</groupId>
+                <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.14.0-SNAPSHOT</version>
                 <configuration>
                     <showLogs>true</showLogs>
                     <images/>
@@ -102,7 +101,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jolokia</groupId>
+                        <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
 
                         <configuration>
@@ -115,12 +114,7 @@
                                             <basedir>/</basedir>
                                         </assembly>
 
-                                        <from>ubuntu:14.04.3</from>
-                                        <runCmds>
-                                            <run>apt-get clean</run>
-                                            <run>apt-get update</run>
-                                            <run>apt-get -y install openjdk-7-jre</run>
-                                        </runCmds>
+                                        <from>jmxtrans/testing:ubuntu14.04.3-0</from>
                                     </build>
                                     <run>
                                         <cmd>
@@ -145,12 +139,7 @@
                                             <basedir>/</basedir>
                                         </assembly>
 
-                                        <from>ubuntu:12.04.5</from>
-                                        <runCmds>
-                                            <run>apt-get clean</run>
-                                            <run>apt-get update</run>
-                                            <run>apt-get -y install openjdk-7-jre</run>
-                                        </runCmds>
+                                        <from>jmxtrans/testing:ubuntu12.04.5-0</from>
                                     </build>
                                     <run>
                                         <cmd>
@@ -195,7 +184,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jolokia</groupId>
+                        <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
 
                         <configuration>
@@ -288,7 +277,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.jolokia</groupId>
+                        <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
 
                         <configuration>
@@ -302,10 +291,7 @@
                                             <basedir>/</basedir>
                                         </assembly>
 
-                                        <from>centos:7</from>
-                                        <runCmds>
-                                            <run>yum -y install java</run>
-                                        </runCmds>
+                                        <from>jmxtrans/testing:centos7-0</from>
                                     </build>
                                     <run>
                                         <cmd>
@@ -330,10 +316,7 @@
                                             <basedir>/</basedir>
                                         </assembly>
 
-                                        <from>centos:6.7</from>
-                                        <runCmds>
-                                            <run>yum -y install java</run>
-                                        </runCmds>
+                                        <from>jmxtrans/testing:centos6.7-0</from>
                                     </build>
                                     <run>
                                         <cmd>
@@ -358,10 +341,7 @@
                                             <basedir>/</basedir>
                                         </assembly>
 
-                                        <from>centos:6.6</from>
-                                        <runCmds>
-                                            <run>yum -y install java</run>
-                                        </runCmds>
+                                        <from>jmxtrans/testing:centos6.6-0</from>
                                     </build>
                                     <run>
                                         <cmd>
@@ -386,10 +366,7 @@
                                             <basedir>/</basedir>
                                         </assembly>
 
-                                        <from>centos:5.11</from>
-                                        <runCmds>
-                                            <run>yum -y install java7</run>
-                                        </runCmds>
+                                        <from>jmxtrans/testing:centos5.11-0</from>
                                     </build>
                                     <run>
                                         <cmd>
@@ -414,10 +391,7 @@
                                             <basedir>/</basedir>
                                         </assembly>
 
-                                        <from>opensuse:42.1</from>
-                                        <runCmds>
-                                            <run>zypper install -ly java-1_8_0-openjdk</run>
-                                        </runCmds>
+                                        <from>jmxtrans/testing:opensuse42.1-0</from>
                                     </build>
                                     <run>
                                         <cmd>
@@ -434,7 +408,7 @@
                                     </run>
                                 </image>
 
-                                <image>
+                                <image  >
                                     <name>opensuse13.2/${project.artifactId}:${project.version}</name>
                                     <build>
                                         <assembly>
@@ -442,10 +416,7 @@
                                             <basedir>/</basedir>
                                         </assembly>
 
-                                        <from>opensuse:13.2</from>
-                                        <runCmds>
-                                            <run>zypper install -ly java-1_8_0-openjdk</run>
-                                        </runCmds>
+                                        <from>jmxtrans/testing:opensuse13.2-0</from>
                                     </build>
                                     <run>
                                         <cmd>

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>org.jolokia</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.13.8</version>
+                <version>0.14.0-SNAPSHOT</version>
                 <configuration>
                     <showLogs>true</showLogs>
                     <images/>

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -1,0 +1,426 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The MIT License
+    Copyright (c) 2010 JmxTrans team
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jmxtrans</groupId>
+        <artifactId>jmxtrans-parent</artifactId>
+        <version>254-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jmxtrans-docker-test</artifactId>
+
+    <properties>
+        <docker.verbose>true</docker.verbose>
+        <verification.message>installation verified</verification.message>
+        <verification.wait.time>30000</verification.wait.time>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jolokia</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.13.8</version>
+                <configuration>
+                    <showLogs>true</showLogs>
+                    <images/>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>start</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                        <phase>post-integration-test</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>deb</id>
+
+            <properties>
+                <deb.install.artifact>org.jmxtrans:jmxtrans:deb</deb.install.artifact>
+                <deb.install.file>jmxtrans.deb</deb.install.file>
+                <deb.run.cmd>dpkg -i /maven/${deb.install.file}; /etc/init.d/jmxtrans start; /maven/verify.sh</deb.run.cmd>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>jmxtrans</artifactId>
+                    <version>${project.version}</version>
+                    <type>deb</type>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jolokia</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+
+                        <configuration>
+                            <images combine.children="append">
+                                <image>
+                                    <name>ubuntu-14.04.3/${project.artifactId}:${project.version}</name>
+                                    <build>
+                                        <assembly>
+                                            <descriptor>assembly-docker.xml</descriptor>
+                                            <basedir>/</basedir>
+                                        </assembly>
+
+                                        <from>ubuntu:14.04.3</from>
+                                        <runCmds>
+                                            <run>apt-get update</run>
+                                            <run>apt-get -y install openjdk-7-jre</run>
+                                        </runCmds>
+                                    </build>
+                                    <run>
+                                        <cmd>
+                                            <exec>
+                                                <arg>/bin/bash</arg>
+                                                <arg>-c</arg>
+                                                <arg>${deb.run.cmd}</arg>
+                                            </exec>
+                                        </cmd>
+                                        <wait>
+                                            <log>${verification.message}</log>
+                                            <time>${verification.wait.time}</time>
+                                        </wait>
+                                    </run>
+                                </image>
+
+                                <image>
+                                    <name>ubuntu-12.04.5/${project.artifactId}:${project.version}</name>
+                                    <build>
+                                        <assembly>
+                                            <descriptor>assembly-docker.xml</descriptor>
+                                            <basedir>/</basedir>
+                                        </assembly>
+
+                                        <from>ubuntu:12.04.5</from>
+                                        <runCmds>
+                                            <run>apt-get update</run>
+                                            <run>apt-get -y install openjdk-7-jre</run>
+                                        </runCmds>
+                                    </build>
+                                    <run>
+                                        <cmd>
+                                            <exec>
+                                                <arg>/bin/bash</arg>
+                                                <arg>-c</arg>
+                                                <arg>${deb.run.cmd}</arg>
+                                            </exec>
+                                        </cmd>
+                                        <wait>
+                                            <log>${verification.message}</log>
+                                            <time>${verification.wait.time}</time>
+                                        </wait>
+                                    </run>
+                                </image>
+
+                                <image>
+                                    <name>debian-8.3/${project.artifactId}:${project.version}</name>
+                                    <build>
+                                        <assembly>
+                                            <descriptor>assembly-docker.xml</descriptor>
+                                            <basedir>/</basedir>
+                                        </assembly>
+
+                                        <from>debian:8.3</from>
+                                        <runCmds>
+                                            <run>apt-get update</run>
+                                            <run>apt-get -y install openjdk-7-jre</run>
+                                        </runCmds>
+                                    </build>
+                                    <run>
+                                        <cmd>
+                                            <exec>
+                                                <arg>/bin/bash</arg>
+                                                <arg>-c</arg>
+                                                <arg>${deb.run.cmd}</arg>
+                                            </exec>
+                                        </cmd>
+                                        <wait>
+                                            <log>${verification.message}</log>
+                                            <time>${verification.wait.time}</time>
+                                        </wait>
+                                    </run>
+                                </image>
+
+                                <image>
+                                    <name>debian-7.9/${project.artifactId}:${project.version}</name>
+                                    <build>
+                                        <assembly>
+                                            <descriptor>assembly-docker.xml</descriptor>
+                                            <basedir>/</basedir>
+                                        </assembly>
+
+                                        <from>debian:7.9</from>
+                                        <runCmds>
+                                            <run>apt-get update</run>
+                                            <run>apt-get -y install openjdk-7-jre</run>
+                                        </runCmds>
+                                    </build>
+                                    <run>
+                                        <cmd>
+                                            <exec>
+                                                <arg>/bin/bash</arg>
+                                                <arg>-c</arg>
+                                                <arg>${deb.run.cmd}</arg>
+                                            </exec>
+                                        </cmd>
+                                        <wait>
+                                            <log>${verification.message}</log>
+                                            <time>${verification.wait.time}</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>rpm</id>
+
+            <properties>
+                <rpm.install.artifact>org.jmxtrans:jmxtrans:rpm</rpm.install.artifact>
+                <rpm.install.file>jmxtrans.rpm</rpm.install.file>
+                <rpm.run.cmd>rpm -ivh --nosignature --nodeps /maven/${rpm.install.file}; /etc/init.d/jmxtrans start; /maven/verify.sh</rpm.run.cmd>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>jmxtrans</artifactId>
+                    <version>${project.version}</version>
+                    <type>rpm</type>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jolokia</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+
+                        <configuration>
+                            <images combine.children="append">
+
+                                <image>
+                                    <name>centos7/${project.artifactId}:${project.version}</name>
+                                    <build>
+                                        <assembly>
+                                            <descriptor>assembly-docker.xml</descriptor>
+                                            <basedir>/</basedir>
+                                        </assembly>
+
+                                        <from>centos:7</from>
+                                        <runCmds>
+                                            <run>yum -y install java</run>
+                                        </runCmds>
+                                    </build>
+                                    <run>
+                                        <cmd>
+                                            <exec>
+                                                <arg>/bin/bash</arg>
+                                                <arg>-c</arg>
+                                                <arg>${rpm.run.cmd}</arg>
+                                            </exec>
+                                        </cmd>
+                                        <wait>
+                                            <log>${verification.message}</log>
+                                            <time>${verification.wait.time}</time>
+                                        </wait>
+                                    </run>
+                                </image>
+
+                                <image>
+                                    <name>centos6.7/${project.artifactId}:${project.version}</name>
+                                    <build>
+                                        <assembly>
+                                            <descriptor>assembly-docker.xml</descriptor>
+                                            <basedir>/</basedir>
+                                        </assembly>
+
+                                        <from>centos:6.7</from>
+                                        <runCmds>
+                                            <run>yum -y install java</run>
+                                        </runCmds>
+                                    </build>
+                                    <run>
+                                        <cmd>
+                                            <exec>
+                                                <arg>/bin/bash</arg>
+                                                <arg>-c</arg>
+                                                <arg>${rpm.run.cmd}</arg>
+                                            </exec>
+                                        </cmd>
+                                        <wait>
+                                            <log>${verification.message}</log>
+                                            <time>${verification.wait.time}</time>
+                                        </wait>
+                                    </run>
+                                </image>
+
+                                <image>
+                                    <name>centos6.6/${project.artifactId}:${project.version}</name>
+                                    <build>
+                                        <assembly>
+                                            <descriptor>assembly-docker.xml</descriptor>
+                                            <basedir>/</basedir>
+                                        </assembly>
+
+                                        <from>centos:6.6</from>
+                                        <runCmds>
+                                            <run>yum -y install java</run>
+                                        </runCmds>
+                                    </build>
+                                    <run>
+                                        <cmd>
+                                            <exec>
+                                                <arg>/bin/bash</arg>
+                                                <arg>-c</arg>
+                                                <arg>${rpm.run.cmd}</arg>
+                                            </exec>
+                                        </cmd>
+                                        <wait>
+                                            <log>${verification.message}</log>
+                                            <time>${verification.wait.time}</time>
+                                        </wait>
+                                    </run>
+                                </image>
+
+                                <image>
+                                    <name>centos5.11/${project.artifactId}:${project.version}</name>
+                                    <build>
+                                        <assembly>
+                                            <descriptor>assembly-docker.xml</descriptor>
+                                            <basedir>/</basedir>
+                                        </assembly>
+
+                                        <from>centos:5.11</from>
+                                        <runCmds>
+                                            <run>yum -y install java7</run>
+                                        </runCmds>
+                                    </build>
+                                    <run>
+                                        <cmd>
+                                            <exec>
+                                                <arg>/bin/bash</arg>
+                                                <arg>-c</arg>
+                                                <arg>${rpm.run.cmd}</arg>
+                                            </exec>
+                                        </cmd>
+                                        <wait>
+                                            <log>${verification.message}</log>
+                                            <time>${verification.wait.time}</time>
+                                        </wait>
+                                    </run>
+                                </image>
+
+                                <image>
+                                    <name>opensuse42.1/${project.artifactId}:${project.version}</name>
+                                    <build>
+                                        <assembly>
+                                            <descriptor>assembly-docker.xml</descriptor>
+                                            <basedir>/</basedir>
+                                        </assembly>
+
+                                        <from>opensuse:42.1</from>
+                                        <runCmds>
+                                            <run>zypper install -ly java-1_8_0-openjdk</run>
+                                        </runCmds>
+                                    </build>
+                                    <run>
+                                        <cmd>
+                                            <exec>
+                                                <arg>/bin/bash</arg>
+                                                <arg>-c</arg>
+                                                <arg>${rpm.run.cmd}</arg>
+                                            </exec>
+                                        </cmd>
+                                        <wait>
+                                            <log>${verification.message}</log>
+                                            <time>${verification.wait.time}</time>
+                                        </wait>
+                                    </run>
+                                </image>
+
+                                <image>
+                                    <name>opensuse13.2/${project.artifactId}:${project.version}</name>
+                                    <build>
+                                        <assembly>
+                                            <descriptor>assembly-docker.xml</descriptor>
+                                            <basedir>/</basedir>
+                                        </assembly>
+
+                                        <from>opensuse:13.2</from>
+                                        <runCmds>
+                                            <run>zypper install -ly java-1_8_0-openjdk</run>
+                                        </runCmds>
+                                    </build>
+                                    <run>
+                                        <cmd>
+                                            <exec>
+                                                <arg>/bin/bash</arg>
+                                                <arg>-c</arg>
+                                                <arg>${rpm.run.cmd}</arg>
+                                            </exec>
+                                        </cmd>
+                                        <wait>
+                                            <log>${verification.message}</log>
+                                            <time>${verification.wait.time}</time>
+                                        </wait>
+                                    </run>
+                                </image>
+
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/jmxtrans-docker-test/src/main/docker/assembly-docker.xml
+++ b/jmxtrans-docker-test/src/main/docker/assembly-docker.xml
@@ -1,0 +1,72 @@
+<!--
+
+    The MIT License
+    Copyright (c) 2010 JmxTrans team
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>assembly-docker</id>
+
+    <baseDirectory>/</baseDirectory>
+
+    <dependencySets>
+        <dependencySet>
+            <includes>
+                <include>${deb.install.artifact}</include>
+            </includes>
+            <outputDirectory>/maven</outputDirectory>
+            <outputFileNameMapping>${deb.install.file}</outputFileNameMapping>
+        </dependencySet>
+
+        <dependencySet>
+            <includes>
+                <include>${rpm.install.artifact}</include>
+            </includes>
+            <outputDirectory>/maven</outputDirectory>
+            <outputFileNameMapping>${rpm.install.file}</outputFileNameMapping>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/src/main/docker</directory>
+            <outputDirectory>/maven</outputDirectory>
+            <filtered>true</filtered>
+            <includes>
+                <include>verify.sh</include>
+            </includes>
+            <fileMode>755</fileMode>
+        </fileSet>
+
+        <fileSet>
+            <directory>${project.basedir}/src/main/docker</directory>
+            <outputDirectory>/var/lib/jmxtrans</outputDirectory>
+            <filtered>true</filtered>
+            <includes>
+                <include>localhost.json</include>
+            </includes>
+            <fileMode>755</fileMode>
+        </fileSet>
+    </fileSets>
+
+</assembly>

--- a/jmxtrans-docker-test/src/main/docker/localhost.json
+++ b/jmxtrans-docker-test/src/main/docker/localhost.json
@@ -1,0 +1,14 @@
+{
+  "servers" : [ {
+    "port" : "2101",
+    "host" : "localhost",
+    "queries" : [ {
+      "outputWriters" : [ {
+        "@class" : "com.googlecode.jmxtrans.model.output.StdOutWriter"
+      } ],
+      "obj" : "java.lang:type=Runtime",
+      "attr" : [ "SpecName" ]
+    } ],
+    "numQueryThreads" : 2
+  } ]
+}

--- a/jmxtrans-docker-test/src/main/docker/verify.sh
+++ b/jmxtrans-docker-test/src/main/docker/verify.sh
@@ -22,8 +22,16 @@
 # THE SOFTWARE.
 #
 
-until grep -q "SpecName=Java Virtual Machine Specification" /var/log/jmxtrans/jmxtrans.log; do
+LOGFILE=/var/log/jmxtrans/jmxtrans.log
+
+echo "$(date) - Looking for log message..."
+
+until grep -q "SpecName=Java Virtual Machine Specification" $LOGFILE; do
+  echo "$(date) - Log contents:"
+  cat $LOGFILE
+  echo "----"
   sleep 1
 done
 
+echo "$(date) - Found log message"
 echo "${verification.message}"

--- a/jmxtrans-docker-test/src/main/docker/verify.sh
+++ b/jmxtrans-docker-test/src/main/docker/verify.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# The MIT License
+# Copyright (c) 2010 JmxTrans team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+until grep -q "SpecName=Java Virtual Machine Specification" /var/log/jmxtrans/jmxtrans.log; do
+  sleep 1
+done
+
+echo "${verification.message}"

--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -320,6 +320,8 @@
 						<artifactId>rpm-maven-plugin</artifactId>
 						<configuration>
 							<group>Applications/Communications</group>
+							<needarch>noarch</needarch>
+							<targetOS>linux</targetOS>
 							<defineStatements>
 								<!--
 									The package contains Tanukisoft libs for multiple architectures. Multi-arch package
@@ -362,6 +364,8 @@
 								<mapping>
 									<directory>${package.install.dir}/bin</directory>
 									<filemode>755</filemode>
+									<username>${package.user}</username>
+									<groupname>${package.group}</groupname>
 									<sources>
 										<source>
 											<location>${jsw.dir}/bin</location>
@@ -391,6 +395,8 @@
 									<directory>/usr/bin</directory>
 									<directoryIncluded>false</directoryIncluded>
 									<filemode>755</filemode>
+									<username>${package.user}</username>
+									<groupname>${package.group}</groupname>
 									<sources>
 										<source>
 											<location>${project.basedir}/bin/</location>

--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -332,15 +332,9 @@
 							<preinstallScriptlet>
 								<script>if [ $1 = 1 ]; then
 									getent group ${package.user} &gt;/dev/null || groupadd -r ${package.user}
-									OS_RELEASE=${dollar.sign}(lsb_release -sd)
-									REDHAT_RELEASE=${dollar.sign}(lsb_release -sr|cut -d"." -f1)
-									if [[ ${dollar.sign}{OS_RELEASE} == *"Red Hat"* &amp;&amp; ${dollar.sign}{REDHAT_RELEASE} -le 5 ]]; then
-										getent passwd ${package.user} &gt;/dev/null || useradd -c "${project.name}" -s /bin/sh -r \
-										-d ${package.install.dir} -g ${package.user} \
-										${package.user}
-									else
-										getent passwd ${package.user} &gt;/dev/null || useradd -r -g ${package.user} -d ${package.install.dir} -s /bin/sh -c "${project.name}" ${package.user}
-									fi
+									getent passwd ${package.user} &gt;/dev/null || useradd -c "${project.name}" -s /bin/sh -r \
+									-d ${package.install.dir} -g ${package.user} \
+									${package.user}
 								fi</script>
 							</preinstallScriptlet>
 							<postinstallScriptlet>
@@ -354,8 +348,7 @@
 									fi</script>
 							</preremoveScriptlet>
 							<requires>
-								<require>java</require>
-								<require>/usr/bin/lsb_release</require>
+								<require>java >= 1.7</require>
 							</requires>
 							<mappings>
 								<mapping>

--- a/pom.xml
+++ b/pom.xml
@@ -586,21 +586,6 @@
 		</dependency>
 	</dependencies>
 
-	<pluginRepositories>
-		<pluginRepository>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-
-			<id>sonatype-nexus-snapshots</id>
-			<name>Sonatype Nexus Snapshots</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</pluginRepository>
-	</pluginRepositories>
-
 	<build>
 
 		<pluginManagement>
@@ -681,6 +666,11 @@
 						<skipUpdateCheck>true</skipUpdateCheck>
 						<usageStatisticsComment>JmxTrans - https://github.com/jmxtrans/jmxtrans</usageStatisticsComment>
 					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>io.fabric8</groupId>
+					<artifactId>docker-maven-plugin</artifactId>
+					<version>0.14.0</version>
 				</plugin>
 				<plugin>
 					<groupId>net.ju-n.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -586,6 +586,21 @@
 		</dependency>
 	</dependencies>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+
+			<id>sonatype-nexus-snapshots</id>
+			<name>Sonatype Nexus Snapshots</name>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<build>
 
 		<pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -753,8 +753,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.5</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.7</source>
+						<target>1.7</target>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
 		<module>jmxtrans-examples</module>
 		<module>jmxtrans-core</module>
 		<module>jmxtrans-test-utils</module>
+		<module>jmxtrans-docker-test</module>
 	</modules>
 
 	<scm>

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -74,9 +74,9 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     fi
   else
     echo "Building feature branch"
-    travis_wait mvn verify --settings ${MVN_SETTINGS} -U -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
+    mvn verify --settings ${MVN_SETTINGS} -U -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
   fi
 else
   echo "Building pull request"
-  travis_wait mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
+  mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
 fi

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -40,7 +40,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     git config --global user.name "JmxTrans travis build"
 
     echo "Building master"
-    mvn deploy --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,gpg,rpm,deb
+    mvn deploy --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,gpg,rpm,deb -Ddocker.skip=false
   elif [ "$TRAVIS_BRANCH" == "release" ]; then
     if [[ `git log --format=%B -n 1` == *"[maven-release-plugin]"* ]]; then
       echo "Do not release commits created by maven release plugin"
@@ -74,9 +74,9 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     fi
   else
     echo "Building feature branch"
-    mvn verify --settings ${MVN_SETTINGS} -U -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
+    mvn verify --settings ${MVN_SETTINGS} -U -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip -Ddocker.skip=false
   fi
 else
   echo "Building pull request"
-  mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
+  mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip -Ddocker.skip=false
 fi

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -74,7 +74,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     fi
   else
     echo "Building feature branch"
-    mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg
+    mvn verify --settings ${MVN_SETTINGS} -e -B -V -PwithMutationTests,rpm,deb,\!gpg
   fi
 else
   echo "Building pull request"

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -74,7 +74,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     fi
   else
     echo "Building feature branch"
-    mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,!gpg
+    mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg
   fi
 else
   echo "Building pull request"

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -78,5 +78,5 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   fi
 else
   echo "Building pull request"
-  mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb
+  mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=
 fi

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -74,7 +74,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     fi
   else
     echo "Building feature branch"
-    mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb
+    mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
   fi
 else
   echo "Building pull request"

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -74,7 +74,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     fi
   else
     echo "Building feature branch"
-    mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb
+    mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,!gpg
   fi
 else
   echo "Building pull request"

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -78,5 +78,5 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   fi
 else
   echo "Building pull request"
-  mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=
+  mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
 fi

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -74,9 +74,9 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     fi
   else
     echo "Building feature branch"
-    mvn verify --settings ${MVN_SETTINGS} -e -B -V -PwithMutationTests,rpm,deb,\!gpg
+    mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb
   fi
 else
   echo "Building pull request"
-  mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests
+  mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb
 fi

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -74,9 +74,9 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     fi
   else
     echo "Building feature branch"
-    mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
+    travis_wait mvn verify --settings ${MVN_SETTINGS} -U -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
   fi
 else
   echo "Building pull request"
-  mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
+  travis_wait mvn verify --settings ${MVN_SETTINGS} -B -V -PwithMutationTests,rpm,deb,\!gpg -Dgpg.passphraseServerId=skip
 fi


### PR DESCRIPTION
@gehel this PR adds a new maven module that spins up docker images for various linux distributions to test the RPM & deb packages.

It is not complete yet but I'm unable to test it in my fork due to the missing GPG information.  I'm hoping that creating the PR here will successfully run the build with your travis config.  

I'll update the PR when the testing is complete.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-183488379%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-183495072%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-183495541%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-183633758%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-183704376%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-183706386%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-183706682%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-186248445%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-186255513%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-187368404%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52825842%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52825848%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52825870%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52830437%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52830576%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52830639%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52830648%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52830655%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52830667%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52830683%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r53725461%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r53725508%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r53725561%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r53725771%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r53725892%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r53725893%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r53725894%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-187762570%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-187770243%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-187770952%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-187774185%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-187774668%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-187776043%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-187893025%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-188144023%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-188436193%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-188821782%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-188846825%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-188850236%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-188913058%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-191455505%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-191474383%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23issuecomment-183488379%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40gehel%20Looks%20like%20pull%20requests%20are%20having%20issues%20with%20the%20GPG%20keys.%5Cr%5Cn%5Cr%5CnOn%20my%20local%20fork%2C%20I%20tried%20disabling%20the%20gpg%20profile%20%28via%20%60-P%20%21gpg...%60%29%20but%20the%20%5Brpm-maven-plugin%5D%28https%3A//github.com/mojohaus/rpm-maven-plugin/blob/5da5c5c1d28647fea78402cc1f8494aec1b66e88/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java%23L1537%29%20looks%20at%20the%20%60gpg.passphraseServerId%60%20property%20and%20tries%20to%20load%20the%20gpg%20key.%22%2C%20%22created_at%22%3A%20%222016-02-12T21%3A06%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20looks%20really%20interesting%21%20I%20have%20a%20few%20comments%2C%20but%20I%20need%20some%20more%20time%20than%20I%20have%20right%20now%20to%20do%20your%20PR%20justice.%20I%27ll%20get%20back%20to%20you%20as%20soon%20as%20I%20can...%22%2C%20%22created_at%22%3A%20%222016-02-12T21%3A31%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%20%20I%27m%20experimenting%20now%20with%20the%20travis%20config%20to%20see%20how%20I%20can%20get%20pull%20requests%20to%20run%20without%20signing%20the%20RPM.%22%2C%20%22created_at%22%3A%20%222016-02-12T21%3A32%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looking%20at%20the%20travis%20build%2C%20it%20seems%20that%20the%20RPM%20builds%20just%20fine%2C%20but%20there%20is%20a%20requirement%20to%20update%20Maven%20to%20more%20recent%20version%20than%20what%20is%20on%20Travis.%20Should%20be%20doable...%22%2C%20%22created_at%22%3A%20%222016-02-13T09%3A55%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3ELooking%20at%20the%20travis%20build%2C%20it%20seems%20that%20the%20RPM%20builds%20just%20fine%2C%20but%20there%20is%20a%20requirement%20to%20update%20Maven%20to%20more%20recent%20version%20than%20what%20is%20on%20Travis.%20Should%20be%20doable...%5Cr%5Cn%5Cr%5CnYes%2C%20I%27m%20trying%20to%20get%20this%20sorted%20out.%5Cr%5Cn%5Cr%5CnThe%20docker%20support%20on%20Travis%20is%20in%20beta%20and%20thus%20is%20using%20the%20beta%20%5BTrusty%20environment%5D%28https%3A//docs.travis-ci.com/user/trusty-ci-environment%29%20which%20is%20only%20using%20maven%203.1.1.%20%20There%20is%20an%20%5Bopen%20issue%5D%28https%3A//github.com/travis-ci/travis-ci/issues/4872%29%20regarding%20the%20maven%20version%20so%20I%27m%20hoping%20this%20gets%20addressed%20soon.%5Cr%5Cn%5Cr%5CnSeparately%2C%20there%20is%20an%20%5Bopen%20issue%5D%28https%3A//github.com/rhuss/docker-maven-plugin/issues/290%29%20with%20the%20docker-maven-plugin%20regarding%20the%20maven%20version%20prerequisite.%20%20I%27m%20hoping%20that%20the%20hard%20requirement%20for%203.2.x%20isn%27t%20necessary.%22%2C%20%22created_at%22%3A%20%222016-02-13T17%3A09%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20should%20not%20be%20too%20hard%20to%20download%20and%20install%20Maven%203.3%20at%20the%20start%20of%20the%20build%20and%20use%20it%20instead%20of%20the%20version%20coming%20by%20default%20on%20Travis.%20Ugly%2C%20yes%2C%20but%20probably%20working.%22%2C%20%22created_at%22%3A%20%222016-02-13T17%3A24%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20It%20should%20not%20be%20too%20hard%20to%20download%20and%20install%20Maven%203.3%20at%20the%20start%20of%20the%20build%20and%20use%20it%20instead%20of%20the%20version%20coming%20by%20default%20on%20Travis.%20Ugly%2C%20yes%2C%20but%20probably%20working.%5Cr%5Cn%5Cr%5CnGlad%20to%20know%20thats%20an%20option.%20%20I%27m%20going%20to%20see%20what%20progress%20I%20can%20make%20on%20the%20other%202%20fronts%20first%20before%20approaching%20this%20one.%22%2C%20%22created_at%22%3A%20%222016-02-13T17%3A26%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40gehel%20I%27m%20still%20working%20on%20this.%20%20I%27ve%20fixed%20the%20above%20issues%20but%20it%20seems%20that%20docker%20on%20travis%20is%20quite%20unstable%2C%20the%20build%20often%20fails%20with%20timeouts%20while%20the%20docker%20images%20are%20being%20built.%20%20I%27m%20brainstorming%20on%20ways%20around%20that.%22%2C%20%22created_at%22%3A%20%222016-02-19T15%3A02%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kevinconaway%20thanks%20a%20lot%20for%20what%20you%20are%20doing%21%20Just%20thinking%20about%20it%20is%20already%20an%20achievement%21%20Sorry%20I%27m%20not%20of%20more%20help%2C%20I%20just%20started%20a%20new%20job%20and%20I%27m%20fairly%20busy%20at%20the%20moment.%20I%20really%20want%20to%20have%20a%20deeper%20look%20in%20what%20you%27ve%20been%20doing%2C%20but%20it%27s%20probably%20going%20to%20take%20some%20time.%5Cr%5Cn%5Cr%5CnLet%20me%20know%20if%20there%20is%20something%20specific%20on%20which%20I%20can%20help%20you%20...%20I%27ll%20do%20my%20best.%22%2C%20%22created_at%22%3A%20%222016-02-19T15%3A16%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Build%20is%20green%20now%20and%20I%27ve%20been%20running%20it%20continuously%20all%20day%20on%20my%20local%20branch.%20%20I%27m%20not%20sure%20if%20that%20the%20flakiness%20is%20resolved%20or%20if%20today%20is%20just%20a%20good%20day%20for%20travis.%22%2C%20%22created_at%22%3A%20%222016-02-22T20%3A23%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Could%20you%20move%20the%20version%20to%20the%20parent%20pom%3F%20That%20way%20we%20have%20all%20versions%20in%20the%20same%20place.%20Also%2C%20is%20it%20necessary%20to%20use%20the%20SNAPSHOT%20version%3F%20This%20is%20going%20to%20be%20a%20problem%20for%20releases.%20It%20seems%20that%20releases%20are%20made%20fairly%20often%20to%20this%20plugin%2C%20so%20I%20hope%20we%20can%20move%20to%20a%20released%20version.%5Cr%5Cn%5Cr%5CnI%27ve%20asked%20the%20docker-maven-plugin%20maintainer%20to%20release%20a%20new%20version.%20%20That%20should%20come%20out%20in%20a%20few%20days%2C%20when%20it%20does%2C%20I%20will%20update%20the%20version%20and%20remove%20the%20plugin%20repo%22%2C%20%22created_at%22%3A%20%222016-02-23T15%3A57%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20that%27s%20OK%20with%20you%2C%20I%27ll%20wait%20for%20the%20removal%20of%20the%20SNAPSHOT%20to%20merge%20this%20PR.%5Cr%5Cn%5Cr%5CnAgain%2C%20thanks%20a%20lot%20for%20the%20work%21%20That%27s%20really%20going%20to%20help%21%22%2C%20%22created_at%22%3A%20%222016-02-23T16%3A19%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20If%20that%27s%20OK%20with%20you%2C%20I%27ll%20wait%20for%20the%20removal%20of%20the%20SNAPSHOT%20to%20merge%20this%20PR.%5Cr%5Cn%5Cr%5CnYes%2C%20definitely%21%5Cr%5Cn%5Cr%5CnOn%20a%20different%20topic%2C%20what%20are%20your%20thoughts%20on%20adding%20a%20travis%20envvar%20to%20control%20whether%20these%20tests%20run%20or%20not%3F%20%20That%20way%2C%20if%20something%20goes%20wrong%20later%20down%20the%20line%20they%20can%20be%20skipped%20by%20modifying%20the%20travis%20envvar%2C%20rather%20than%20changing%20the%20code.%22%2C%20%22created_at%22%3A%20%222016-02-23T16%3A21%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27d%20actually%20prefer%20to%20have%20a%20variable%20defined%20inside%20the%20travis%20script.%20That%20way%2C%20the%20configuration%20itself%20is%20under%20version%20control.%20There%20is%20no%20good%20way%20%28that%20I%20know%20of%29%20to%20trace%20changes%20to%20travis%20envvars.%22%2C%20%22created_at%22%3A%20%222016-02-23T16%3A28%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20I%27d%20actually%20prefer%20to%20have%20a%20variable%20defined%20inside%20the%20travis%20script.%5Cr%5Cn%5Cr%5CnIn%20that%20case%2C%20I%20would%20modify%20the%20_mvn_%20invocation%20to%20include%20something%20like%20_-Ddocker.skip%3Dfalse_%20which%20could%20be%20made%20true%20as%20necessary.%20%20Is%20that%20what%20you%20had%20in%20mind%3F%22%2C%20%22created_at%22%3A%20%222016-02-23T16%3A30%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20sounds%20like%20something%20reasonable.%20We%20probably%20want%20to%20have%20it%20disabled%20by%20default%20%28so%20that%20people%20trying%20to%20build%20jmxtrans%20locally%20and%20who%20do%20not%20have%20docker%20installed%20can%20build%20it%20without%20issue%29.%22%2C%20%22created_at%22%3A%20%222016-02-23T16%3A33%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20seeing%20some%20intermittent%20issues%20with%20the%20Debian%20images.%20%20The%20apt-get%20updates%20when%20installing%20the%20JRE%20will%20occasionally%20fail.%20%20This%20seems%20to%20be%20a%20known%20issue%20with%20the%20debian%20mirrors%3A%5Cr%5Cn%5Cr%5Cnhttps%3A//lists.debian.org/debian-devel/2015/07/msg00132.html%5Cr%5Cnhttp%3A//stackoverflow.com/questions/32304631/docker-debian-apt-error-reading-from-server%5Cr%5Cnhttp%3A//serverfault.com/questions/690639/api-get-error-reading-from-server-under-docker%5Cr%5Cn%5Cr%5CnDo%20you%20think%20we%27ll%20get%20adequate%20coverage%20of%20installing%20the%20.deb%20with%20just%20testing%20on%20Ubuntu%3F%20%20If%20so%2C%20we%20can%20drop%20the%20debian%20images%20all%20together.%20%20Other%20than%20that%2C%20it%20sounds%20like%20we%27ll%20need%20to%20either%20use%20a%20specific%20mirror%20for%20pulling%20apt-get%20artifacts%20%28not%20a%20great%20solution%20IMO%29%20or%20add%20some%20basic%20retry%20logic%20to%20the%20apt-get%20update%20/%20install%20commands%20%28also%20not%20that%20great%29%5Cr%5Cn%5Cr%5CnThoughts%3F%22%2C%20%22created_at%22%3A%20%222016-02-23T20%3A41%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22Debian%20and%20Ubuntu%20should%20be%20close%20enough%20so%20that%20testing%20one%20is%20sufficient.%20More%20than%20that%2C%20having%20unstable%20tests%20is%20the%20best%20way%20to%20learn%20to%20ignore%20their%20results.%20And%20in%20any%20case%2C%20testing%20just%20one%20distro%20will%20already%20be%20so%20much%20better%20than%20the%20no%20tests%20at%20all%20that%20we%20have%20at%20the%20moment%21%22%2C%20%22created_at%22%3A%20%222016-02-24T08%3A51%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%20great.%20%20I%20moved%20the%20debian%20images%20in%20to%20a%20separate%20profile%20so%20that%20they%20can%20be%20run%20manually%20if%20needed.%22%2C%20%22created_at%22%3A%20%222016-02-24T20%3A10%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40gehel%20The%20build%20is%20still%20taking%20quite%20a%20while%20on%20Travis%20%28in%20some%20cases%20too%20long%20which%20causes%20it%20to%20hit%20the%20hard%20time%20limit%20and%20gets%20killed%29.%5Cr%5Cn%5Cr%5CnI%20think%20the%20issue%20is%20that%20I%27m%20building%20images%20from%20the%20base%20linux%20images%20and%20then%20running%20jmxtrans.%20%20It%20takes%20quite%20a%20while%20to%20pull%20down%20the%20JDK%20with%20all%20of%20its%20dependencies.%5Cr%5Cn%5Cr%5CnI%20think%20I%20can%20speed%20this%20up%20by%20pre-creating%20docker%20images%20with%20the%20JDK%20already%20installed%20and%20using%20that%20instead.%5Cr%5Cn%5Cr%5CnI%20see%20that%20there%20is%20already%20a%20jmxtrans%20public%20repo%20on%20docker%20hub%3A%20https%3A//hub.docker.com/r/jmxtrans/jmxtrans/%5Cr%5Cn%5Cr%5CnAre%20you%20the%20owner%20for%20this%3F%20%20If%20so%2C%20will%20you%20grant%20me%20write%20access%20so%20that%20I%20can%20push%20images%3F%22%2C%20%22created_at%22%3A%20%222016-02-25T14%3A58%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20might%20be%20able%20to%20use%20the%20official%20java%20images%20%28https%3A//hub.docker.com/_/java/%29.%20You%20are%20now%20part%20of%20the%20jmxtrans%20org%20on%20docker%20hub.%20Feel%20free%20to%20upload%20images%20if%20that%20make%20sense...%22%2C%20%22created_at%22%3A%20%222016-02-25T15%3A42%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20granting%20me%20access%21%5Cr%5Cn%5Cr%5Cn%3E%20You%20might%20be%20able%20to%20use%20the%20official%20java%20images%5Cr%5Cn%5Cr%5CnWe%20can%27t%20use%20the%20official%20images%20because%20we%20need%20OS%20specific%20images%20%28centos7%2C%20centos6.6%2C%20ubuntu%3Awheezy%20etc%29%20with%20java%20on%20them.%20%20%5Cr%5Cn%5Cr%5CnThe%20official%20java%20images%20appear%20to%20all%20use%20some%20ubuntu%20/%20debian%20version%22%2C%20%22created_at%22%3A%20%222016-02-25T15%3A51%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22They%20seem%20to%20be%20based%20on%20Jessie%2C%20so%20we%20might%20use%20them%20to%20test%20debian%20packages.%20But%20yes%2C%20if%20we%20want%20to%20test%20a%20large%20number%20of%20distro%2C%20we%20might%20need%20something%20more...%22%2C%20%22created_at%22%3A%20%222016-02-25T18%3A14%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40gehel%20I%27m%20happy%20with%20the%20current%20state%20of%20the%20PR.%20%20Creating%20specific%20images%20for%20each%20target%20OS%20really%20helped%20speed%20up%20the%20build%20and%20improve%20its%20stability%20on%20travis.%22%2C%20%22created_at%22%3A%20%222016-03-02T22%3A09%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22Great%20job%21%20If%20we%20ever%20meet%2C%20beer%20is%20on%20me%21%22%2C%20%22created_at%22%3A%20%222016-03-02T22%3A42%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2029910ff1c3aff577116eaa139428d82b7abd45cc%20jmxtrans-docker-test/src/main/docker/verify.sh%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r53725771%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20like%20a%20good%20place%20to%20start%20using%20%5BBats%5D%28https%3A//github.com/sstephenson/bats%29.%20And%20test%20more%20things%20than%20just%20jmxtrans%20starting.%20But%20that%27s%20evolution%20for%20later...%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-23T01%3A48%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-docker-test/src/main/docker/verify.sh%3AL1-30%22%7D%2C%20%22Pull%20e2777aa8a112f98a3f3a7fbfaada4185ce499129%20jmxtrans-docker-test/pom.xml%20101%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52825848%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20is%20a%20log%20of%20duplication%20in%20the%20definition%20of%20images.%20I%27m%20wondering%20if%20there%20isn%27t%20a%20way%20to%20simplify%20that.%20%28No%2C%20I%20have%20no%20idea%20of%20what%20that%20way%20might%20be%29.%22%2C%20%22created_at%22%3A%20%222016-02-13T09%3A47%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20I%27m%20not%20quite%20happy%20with%20amount%20of%20duplication%20but%20I%27ve%20tried%20to%20minimize%20it%20as%20much%20as%20possible.%20%20I%27m%20brainstorming%20on%20ways%20to%20improve%20this%20but%20I%20wanted%20to%20start%20testing%20this%20on%20Travis%20first%20while%20I%20had%20workable%20solution%20rather%20than%20continue%20to%20gold%20plate%20it.%22%2C%20%22created_at%22%3A%20%222016-02-13T17%3A06%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%2C%20that%27s%20cosmetic%2C%20don%27t%20let%20it%20stop%20you%21%22%2C%20%22created_at%22%3A%20%222016-02-13T17%3A23%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-02-23T01%3A50%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-docker-test/pom.xml%3AL1-427%22%7D%2C%20%22Pull%20e2777aa8a112f98a3f3a7fbfaada4185ce499129%20jmxtrans-docker-test/pom.xml%20229%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52825870%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20expect%20jmxtrans%20to%20start%20running%20when%20the%20package%20is%20installed.%20So%20%60/etc/init.d/jmxtrans%20start%60%20should%20probably%20not%20bee%20required.%22%2C%20%22created_at%22%3A%20%222016-02-13T09%3A50%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20doesn%27t%20start%20automatically.%20%20The%20only%20thing%20I%20see%20in%20the%20postInstall%20scriptlet%20is%20%60chkconfig%20--add%60%20which%20doesn%27t%20start%20the%20service.%20%20The%20%5Bman%20page%5D%28http%3A//linux.die.net/man/8/chkconfig%29%20seems%20to%20indicate%20that%20%60--add%60%20just%20registers%20the%20service%20with%20chkconfig%20but%20does%20not%20start%20it.%22%2C%20%22created_at%22%3A%20%222016-02-13T17%3A22%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20should%20probably%20be%20considered%20as%20a%20bug%2C%20but%20out%20of%20the%20scope%20of%20this%20PR.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-23T01%3A45%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-02-23T01%3A50%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-docker-test/pom.xml%3AL1-427%22%7D%2C%20%22Pull%2029910ff1c3aff577116eaa139428d82b7abd45cc%20jmxtrans-docker-test/pom.xml%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r53725461%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20move%20the%20version%20to%20the%20parent%20pom%3F%20That%20way%20we%20have%20all%20versions%20in%20the%20same%20place.%20Also%2C%20is%20it%20necessary%20to%20use%20the%20SNAPSHOT%20version%3F%20This%20is%20going%20to%20be%20a%20problem%20for%20releases.%20It%20seems%20that%20releases%20are%20made%20fairly%20often%20to%20this%20plugin%2C%20so%20I%20hope%20we%20can%20move%20to%20a%20released%20version.%22%2C%20%22created_at%22%3A%20%222016-02-23T01%3A44%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-docker-test/pom.xml%3AL1-439%22%7D%2C%20%22Pull%20e2777aa8a112f98a3f3a7fbfaada4185ce499129%20jmxtrans/pom.xml%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r52825842%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20are%20actually%20still%20supporting%20Java%201.6.%22%2C%20%22created_at%22%3A%20%222016-02-13T09%3A46%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20looks%20like%20the%20%60JCommanderArgumentParser%60%20library%20has%20a%20java%201.7%20dependency%20though.%20%20I%20saw%20the%20following%20error%20when%20I%20ran%20with%20jdk6%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5CnException%20in%20thread%20%5C%22main%5C%22%20java.lang.NoClassDefFoundError%3A%20java/nio/file/Path%5Cr%5Cn%5Ctat%20com.beust.jcommander.internal.DefaultConverterFactory.%3Cclinit%3E%28DefaultConverterFactory.java%3A66%29%5Cr%5Cn%5Ctat%20com.beust.jcommander.JCommander.%3Cclinit%3E%28JCommander.java%3A167%29%5Cr%5Cn%5Ctat%20com.googlecode.jmxtrans.cli.JCommanderArgumentParser.parseOptions%28JCommanderArgumentParser.java%3A35%29%5Cr%5Cn%5Ctat%20com.googlecode.jmxtrans.JmxTransformer.main%28JmxTransformer.java%3A118%29%5Cr%5CnCaused%20by%3A%20java.lang.ClassNotFoundException%3A%20java.nio.file.Path%5Cr%5Cn%5Ctat%20java.net.URLClassLoader%241.run%28URLClassLoader.java%3A217%29%5Cr%5Cn%5Ctat%20java.security.AccessController.doPrivileged%28Native%20Method%29%5Cr%5Cn%5Ctat%20java.net.URLClassLoader.findClass%28URLClassLoader.java%3A205%29%5Cr%5Cn%5Ctat%20java.lang.ClassLoader.loadClass%28ClassLoader.java%3A323%29%5Cr%5Cn%5Ctat%20sun.misc.Launcher%24AppClassLoader.loadClass%28Launcher.java%3A294%29%5Cr%5Cn%5Ctat%20java.lang.ClassLoader.loadClass%28ClassLoader.java%3A268%29%5Cr%5Cn%5Ct...%204%20more%5Cr%5CnException%20in%20thread%20%5C%22main%5C%22%20java.lang.NoClassDefFoundError%3A%20java/nio/file/Path%5Cr%5Cn%5Ctat%20com.beust.jcommander.internal.DefaultConverterFactory.%3Cclinit%3E%28DefaultConverterFactory.java%3A66%29%5Cr%5Cn%5Ctat%20com.beust.jcommander.JCommander.%3Cclinit%3E%28JCommander.java%3A167%29%5Cr%5Cn%5Ctat%20com.googlecode.jmxtrans.cli.JCommanderArgumentParser.parseOptions%28JCommanderArgumentParser.java%3A35%29%5Cr%5Cn%5Ctat%20com.googlecode.jmxtrans.JmxTransformer.main%28JmxTransformer.java%3A118%29%5Cr%5CnCaused%20by%3A%20java.lang.ClassNotFoundException%3A%20java.nio.file.Path%5Cr%5Cn%5Ctat%20java.net.URLClassLoader%241.run%28URLClassLoader.java%3A217%29%5Cr%5Cn%5Ctat%20java.security.AccessController.doPrivileged%28Native%20Method%29%5Cr%5Cn%5Ctat%20java.net.URLClassLoader.findClass%28URLClassLoader.java%3A205%29%5Cr%5Cn%5Ctat%20java.lang.ClassLoader.loadClass%28ClassLoader.java%3A323%29%5Cr%5Cn%5Ctat%20sun.misc.Launcher%24AppClassLoader.loadClass%28Launcher.java%3A294%29%5Cr%5Cn%5Ctat%20java.lang.ClassLoader.loadClass%28ClassLoader.java%3A268%29%5Cr%5Cn%5Ct...%204%20more%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-02-13T17%3A17%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22Damn%2C%20you%20might%20well%20be%20right.%20Maybe%20it%20is%20time%20to%20drop%201.6%20support.%20Oracle%20stopped%20public%20support%20in%202013%2C%20so%20it%20might%20be%20reasonable%20to%20upgrade%20to%201.7%20%28and%20try-with-resources%20at%20last%21%29%22%2C%20%22created_at%22%3A%20%222016-02-13T17%3A23%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sounds%20good.%20%20The%20jdk7%20requirement%20is%20why%20I%20didn%27t%20add%20images%20for%20older%20debian/centos%20releases%20that%20didn%27t%20have%20OOTB%20packages%20for%20jdk7%20%28debian%20squeeze%20for%20example%29.%22%2C%20%22created_at%22%3A%20%222016-02-13T17%3A24%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6921953%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kevinconaway%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20you%20put%20a%20dependency%20on%20Java%20%3E%3D%201.7%20in%20the%20packages%2C%20can%20you%20also%20update%20the%20configuration%20of%20the%20maven-compiler-plugin%3F%22%2C%20%22created_at%22%3A%20%222016-02-13T17%3A25%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222016-02-23T01%3A50%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans/pom.xml%3AL350-357%22%7D%2C%20%22Pull%2029910ff1c3aff577116eaa139428d82b7abd45cc%20pom.xml%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/423%23discussion_r53725561%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20we%20can%20remove%20the%20SNAPSHOT%20dependency%2C%20we%20can%20probably%20remove%20this%20repository%20as%20well.%22%2C%20%22created_at%22%3A%20%222016-02-23T01%3A45%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20pom.xml%3AL586-607%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/423#issuecomment-183488379'>General Comment</a></b>
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> @gehel Looks like pull requests are having issues with the GPG keys.
On my local fork, I tried disabling the gpg profile (via `-P !gpg...`) but the [rpm-maven-plugin](https://github.com/mojohaus/rpm-maven-plugin/blob/5da5c5c1d28647fea78402cc1f8494aec1b66e88/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java#L1537) looks at the `gpg.passphraseServerId` property and tries to load the gpg key.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This looks really interesting! I have a few comments, but I need some more time than I have right now to do your PR justice. I'll get back to you as soon as I can...
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> Thanks.  I'm experimenting now with the travis config to see how I can get pull requests to run without signing the RPM.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Looking at the travis build, it seems that the RPM builds just fine, but there is a requirement to update Maven to more recent version than what is on Travis. Should be doable...
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> >Looking at the travis build, it seems that the RPM builds just fine, but there is a requirement to update Maven to more recent version than what is on Travis. Should be doable...
Yes, I'm trying to get this sorted out.
The docker support on Travis is in beta and thus is using the beta [Trusty environment](https://docs.travis-ci.com/user/trusty-ci-environment) which is only using maven 3.1.1.  There is an [open issue](https://github.com/travis-ci/travis-ci/issues/4872) regarding the maven version so I'm hoping this gets addressed soon.
Separately, there is an [open issue](https://github.com/rhuss/docker-maven-plugin/issues/290) with the docker-maven-plugin regarding the maven version prerequisite.  I'm hoping that the hard requirement for 3.2.x isn't necessary.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> It should not be too hard to download and install Maven 3.3 at the start of the build and use it instead of the version coming by default on Travis. Ugly, yes, but probably working.
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> > It should not be too hard to download and install Maven 3.3 at the start of the build and use it instead of the version coming by default on Travis. Ugly, yes, but probably working.
Glad to know thats an option.  I'm going to see what progress I can make on the other 2 fronts first before approaching this one.
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> @gehel I'm still working on this.  I've fixed the above issues but it seems that docker on travis is quite unstable, the build often fails with timeouts while the docker images are being built.  I'm brainstorming on ways around that.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> @kevinconaway thanks a lot for what you are doing! Just thinking about it is already an achievement! Sorry I'm not of more help, I just started a new job and I'm fairly busy at the moment. I really want to have a deeper look in what you've been doing, but it's probably going to take some time.
Let me know if there is something specific on which I can help you ... I'll do my best.
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> Build is green now and I've been running it continuously all day on my local branch.  I'm not sure if that the flakiness is resolved or if today is just a good day for travis.
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> > Could you move the version to the parent pom? That way we have all versions in the same place. Also, is it necessary to use the SNAPSHOT version? This is going to be a problem for releases. It seems that releases are made fairly often to this plugin, so I hope we can move to a released version.
I've asked the docker-maven-plugin maintainer to release a new version.  That should come out in a few days, when it does, I will update the version and remove the plugin repo
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> If that's OK with you, I'll wait for the removal of the SNAPSHOT to merge this PR.
Again, thanks a lot for the work! That's really going to help!
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> > If that's OK with you, I'll wait for the removal of the SNAPSHOT to merge this PR.
Yes, definitely!
On a different topic, what are your thoughts on adding a travis envvar to control whether these tests run or not?  That way, if something goes wrong later down the line they can be skipped by modifying the travis envvar, rather than changing the code.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I'd actually prefer to have a variable defined inside the travis script. That way, the configuration itself is under version control. There is no good way (that I know of) to trace changes to travis envvars.
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> > I'd actually prefer to have a variable defined inside the travis script.
In that case, I would modify the _mvn_ invocation to include something like _-Ddocker.skip=false_ which could be made true as necessary.  Is that what you had in mind?
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> That sounds like something reasonable. We probably want to have it disabled by default (so that people trying to build jmxtrans locally and who do not have docker installed can build it without issue).
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> I'm seeing some intermittent issues with the Debian images.  The apt-get updates when installing the JRE will occasionally fail.  This seems to be a known issue with the debian mirrors:
https://lists.debian.org/debian-devel/2015/07/msg00132.html
http://stackoverflow.com/questions/32304631/docker-debian-apt-error-reading-from-server
http://serverfault.com/questions/690639/api-get-error-reading-from-server-under-docker
Do you think we'll get adequate coverage of installing the .deb with just testing on Ubuntu?  If so, we can drop the debian images all together.  Other than that, it sounds like we'll need to either use a specific mirror for pulling apt-get artifacts (not a great solution IMO) or add some basic retry logic to the apt-get update / install commands (also not that great)
Thoughts?
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Debian and Ubuntu should be close enough so that testing one is sufficient. More than that, having unstable tests is the best way to learn to ignore their results. And in any case, testing just one distro will already be so much better than the no tests at all that we have at the moment!
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> OK great.  I moved the debian images in to a separate profile so that they can be run manually if needed.
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> @gehel The build is still taking quite a while on Travis (in some cases too long which causes it to hit the hard time limit and gets killed).
I think the issue is that I'm building images from the base linux images and then running jmxtrans.  It takes quite a while to pull down the JDK with all of its dependencies.
I think I can speed this up by pre-creating docker images with the JDK already installed and using that instead.
I see that there is already a jmxtrans public repo on docker hub: https://hub.docker.com/r/jmxtrans/jmxtrans/
Are you the owner for this?  If so, will you grant me write access so that I can push images?
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> You might be able to use the official java images (https://hub.docker.com/_/java/). You are now part of the jmxtrans org on docker hub. Feel free to upload images if that make sense...
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> Thanks for granting me access!
> You might be able to use the official java images
We can't use the official images because we need OS specific images (centos7, centos6.6, ubuntu:wheezy etc) with java on them.
The official java images appear to all use some ubuntu / debian version
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> They seem to be based on Jessie, so we might use them to test debian packages. But yes, if we want to test a large number of distro, we might need something more...
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> @gehel I'm happy with the current state of the PR.  Creating specific images for each target OS really helped speed up the build and improve its stability on travis.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Great job! If we ever meet, beer is on me!
- [ ] <a href='#crh-comment-Pull 29910ff1c3aff577116eaa139428d82b7abd45cc jmxtrans-docker-test/pom.xml 48'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/423#discussion_r53725461'>File: jmxtrans-docker-test/pom.xml:L1-439</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Could you move the version to the parent pom? That way we have all versions in the same place. Also, is it necessary to use the SNAPSHOT version? This is going to be a problem for releases. It seems that releases are made fairly often to this plugin, so I hope we can move to a released version.
- [x] <a href='#crh-comment-Pull 29910ff1c3aff577116eaa139428d82b7abd45cc pom.xml 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/423#discussion_r53725561'>File: pom.xml:L586-607</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> If we can remove the SNAPSHOT dependency, we can probably remove this repository as well.
- [x] <a href='#crh-comment-Pull e2777aa8a112f98a3f3a7fbfaada4185ce499129 jmxtrans/pom.xml 34'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/423#discussion_r52825842'>File: jmxtrans/pom.xml:L350-357</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> We are actually still supporting Java 1.6.
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> It looks like the `JCommanderArgumentParser` library has a java 1.7 dependency though.  I saw the following error when I ran with jdk6:
```
Exception in thread "main" java.lang.NoClassDefFoundError: java/nio/file/Path
at com.beust.jcommander.internal.DefaultConverterFactory.<clinit>(DefaultConverterFactory.java:66)
at com.beust.jcommander.JCommander.<clinit>(JCommander.java:167)
at com.googlecode.jmxtrans.cli.JCommanderArgumentParser.parseOptions(JCommanderArgumentParser.java:35)
at com.googlecode.jmxtrans.JmxTransformer.main(JmxTransformer.java:118)
Caused by: java.lang.ClassNotFoundException: java.nio.file.Path
at java.net.URLClassLoader$1.run(URLClassLoader.java:217)
at java.security.AccessController.doPrivileged(Native Method)
at java.net.URLClassLoader.findClass(URLClassLoader.java:205)
at java.lang.ClassLoader.loadClass(ClassLoader.java:323)
at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:294)
at java.lang.ClassLoader.loadClass(ClassLoader.java:268)
... 4 more
Exception in thread "main" java.lang.NoClassDefFoundError: java/nio/file/Path
at com.beust.jcommander.internal.DefaultConverterFactory.<clinit>(DefaultConverterFactory.java:66)
at com.beust.jcommander.JCommander.<clinit>(JCommander.java:167)
at com.googlecode.jmxtrans.cli.JCommanderArgumentParser.parseOptions(JCommanderArgumentParser.java:35)
at com.googlecode.jmxtrans.JmxTransformer.main(JmxTransformer.java:118)
Caused by: java.lang.ClassNotFoundException: java.nio.file.Path
at java.net.URLClassLoader$1.run(URLClassLoader.java:217)
at java.security.AccessController.doPrivileged(Native Method)
at java.net.URLClassLoader.findClass(URLClassLoader.java:205)
at java.lang.ClassLoader.loadClass(ClassLoader.java:323)
at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:294)
at java.lang.ClassLoader.loadClass(ClassLoader.java:268)
... 4 more
```
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Damn, you might well be right. Maybe it is time to drop 1.6 support. Oracle stopped public support in 2013, so it might be reasonable to upgrade to 1.7 (and try-with-resources at last!)
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> Sounds good.  The jdk7 requirement is why I didn't add images for older debian/centos releases that didn't have OOTB packages for jdk7 (debian squeeze for example).
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> If you put a dependency on Java >= 1.7 in the packages, can you also update the configuration of the maven-compiler-plugin?
- [x] <a href='#crh-comment-Pull e2777aa8a112f98a3f3a7fbfaada4185ce499129 jmxtrans-docker-test/pom.xml 101'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/423#discussion_r52825848'>File: jmxtrans-docker-test/pom.xml:L1-427</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> There is a log of duplication in the definition of images. I'm wondering if there isn't a way to simplify that. (No, I have no idea of what that way might be).
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> Yes, I'm not quite happy with amount of duplication but I've tried to minimize it as much as possible.  I'm brainstorming on ways to improve this but I wanted to start testing this on Travis first while I had workable solution rather than continue to gold plate it.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Yep, that's cosmetic, don't let it stop you!
- [x] <a href='#crh-comment-Pull e2777aa8a112f98a3f3a7fbfaada4185ce499129 jmxtrans-docker-test/pom.xml 229'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/423#discussion_r52825870'>File: jmxtrans-docker-test/pom.xml:L1-427</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I would expect jmxtrans to start running when the package is installed. So `/etc/init.d/jmxtrans start` should probably not bee required.
- <a href='https://github.com/kevinconaway'><img border=0 src='https://avatars.githubusercontent.com/u/6921953?v=3' height=16 width=16'></a> It doesn't start automatically.  The only thing I see in the postInstall scriptlet is `chkconfig --add` which doesn't start the service.  The [man page](http://linux.die.net/man/8/chkconfig) seems to indicate that `--add` just registers the service with chkconfig but does not start it.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> That should probably be considered as a bug, but out of the scope of this PR. :+1:
- [x] <a href='#crh-comment-Pull 29910ff1c3aff577116eaa139428d82b7abd45cc jmxtrans-docker-test/src/main/docker/verify.sh 25'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/423#discussion_r53725771'>File: jmxtrans-docker-test/src/main/docker/verify.sh:L1-30</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Seems like a good place to start using [Bats](https://github.com/sstephenson/bats). And test more things than just jmxtrans starting. But that's evolution for later... :+1:


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/423?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/423?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/423'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>