### PR TITLE
Add the ability to configure a FlushStrategy on TCP and UDP outputwriters

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
@@ -22,23 +22,20 @@
  */
 package com.googlecode.jmxtrans.model.output.support;
 
-import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.OutputWriterAdapter;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
-import com.googlecode.jmxtrans.model.ValidationException;
 import com.googlecode.jmxtrans.model.results.BooleanAsNumberValueTransformer;
 import com.googlecode.jmxtrans.model.results.IdentityValueTransformer;
 import com.googlecode.jmxtrans.model.results.ResultValuesTransformer;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
-import java.util.Map;
 
 import static com.google.common.collect.FluentIterable.from;
 
-public class ResultTransformerOutputWriter<T extends OutputWriter> implements OutputWriter {
+public class ResultTransformerOutputWriter<T extends OutputWriter> extends OutputWriterAdapter {
 
 	@Nonnull private final ResultValuesTransformer resultValuesTransformer;
 	@Nonnull private final T target;
@@ -49,28 +46,11 @@ public class ResultTransformerOutputWriter<T extends OutputWriter> implements Ou
 	}
 
 	@Override
-	public void start() throws LifecycleException {
-	}
-
-	@Override
-	public void stop() throws LifecycleException {
-	}
-
-	@Override
 	public void doWrite(Server server, Query query, Iterable<Result> results) throws Exception {
 		target.doWrite(
 				server,
 				query,
 				from(results).transform(resultValuesTransformer).toList());
-	}
-
-	@Override
-	public Map<String, Object> getSettings() {
-		return Collections.emptyMap();
-	}
-
-	@Override
-	public void validateSetup(Server server, Query query) throws ValidationException {
 	}
 
 	public static <T extends OutputWriter> ResultTransformerOutputWriter<T> booleanToNumber(boolean booleanToNumber, T target) {

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -57,7 +57,7 @@
 				<artifactId>docker-maven-plugin</artifactId>
 				<configuration>
 					<showLogs>true</showLogs>
-					<images />
+					<images></images>
 				</configuration>
 				<executions>
 					<execution>

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
@@ -29,15 +29,18 @@ import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter;
 import com.googlecode.jmxtrans.model.output.support.TcpOutputWriterBuilder;
 import com.googlecode.jmxtrans.model.output.support.WriterPoolOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.pool.FlushStrategy;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import java.net.InetSocketAddress;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.googlecode.jmxtrans.model.output.support.pool.FlushStrategyUtils.createFlushStrategy;
 
 /**
  * This low latency and thread safe output writer sends data to a host/port combination
@@ -52,10 +55,11 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 
 	private static final String DEFAULT_ROOT_PREFIX = "servers";
 
-	private final String rootPrefix;
-	private final InetSocketAddress graphiteServer;
-	private final ImmutableList<String> typeNames;
+	@Nonnull private final String rootPrefix;
+	@Nonnull private final InetSocketAddress graphiteServer;
+	@Nonnull private final ImmutableList<String> typeNames;
 	private final boolean booleanAsNumber;
+	@Nonnull private final FlushStrategy flushStrategy;
 
 	@JsonCreator
 	public GraphiteWriterFactory(
@@ -63,7 +67,9 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
 			@JsonProperty("rootPrefix") String rootPrefix,
 			@JsonProperty("host") String host,
-			@JsonProperty("port") Integer port) {
+			@JsonProperty("port") Integer port,
+			@JsonProperty("flushStrategy") String flushStrategy,
+			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds) {
 		this.typeNames = typeNames;
 		this.booleanAsNumber = booleanAsNumber;
 		this.rootPrefix = firstNonNull(rootPrefix, DEFAULT_ROOT_PREFIX);
@@ -71,6 +77,7 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 		this.graphiteServer = new InetSocketAddress(
 				checkNotNull(host, "Host cannot be null."),
 				checkNotNull(port, "Port cannot be null."));
+		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
 	}
 
 	@Override
@@ -79,6 +86,7 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 				booleanAsNumber,
 				TcpOutputWriterBuilder.builder(graphiteServer, new GraphiteWriter2(typeNames, rootPrefix))
 						.setCharset(UTF_8)
+						.setFlushStrategy(flushStrategy)
 						.build()
 		);
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
@@ -32,6 +32,7 @@ import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWrite
 import com.googlecode.jmxtrans.model.output.support.TcpOutputWriterBuilder;
 import com.googlecode.jmxtrans.model.output.support.WriterPoolOutputWriter;
 import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
+import com.googlecode.jmxtrans.model.output.support.pool.FlushStrategy;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -43,6 +44,7 @@ import java.net.UnknownHostException;
 import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.googlecode.jmxtrans.model.output.support.pool.FlushStrategyUtils.createFlushStrategy;
 
 @ThreadSafe
 @EqualsAndHashCode
@@ -52,6 +54,7 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 	@Nonnull private final boolean booleanAsNumber;
 	@Nonnull private final InetSocketAddress server;
 	@Nonnull private final OpenTSDBMessageFormatter messageFormatter;
+	@Nonnull private final FlushStrategy flushStrategy;
 
 	@JsonCreator
 	public OpenTSDBWriterFactory(
@@ -63,7 +66,9 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 			@JsonProperty("tagName") String tagName,
 			@JsonProperty("mergeTypeNamesTags") Boolean mergeTypeNamesTags,
 			@JsonProperty("metricNamingExpression") String metricNamingExpression,
-			@JsonProperty("addHostnameTag") Boolean addHostnameTag) throws LifecycleException, UnknownHostException {
+			@JsonProperty("addHostnameTag") Boolean addHostnameTag,
+			@JsonProperty("flushStrategy") String flushStrategy,
+			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds) throws LifecycleException, UnknownHostException {
 
 		this.booleanAsNumber = booleanAsNumber;
 		this.server = new InetSocketAddress(
@@ -76,6 +81,7 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 		messageFormatter = new OpenTSDBMessageFormatter(typeNames, immutableTags, tagName,
 				metricNamingExpression, mergeTypeNamesTags,
 				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);
+		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
 	}
 
 	@Override
@@ -85,6 +91,7 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 				TcpOutputWriterBuilder.builder(
 						server,
 						new OpenTSDBWriter2(messageFormatter))
+						.setFlushStrategy(flushStrategy)
 						.build());
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactory.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.output.support.UdpOutputWriterBuilder;
 import com.googlecode.jmxtrans.model.output.support.WriterPoolOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.pool.FlushStrategy;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -36,6 +37,7 @@ import java.net.InetSocketAddress;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.googlecode.jmxtrans.model.output.support.pool.FlushStrategyUtils.createFlushStrategy;
 
 @EqualsAndHashCode
 @ToString
@@ -47,6 +49,7 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 	@Nonnull private final String bucketType;
 	@Nonnull private final Long stringValueDefaultCount;
 	@Nonnull private final InetSocketAddress server;
+	@Nonnull private final FlushStrategy flushStrategy;
 
 	public StatsDWriterFactory(
 			@JsonProperty("typeNames") ImmutableList<String> typeNames,
@@ -55,7 +58,9 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 			@JsonProperty("stringValuesAsKey") boolean stringsValuesAsKey,
 			@JsonProperty("stringValueDefaultCount") Long stringValueDefaultCount,
 			@JsonProperty("host") String host,
-			@JsonProperty("port") Integer port) {
+			@JsonProperty("port") Integer port,
+			@JsonProperty("flushStrategy") String flushStrategy,
+			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds) {
 		this.typeNames = firstNonNull(typeNames, ImmutableList.<String>of());
 		this.rootPrefix = firstNonNull(rootPrefix, "servers");
 		this.stringsValuesAsKey = stringsValuesAsKey;
@@ -64,6 +69,7 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 		this.server = new InetSocketAddress(
 				checkNotNull(host, "Host cannot be null."),
 				checkNotNull(port, "Port cannot be null."));
+		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
 	}
 
 	@Override
@@ -72,6 +78,7 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 				server,
 				new StatsDWriter2(typeNames, rootPrefix, bucketType, stringsValuesAsKey, stringValueDefaultCount))
 				.setCharset(UTF_8)
+				.setFlushStrategy(flushStrategy)
 				.build();
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriterBuilder.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriterBuilder.java
@@ -23,6 +23,8 @@
 package com.googlecode.jmxtrans.model.output.support;
 
 import com.google.common.base.Charsets;
+import com.googlecode.jmxtrans.model.output.support.pool.FlushStrategy;
+import com.googlecode.jmxtrans.model.output.support.pool.NeverFlush;
 import com.googlecode.jmxtrans.model.output.support.pool.SocketAllocator;
 import com.googlecode.jmxtrans.model.output.support.pool.SocketExpiration;
 import com.googlecode.jmxtrans.model.output.support.pool.SocketPoolable;
@@ -41,17 +43,12 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Accessors(chain = true)
 public class TcpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
-	@Nonnull
-	private final InetSocketAddress server;
-	@Nonnull
-	private final T target;
-	@Nonnull
-	@Setter
-	private Charset charset = Charsets.UTF_8;
-	@Setter
-	private int socketTimeoutMillis = 200;
-	@Setter
-	private int poolSize = 1;
+	@Nonnull private final InetSocketAddress server;
+	@Nonnull private final T target;
+	@Nonnull @Setter private Charset charset = Charsets.UTF_8;
+	@Setter private int socketTimeoutMillis = 200;
+	@Setter private int poolSize = 1;
+	@Nonnull @Setter private FlushStrategy flushStrategy = new NeverFlush();
 
 	private TcpOutputWriterBuilder(@Nonnull InetSocketAddress server, @Nonnull T target) {
 		this.server = server;
@@ -69,7 +66,8 @@ public class TcpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
 				.setAllocator(new SocketAllocator(
 						server,
 						socketTimeoutMillis,
-						charset))
+						charset,
+						flushStrategy))
 				.setExpiration(new SocketExpiration())
 				.setSize(poolSize);
 		return new BlazePool<SocketPoolable>(config);

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/UdpOutputWriterBuilder.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/UdpOutputWriterBuilder.java
@@ -26,6 +26,8 @@ import com.google.common.base.Charsets;
 import com.googlecode.jmxtrans.model.output.support.pool.DatagramChannelAllocator;
 import com.googlecode.jmxtrans.model.output.support.pool.DatagramChannelExpiration;
 import com.googlecode.jmxtrans.model.output.support.pool.DatagramChannelPoolable;
+import com.googlecode.jmxtrans.model.output.support.pool.FlushStrategy;
+import com.googlecode.jmxtrans.model.output.support.pool.NeverFlush;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import stormpot.BlazePool;
@@ -46,6 +48,7 @@ public class UdpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
 	@Nonnull @Setter private Charset charset = Charsets.UTF_8;
 	@Setter private int bufferSize = 1472;
 	@Setter private int poolSize = 1;
+	@Nonnull @Setter private FlushStrategy flushStrategy = new NeverFlush();
 
 	private UdpOutputWriterBuilder(@Nonnull InetSocketAddress server, @Nonnull T target) {
 		this.server = server;
@@ -63,7 +66,8 @@ public class UdpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
 				.setAllocator(new DatagramChannelAllocator(
 						server,
 						bufferSize,
-						charset))
+						charset,
+						flushStrategy))
 				.setExpiration(new DatagramChannelExpiration())
 				.setSize(poolSize);
 		return new BlazePool<DatagramChannelPoolable>(config);

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/AlwaysFlush.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/AlwaysFlush.java
@@ -22,44 +22,13 @@
  */
 package com.googlecode.jmxtrans.model.output.support.pool;
 
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import stormpot.Poolable;
-import stormpot.Slot;
-
 import javax.annotation.Nonnull;
+import java.io.Flushable;
 import java.io.IOException;
-import java.io.Writer;
 
-public class WriterPoolable implements Poolable {
-
-	private static final Logger logger = LoggerFactory.getLogger(WriterPoolable.class);
-
-	@Nonnull private final Slot slot;
-
-	@Nonnull @Getter private final Writer writer;
-
-	@Nonnull private final FlushStrategy flushStrategy;
-
-	public WriterPoolable(@Nonnull Slot slot, @Nonnull Writer writer, @Nonnull FlushStrategy flushStrategy) {
-		this.slot = slot;
-		this.writer = writer;
-		this.flushStrategy = flushStrategy;
-	}
-
+public class AlwaysFlush implements FlushStrategy {
 	@Override
-	public void release() {
-		try {
-			flushStrategy.flush(writer);
-			slot.release(this);
-		} catch (IOException ioe) {
-			logger.error("Could not flush writer", ioe);
-			invalidate();
-		}
-	}
-
-	public void invalidate() {
-		slot.expire(this);
+	public void flush(@Nonnull Flushable flushable) throws IOException {
+		flushable.flush();
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/DatagramChannelAllocator.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/DatagramChannelAllocator.java
@@ -35,13 +35,19 @@ import java.nio.charset.Charset;
 public class DatagramChannelAllocator implements Allocator<DatagramChannelPoolable> {
 
 	@Nonnull private final InetSocketAddress server;
-	@Nonnull private final int bufferSize;
+	private final int bufferSize;
 	@Nonnull private final Charset charset;
+	@Nonnull private final FlushStrategy flushStrategy;
 
-	public DatagramChannelAllocator(@Nonnull InetSocketAddress server, @Nonnull int bufferSize, @Nonnull Charset charset) {
+	public DatagramChannelAllocator(
+			@Nonnull InetSocketAddress server,
+			int bufferSize,
+			@Nonnull Charset charset,
+			@Nonnull FlushStrategy flushStrategy) {
 		this.server = server;
 		this.bufferSize = bufferSize;
 		this.charset = charset;
+		this.flushStrategy = flushStrategy;
 	}
 
 	@Override
@@ -49,7 +55,7 @@ public class DatagramChannelAllocator implements Allocator<DatagramChannelPoolab
 		DatagramChannel channel = DatagramChannel.open();
 		channel.connect(new InetSocketAddress(server.getHostName(), server.getPort()));
 		ChannelWriter writer = new ChannelWriter(bufferSize, charset, channel);
-		return new DatagramChannelPoolable(slot, writer, channel);
+		return new DatagramChannelPoolable(slot, writer, channel, flushStrategy);
 	}
 
 	@Override

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/DatagramChannelPoolable.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/DatagramChannelPoolable.java
@@ -33,8 +33,12 @@ public class DatagramChannelPoolable extends WriterPoolable {
 
 	@Nonnull @Getter private final DatagramChannel channel;
 
-	public DatagramChannelPoolable(@Nonnull Slot slot, @Nonnull Writer writer, @Nonnull DatagramChannel channel) {
-		super(slot, writer);
+	public DatagramChannelPoolable(
+			@Nonnull Slot slot,
+			@Nonnull Writer writer,
+			@Nonnull DatagramChannel channel,
+			@Nonnull FlushStrategy flushStrategy) {
+		super(slot, writer, flushStrategy);
 		this.channel = channel;
 	}
 

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/FlushStrategy.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/FlushStrategy.java
@@ -22,44 +22,10 @@
  */
 package com.googlecode.jmxtrans.model.output.support.pool;
 
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import stormpot.Poolable;
-import stormpot.Slot;
-
 import javax.annotation.Nonnull;
+import java.io.Flushable;
 import java.io.IOException;
-import java.io.Writer;
 
-public class WriterPoolable implements Poolable {
-
-	private static final Logger logger = LoggerFactory.getLogger(WriterPoolable.class);
-
-	@Nonnull private final Slot slot;
-
-	@Nonnull @Getter private final Writer writer;
-
-	@Nonnull private final FlushStrategy flushStrategy;
-
-	public WriterPoolable(@Nonnull Slot slot, @Nonnull Writer writer, @Nonnull FlushStrategy flushStrategy) {
-		this.slot = slot;
-		this.writer = writer;
-		this.flushStrategy = flushStrategy;
-	}
-
-	@Override
-	public void release() {
-		try {
-			flushStrategy.flush(writer);
-			slot.release(this);
-		} catch (IOException ioe) {
-			logger.error("Could not flush writer", ioe);
-			invalidate();
-		}
-	}
-
-	public void invalidate() {
-		slot.expire(this);
-	}
+public interface FlushStrategy {
+	void flush(@Nonnull Flushable flushable) throws IOException;
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/NeverFlush.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/NeverFlush.java
@@ -22,44 +22,12 @@
  */
 package com.googlecode.jmxtrans.model.output.support.pool;
 
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import stormpot.Poolable;
-import stormpot.Slot;
-
 import javax.annotation.Nonnull;
+import java.io.Flushable;
 import java.io.IOException;
-import java.io.Writer;
 
-public class WriterPoolable implements Poolable {
-
-	private static final Logger logger = LoggerFactory.getLogger(WriterPoolable.class);
-
-	@Nonnull private final Slot slot;
-
-	@Nonnull @Getter private final Writer writer;
-
-	@Nonnull private final FlushStrategy flushStrategy;
-
-	public WriterPoolable(@Nonnull Slot slot, @Nonnull Writer writer, @Nonnull FlushStrategy flushStrategy) {
-		this.slot = slot;
-		this.writer = writer;
-		this.flushStrategy = flushStrategy;
-	}
-
+public class NeverFlush implements FlushStrategy {
 	@Override
-	public void release() {
-		try {
-			flushStrategy.flush(writer);
-			slot.release(this);
-		} catch (IOException ioe) {
-			logger.error("Could not flush writer", ioe);
-			invalidate();
-		}
-	}
-
-	public void invalidate() {
-		slot.expire(this);
+	public void flush(@Nonnull Flushable flushable) throws IOException {
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/SocketAllocator.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/SocketAllocator.java
@@ -39,11 +39,17 @@ public class SocketAllocator implements Allocator<SocketPoolable> {
 	@Nonnull private final InetSocketAddress server;
 	private final int socketTimeoutMillis;
 	@Nonnull private final Charset charset;
+	@Nonnull private final FlushStrategy flushStrategy;
 
-	public SocketAllocator(@Nonnull InetSocketAddress server, int socketTimeoutMillis, @Nonnull Charset charset) {
+	public SocketAllocator(
+			@Nonnull InetSocketAddress server,
+			int socketTimeoutMillis,
+			@Nonnull Charset charset,
+			@Nonnull FlushStrategy flushStrategy) {
 		this.server = server;
 		this.socketTimeoutMillis = socketTimeoutMillis;
 		this.charset = charset;
+		this.flushStrategy = flushStrategy;
 	}
 
 	@Override
@@ -56,7 +62,7 @@ public class SocketAllocator implements Allocator<SocketPoolable> {
 
 		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), charset));
 
-		return new SocketPoolable(slot, socket, writer);
+		return new SocketPoolable(slot, socket, writer, flushStrategy);
 	}
 
 	@Override

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/SocketPoolable.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/SocketPoolable.java
@@ -32,8 +32,12 @@ import java.net.Socket;
 public class SocketPoolable extends WriterPoolable {
 	@Nonnull @Getter private final Socket socket;
 
-	public SocketPoolable(@Nonnull Slot slot, @Nonnull Socket socket, @Nonnull Writer writer) {
-		super(slot, writer);
+	public SocketPoolable(
+			@Nonnull Slot slot,
+			@Nonnull Socket socket,
+			@Nonnull Writer writer,
+			@Nonnull FlushStrategy flushStrategy) {
+		super(slot, writer, flushStrategy);
 		this.socket = socket;
 	}
 

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/LibratoWriterFactoryIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/LibratoWriterFactoryIT.java
@@ -24,10 +24,12 @@ package com.googlecode.jmxtrans.model.output;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableList;
+import com.google.common.eventbus.AllowConcurrentEvents;
 import com.googlecode.jmxtrans.model.QueryFixtures;
 import com.googlecode.jmxtrans.model.ResultFixtures;
 import com.googlecode.jmxtrans.model.ServerFixtures;
 import com.googlecode.jmxtrans.test.IntegrationTest;
+import com.kaching.platform.testing.AllowLocalFileAccess;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -44,6 +46,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 
 @Category(IntegrationTest.class)
+@AllowLocalFileAccess(paths = "*")
 public class LibratoWriterFactoryIT {
 	@Rule public WireMockRule wireMockRule = new WireMockRule(1234);
 

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactoryIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactoryIT.java
@@ -56,7 +56,8 @@ public class StatsDWriterFactoryIT {
 			ImmutableList.<String>of(),
 				null, null, false, null,
 				udpLoggingServer.getLocalSocketAddress().getHostName(),
-				udpLoggingServer.getLocalSocketAddress().getPort()
+				udpLoggingServer.getLocalSocketAddress().getPort(),
+				null, null
 		).create();
 
 		statsDWriter.doWrite(dummyServer(), dummyQuery(), dummyResults());

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/HttpOutputWriterIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/HttpOutputWriterIT.java
@@ -24,6 +24,9 @@ package com.googlecode.jmxtrans.model.output.support;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.googlecode.jmxtrans.test.IntegrationTest;
+import com.kaching.platform.testing.AllowLocalFileAccess;
+import com.kaching.platform.testing.AllowNetworkAccess;
+import com.kaching.platform.testing.AllowNetworkListen;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/WriterPoolOutputWriterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/WriterPoolOutputWriterTest.java
@@ -25,6 +25,7 @@ package com.googlecode.jmxtrans.model.output.support;
 import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.output.support.pool.NeverFlush;
 import com.googlecode.jmxtrans.model.output.support.pool.SocketPoolable;
 import com.googlecode.jmxtrans.model.output.support.pool.WriterPoolable;
 import com.googlecode.jmxtrans.test.IntegrationTest;
@@ -120,7 +121,7 @@ public class WriterPoolOutputWriterTest {
 	private class DummyAllocator implements Allocator<WriterPoolable> {
 		@Override
 		public WriterPoolable allocate(Slot slot) throws Exception {
-			return new SocketPoolable(slot, null, writer);
+			return new SocketPoolable(slot, null, writer, new NeverFlush());
 		}
 
 		@Override

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/AlwaysFlushTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/AlwaysFlushTest.java
@@ -22,44 +22,24 @@
  */
 package com.googlecode.jmxtrans.model.output.support.pool;
 
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import stormpot.Poolable;
-import stormpot.Slot;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
-import javax.annotation.Nonnull;
+import java.io.Flushable;
 import java.io.IOException;
-import java.io.Writer;
 
-public class WriterPoolable implements Poolable {
+import static org.mockito.Mockito.verify;
 
-	private static final Logger logger = LoggerFactory.getLogger(WriterPoolable.class);
+@RunWith(MockitoJUnitRunner.class)
+public class AlwaysFlushTest {
 
-	@Nonnull private final Slot slot;
+	@Mock private Flushable flushable;
 
-	@Nonnull @Getter private final Writer writer;
-
-	@Nonnull private final FlushStrategy flushStrategy;
-
-	public WriterPoolable(@Nonnull Slot slot, @Nonnull Writer writer, @Nonnull FlushStrategy flushStrategy) {
-		this.slot = slot;
-		this.writer = writer;
-		this.flushStrategy = flushStrategy;
-	}
-
-	@Override
-	public void release() {
-		try {
-			flushStrategy.flush(writer);
-			slot.release(this);
-		} catch (IOException ioe) {
-			logger.error("Could not flush writer", ioe);
-			invalidate();
-		}
-	}
-
-	public void invalidate() {
-		slot.expire(this);
+	@Test
+	public void argumentIsAlwaysFlushed() throws IOException {
+		new AlwaysFlush().flush(flushable);
+		verify(flushable).flush();
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/NeverFlushTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/NeverFlushTest.java
@@ -22,44 +22,25 @@
  */
 package com.googlecode.jmxtrans.model.output.support.pool;
 
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import stormpot.Poolable;
-import stormpot.Slot;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
-import javax.annotation.Nonnull;
+import java.io.Flushable;
 import java.io.IOException;
-import java.io.Writer;
 
-public class WriterPoolable implements Poolable {
+import static org.mockito.Mockito.verifyZeroInteractions;
 
-	private static final Logger logger = LoggerFactory.getLogger(WriterPoolable.class);
+@RunWith(MockitoJUnitRunner.class)
+public class NeverFlushTest {
 
-	@Nonnull private final Slot slot;
+	@Mock private Flushable flushable;
 
-	@Nonnull @Getter private final Writer writer;
-
-	@Nonnull private final FlushStrategy flushStrategy;
-
-	public WriterPoolable(@Nonnull Slot slot, @Nonnull Writer writer, @Nonnull FlushStrategy flushStrategy) {
-		this.slot = slot;
-		this.writer = writer;
-		this.flushStrategy = flushStrategy;
+	@Test
+	public void argumentIsNeverFlushed() throws IOException {
+		new NeverFlush().flush(flushable);
+		verifyZeroInteractions(flushable);
 	}
 
-	@Override
-	public void release() {
-		try {
-			flushStrategy.flush(writer);
-			slot.release(this);
-		} catch (IOException ioe) {
-			logger.error("Could not flush writer", ioe);
-			invalidate();
-		}
-	}
-
-	public void invalidate() {
-		slot.expire(this);
-	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/SocketAllocatorTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/SocketAllocatorTest.java
@@ -54,7 +54,7 @@ public class SocketAllocatorTest {
 		try {
 			echoServer.start();
 
-			SocketAllocator socketAllocator = new SocketAllocator(echoServer.getLocalSocketAddress(), 100, UTF_8);
+			SocketAllocator socketAllocator = new SocketAllocator(echoServer.getLocalSocketAddress(), 100, UTF_8, new NeverFlush());
 			SocketPoolable socketPoolable = socketAllocator.allocate(mock(Slot.class));
 
 			try {
@@ -72,11 +72,11 @@ public class SocketAllocatorTest {
 
 	@Test
 	public void socketAndWritersAreClosed() throws Exception {
-		SocketAllocator socketAllocator = new SocketAllocator(new InetSocketAddress("localhost", 80), 100, UTF_8);
+		SocketAllocator socketAllocator = new SocketAllocator(new InetSocketAddress("localhost", 80), 100, UTF_8, new NeverFlush());
 
 		Socket socket = mock(Socket.class);
 		Writer writer = mock(Writer.class);
-		SocketPoolable socketPoolable = new SocketPoolable(null, socket, writer);
+		SocketPoolable socketPoolable = new SocketPoolable(null, socket, writer, new NeverFlush());
 		socketAllocator.deallocate(socketPoolable);
 
 		verify(socket).close();
@@ -85,14 +85,14 @@ public class SocketAllocatorTest {
 
 	@Test(expected = IOException.class)
 	public void socketAndWritersAreClosedEvenWhenExceptions() throws Exception {
-		SocketAllocator socketAllocator = new SocketAllocator(new InetSocketAddress("localhost", 80), 100, UTF_8);
+		SocketAllocator socketAllocator = new SocketAllocator(new InetSocketAddress("localhost", 80), 100, UTF_8, new NeverFlush());
 
 		Socket socket = mock(Socket.class);
 		doThrow(IOException.class).when(socket).close();
 		Writer writer = mock(Writer.class);
 		doThrow(IOException.class).when(writer).close();
 
-		SocketPoolable socketPoolable = new SocketPoolable(null, socket, writer);
+		SocketPoolable socketPoolable = new SocketPoolable(null, socket, writer, new NeverFlush());
 		socketAllocator.deallocate(socketPoolable);
 
 		verify(socket).close();

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/TimeBasedFlushTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/TimeBasedFlushTest.java
@@ -1,0 +1,71 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output.support.pool;
+
+import com.googlecode.jmxtrans.util.ManualClock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.Flushable;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TimeBasedFlushTest {
+
+	@Mock private Flushable flushable;
+
+	@Test
+	public void argumentIsNotFlushedBeforeDelay() throws IOException {
+		ManualClock clock = new ManualClock();
+		TimeBasedFlush timeBasedFlush = new TimeBasedFlush(clock, 60, SECONDS);
+
+		timeBasedFlush.flush(flushable);
+		verifyZeroInteractions(flushable);
+
+		clock.waitFor(10, SECONDS);
+		timeBasedFlush.flush(flushable);
+		verifyZeroInteractions(flushable);
+
+		clock.waitFor(10, SECONDS);
+		timeBasedFlush.flush(flushable);
+		verifyZeroInteractions(flushable);
+	}
+
+	@Test
+	public void argumentIsFlushedAfterDelay() throws IOException {
+		ManualClock clock = new ManualClock();
+		TimeBasedFlush timeBasedFlush = new TimeBasedFlush(clock, 60, SECONDS);
+
+		clock.waitFor(61, SECONDS);
+		timeBasedFlush.flush(flushable);
+		verify(flushable).flush();
+	}
+
+}

--- a/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/util/Clock.java
+++ b/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/util/Clock.java
@@ -20,46 +20,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.model.output.support.pool;
+package com.googlecode.jmxtrans.util;
 
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import stormpot.Poolable;
-import stormpot.Slot;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.io.Writer;
-
-public class WriterPoolable implements Poolable {
-
-	private static final Logger logger = LoggerFactory.getLogger(WriterPoolable.class);
-
-	@Nonnull private final Slot slot;
-
-	@Nonnull @Getter private final Writer writer;
-
-	@Nonnull private final FlushStrategy flushStrategy;
-
-	public WriterPoolable(@Nonnull Slot slot, @Nonnull Writer writer, @Nonnull FlushStrategy flushStrategy) {
-		this.slot = slot;
-		this.writer = writer;
-		this.flushStrategy = flushStrategy;
-	}
-
-	@Override
-	public void release() {
-		try {
-			flushStrategy.flush(writer);
-			slot.release(this);
-		} catch (IOException ioe) {
-			logger.error("Could not flush writer", ioe);
-			invalidate();
-		}
-	}
-
-	public void invalidate() {
-		slot.expire(this);
-	}
+public interface Clock {
+	long currentTimeMillis();
 }

--- a/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/util/SystemClock.java
+++ b/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/util/SystemClock.java
@@ -20,46 +20,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.model.output.support.pool;
+package com.googlecode.jmxtrans.util;
 
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import stormpot.Poolable;
-import stormpot.Slot;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.io.Writer;
-
-public class WriterPoolable implements Poolable {
-
-	private static final Logger logger = LoggerFactory.getLogger(WriterPoolable.class);
-
-	@Nonnull private final Slot slot;
-
-	@Nonnull @Getter private final Writer writer;
-
-	@Nonnull private final FlushStrategy flushStrategy;
-
-	public WriterPoolable(@Nonnull Slot slot, @Nonnull Writer writer, @Nonnull FlushStrategy flushStrategy) {
-		this.slot = slot;
-		this.writer = writer;
-		this.flushStrategy = flushStrategy;
-	}
-
+public class SystemClock implements Clock {
 	@Override
-	public void release() {
-		try {
-			flushStrategy.flush(writer);
-			slot.release(this);
-		} catch (IOException ioe) {
-			logger.error("Could not flush writer", ioe);
-			invalidate();
-		}
-	}
-
-	public void invalidate() {
-		slot.expire(this);
+	public long currentTimeMillis() {
+		return System.currentTimeMillis();
 	}
 }

--- a/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/ManualClockTest.java
+++ b/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/ManualClockTest.java
@@ -20,46 +20,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.model.output.support.pool;
+package com.googlecode.jmxtrans.util;
 
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import stormpot.Poolable;
-import stormpot.Slot;
+import org.junit.Test;
 
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.io.Writer;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class WriterPoolable implements Poolable {
+public class ManualClockTest {
 
-	private static final Logger logger = LoggerFactory.getLogger(WriterPoolable.class);
-
-	@Nonnull private final Slot slot;
-
-	@Nonnull @Getter private final Writer writer;
-
-	@Nonnull private final FlushStrategy flushStrategy;
-
-	public WriterPoolable(@Nonnull Slot slot, @Nonnull Writer writer, @Nonnull FlushStrategy flushStrategy) {
-		this.slot = slot;
-		this.writer = writer;
-		this.flushStrategy = flushStrategy;
+	@Test
+	public void clockCanBeInitialized() {
+		ManualClock clock = new ManualClock(10, SECONDS);
+		assertThat(clock.currentTimeMillis()).isEqualTo(10000);
 	}
 
-	@Override
-	public void release() {
-		try {
-			flushStrategy.flush(writer);
-			slot.release(this);
-		} catch (IOException ioe) {
-			logger.error("Could not flush writer", ioe);
-			invalidate();
-		}
-	}
-
-	public void invalidate() {
-		slot.expire(this);
+	@Test
+	public void canWaitForDuration() {
+		ManualClock clock = new ManualClock();
+		assertThat(clock.currentTimeMillis()).isEqualTo(0L);
+		clock.waitFor(10, MINUTES);
+		assertThat(clock.currentTimeMillis()).isEqualTo(10 * 60 * 1000);
 	}
 }

--- a/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/SystemClockTest.java
+++ b/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/SystemClockTest.java
@@ -20,46 +20,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.model.output.support.pool;
+package com.googlecode.jmxtrans.util;
 
-import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import stormpot.Poolable;
-import stormpot.Slot;
+import org.junit.Test;
 
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.io.Writer;
+import static java.lang.System.currentTimeMillis;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
-public class WriterPoolable implements Poolable {
+public class SystemClockTest {
 
-	private static final Logger logger = LoggerFactory.getLogger(WriterPoolable.class);
-
-	@Nonnull private final Slot slot;
-
-	@Nonnull @Getter private final Writer writer;
-
-	@Nonnull private final FlushStrategy flushStrategy;
-
-	public WriterPoolable(@Nonnull Slot slot, @Nonnull Writer writer, @Nonnull FlushStrategy flushStrategy) {
-		this.slot = slot;
-		this.writer = writer;
-		this.flushStrategy = flushStrategy;
+	@Test
+	public void correctTimeIsReturned() {
+		// pretty dumb test, I know...
+		assertThat(new SystemClock().currentTimeMillis()).isCloseTo(currentTimeMillis(), within(100L));
 	}
 
-	@Override
-	public void release() {
-		try {
-			flushStrategy.flush(writer);
-			slot.release(this);
-		} catch (IOException ioe) {
-			logger.error("Could not flush writer", ioe);
-			invalidate();
-		}
-	}
-
-	public void invalidate() {
-		slot.expire(this);
-	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -504,8 +504,8 @@
 			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
-				<!-- AssertJ > 3 does not support Java 7 anymore, let's stay with 2.0.0 for the moment -->
-				<version>2.0.0</version>
+				<!-- AssertJ > 3 does not support Java 7 anymore, let's stay with 2.X.X for the moment -->
+				<version>2.3.0</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -777,7 +777,7 @@
 							<phase>test-compile</phase>
 							<configuration>
 								<rules>
-									<NoPackageCyclesRule implementation="de.andrena.tools.nopackagecycles.NoPackageCyclesRule" />
+									<NoPackageCyclesRule implementation="de.andrena.tools.nopackagecycles.NoPackageCyclesRule"></NoPackageCyclesRule>
 								</rules>
 							</configuration>
 						</execution>


### PR DESCRIPTION
This can be configured with the `flushStrategy` paramter which can take
the following values: `never`, `always` and `timeBased`. If `timeBased` is
choosen, the additional `flushDelayInSeconds` paramter is required.

Fixes #433
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/434?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/434'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>