### PR TITLE
Correct issue with multiple instances of output writers being created

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/ServerListBuilder.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/ServerListBuilder.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.SingletonOutputWriterFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -61,6 +62,7 @@ public class ServerListBuilder {
 	}
 
 	private OutputWriterFactory singleton(OutputWriterFactory outputWriter) {
+		outputWriter = new SingletonOutputWriterFactory(outputWriter);
 		if (!outputWriters.containsKey(outputWriter)) outputWriters.put(outputWriter, outputWriter);
 		return outputWriters.get(outputWriter);
 	}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/SingletonOutputWriterFactory.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/SingletonOutputWriterFactory.java
@@ -22,17 +22,26 @@
  */
 package com.googlecode.jmxtrans.model;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import javax.annotation.Nonnull;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import static com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.NON_NULL;
+@ToString
+@EqualsAndHashCode(of = "outputWriterFactory")
+public class SingletonOutputWriterFactory<T extends OutputWriter> implements OutputWriterFactory<T> {
 
-@JsonSerialize(include = NON_NULL)
-@JsonTypeInfo(use = Id.CLASS, include = As.PROPERTY, property = "@class")
-public interface OutputWriterFactory<T extends OutputWriter> {
-	@Nonnull T create();
+	@Nonnull private final T outputWriter;
+
+	@Nonnull private final OutputWriterFactory<T> outputWriterFactory;
+
+	public SingletonOutputWriterFactory(@Nonnull OutputWriterFactory<T> outputWriterFactory) {
+		this.outputWriterFactory = outputWriterFactory;
+		outputWriter = outputWriterFactory.create();
+	}
+
+	@Override
+	public T create() {
+		return outputWriter;
+	}
 }

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/ServerListBuilderTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/ServerListBuilderTest.java
@@ -42,6 +42,7 @@ import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static com.googlecode.jmxtrans.model.ServerFixtures.serverWithNoQuery;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ServerListBuilderTest {
 
@@ -71,6 +72,7 @@ public class ServerListBuilderTest {
 
 		Server createdServer = serverList.iterator().next();
 		assertThat(createdServer.getOutputWriterFactories()).hasSize(3);
+		assertThat(createdServer.getOutputWriters()).hasSize(3);
 	}
 
 	@Test
@@ -97,10 +99,14 @@ public class ServerListBuilderTest {
 		Query query2 = queryIterator.next();
 
 		assertThat(query1.getOutputWriters()).hasSize(1);
+		assertThat(query1.getOutputWriterInstances()).hasSize(1);
 		assertThat(query2.getOutputWriters()).hasSize(1);
+		assertThat(query2.getOutputWriterInstances()).hasSize(1);
 
 		assertThat(query1.getOutputWriters().iterator().next())
 				.isSameAs(query2.getOutputWriters().iterator().next());
+		assertThat(query1.getOutputWriterInstances().iterator().next())
+				.isSameAs(query2.getOutputWriterInstances().iterator().next());
 	}
 
 	@Test
@@ -122,6 +128,9 @@ public class ServerListBuilderTest {
 
 		assertThat(createdServer.getOutputWriterFactories().iterator().next())
 				.isSameAs(createdQuery.getOutputWriters().iterator().next());
+
+		assertThat(createdServer.getOutputWriters().iterator().next())
+				.isSameAs(createdQuery.getOutputWriterInstances().iterator().next());
 	}
 
 	@EqualsAndHashCode

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/SingletonOutputWriterFactoryTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/SingletonOutputWriterFactoryTest.java
@@ -1,0 +1,67 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model;
+
+import lombok.EqualsAndHashCode;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingletonOutputWriterFactoryTest {
+
+	@Test
+	public void sameInstanceIsAlwaysReturned() {
+		SingletonOutputWriterFactory outputWriterFactory = new SingletonOutputWriterFactory(new DummyOutputWriterFactory());
+
+		OutputWriter outputWriter1 = outputWriterFactory.create();
+		OutputWriter outputWriter2 = outputWriterFactory.create();
+
+		assertThat(outputWriter1).isSameAs(outputWriter2);
+	}
+
+	@Test
+	public void twoSingletonFactoriesAreEqualIfTheyWrapTheSameFactory() {
+		SingletonOutputWriterFactory outputWriterFactory1 = new SingletonOutputWriterFactory(new DummyOutputWriterFactory());
+		SingletonOutputWriterFactory outputWriterFactory2 = new SingletonOutputWriterFactory(new DummyOutputWriterFactory());
+
+		assertThat(outputWriterFactory1).isEqualTo(outputWriterFactory2);
+	}
+
+	@EqualsAndHashCode
+	private static final class DummyOutputWriterFactory implements OutputWriterFactory {
+
+		@Nonnull
+		@Override
+		public OutputWriter create() {
+			return new OutputWriterAdapter() {
+				@Override
+				public void doWrite(Server server, Query query, Iterable<Result> results) throws Exception {
+
+				}
+			};
+		}
+	}
+
+}


### PR DESCRIPTION
as pointed out in #432.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/435?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/435'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>