### PR TITLE
Make XXXWriter Pool configurable

### DIFF
--- a/jmxtrans-core/pom.xml
+++ b/jmxtrans-core/pom.xml
@@ -39,9 +39,9 @@
 
 	<properties>
 		<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-		<verify.mutationThreshold>18</verify.mutationThreshold>
-		<verify.totalBranchRate>38</verify.totalBranchRate>
-		<verify.totalLineRate>40</verify.totalLineRate>
+		<verify.mutationThreshold>25</verify.mutationThreshold>
+		<verify.totalBranchRate>41</verify.totalBranchRate>
+		<verify.totalLineRate>47</verify.totalLineRate>
 	</properties>
 
 	<dependencies>

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
@@ -60,6 +60,7 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 	@Nonnull private final ImmutableList<String> typeNames;
 	private final boolean booleanAsNumber;
 	@Nonnull private final FlushStrategy flushStrategy;
+	private final int poolSize;
 
 	@JsonCreator
 	public GraphiteWriterFactory(
@@ -69,7 +70,8 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 			@JsonProperty("host") String host,
 			@JsonProperty("port") Integer port,
 			@JsonProperty("flushStrategy") String flushStrategy,
-			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds) {
+			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
+			@JsonProperty("poolSize") Integer poolSize) {
 		this.typeNames = typeNames;
 		this.booleanAsNumber = booleanAsNumber;
 		this.rootPrefix = firstNonNull(rootPrefix, DEFAULT_ROOT_PREFIX);
@@ -78,6 +80,7 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 				checkNotNull(host, "Host cannot be null."),
 				checkNotNull(port, "Port cannot be null."));
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
+		this.poolSize = firstNonNull(poolSize, 1);
 	}
 
 	@Override
@@ -87,6 +90,7 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 				TcpOutputWriterBuilder.builder(graphiteServer, new GraphiteWriter2(typeNames, rootPrefix))
 						.setCharset(UTF_8)
 						.setFlushStrategy(flushStrategy)
+						.setPoolSize(poolSize)
 						.build()
 		);
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
@@ -55,6 +55,7 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 	@Nonnull private final InetSocketAddress server;
 	@Nonnull private final OpenTSDBMessageFormatter messageFormatter;
 	@Nonnull private final FlushStrategy flushStrategy;
+	private final int poolSize;
 
 	@JsonCreator
 	public OpenTSDBWriterFactory(
@@ -68,7 +69,8 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 			@JsonProperty("metricNamingExpression") String metricNamingExpression,
 			@JsonProperty("addHostnameTag") Boolean addHostnameTag,
 			@JsonProperty("flushStrategy") String flushStrategy,
-			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds) throws LifecycleException, UnknownHostException {
+			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
+			@JsonProperty("poolSize") Integer poolSize) throws LifecycleException, UnknownHostException {
 
 		this.booleanAsNumber = booleanAsNumber;
 		this.server = new InetSocketAddress(
@@ -82,6 +84,7 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 				metricNamingExpression, mergeTypeNamesTags,
 				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
+		this.poolSize = firstNonNull(poolSize, 1);
 	}
 
 	@Override
@@ -92,6 +95,7 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 						server,
 						new OpenTSDBWriter2(messageFormatter))
 						.setFlushStrategy(flushStrategy)
+						.setPoolSize(poolSize)
 						.build());
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/SensuWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/SensuWriterFactory.java
@@ -49,6 +49,7 @@ public class SensuWriterFactory implements OutputWriterFactory {
 	@Nonnull private final ImmutableList<String> typeNames;
 	@Nullable private final String rootPrefix;
 	@Nonnull private final FlushStrategy flushStrategy;
+	private final int poolSize;
 
 	public SensuWriterFactory(
 			@JsonProperty("typeNames") ImmutableList<String> typeNames,
@@ -57,7 +58,8 @@ public class SensuWriterFactory implements OutputWriterFactory {
 			@JsonProperty("port") Integer port,
 			@JsonProperty("rootPrefix") String rootPrefix,
 			@JsonProperty("flushStrategy") String flushStrategy,
-			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds) {
+			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
+			@JsonProperty("poolSize") Integer poolSize) {
 		this.rootPrefix = rootPrefix;
 		this.typeNames = firstNonNull(typeNames, ImmutableList.<String>of());
 		this.booleanAsNumber = booleanAsNumber;
@@ -65,6 +67,7 @@ public class SensuWriterFactory implements OutputWriterFactory {
 				firstNonNull(host, "localhost"),
 				firstNonNull(port, 3030));
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
+		this.poolSize = firstNonNull(poolSize, 1);
 	}
 
 	@Override
@@ -77,6 +80,7 @@ public class SensuWriterFactory implements OutputWriterFactory {
 								new GraphiteWriter2(typeNames, rootPrefix),
 								new JsonFactory()))
 						.setFlushStrategy(flushStrategy)
+						.setPoolSize(poolSize)
 						.build());
 	}
 

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactory.java
@@ -50,6 +50,7 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 	@Nonnull private final Long stringValueDefaultCount;
 	@Nonnull private final InetSocketAddress server;
 	@Nonnull private final FlushStrategy flushStrategy;
+	private final int poolSize;
 
 	public StatsDWriterFactory(
 			@JsonProperty("typeNames") ImmutableList<String> typeNames,
@@ -60,7 +61,8 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 			@JsonProperty("host") String host,
 			@JsonProperty("port") Integer port,
 			@JsonProperty("flushStrategy") String flushStrategy,
-			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds) {
+			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
+			@JsonProperty("poolSize") Integer poolSize) {
 		this.typeNames = firstNonNull(typeNames, ImmutableList.<String>of());
 		this.rootPrefix = firstNonNull(rootPrefix, "servers");
 		this.stringsValuesAsKey = stringsValuesAsKey;
@@ -70,6 +72,7 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 				checkNotNull(host, "Host cannot be null."),
 				checkNotNull(port, "Port cannot be null."));
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
+		this.poolSize = firstNonNull(poolSize, 1);
 	}
 
 	@Override
@@ -79,6 +82,7 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 				new StatsDWriter2(typeNames, rootPrefix, bucketType, stringsValuesAsKey, stringValueDefaultCount))
 				.setCharset(UTF_8)
 				.setFlushStrategy(flushStrategy)
+				.setPoolSize(poolSize)
 				.build();
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java
@@ -55,6 +55,7 @@ public class TCollectorUDPWriterFactory implements OutputWriterFactory {
 	@Nonnull private final InetSocketAddress server;
 	@Nonnull private final OpenTSDBMessageFormatter messageFormatter;
 	@Nonnull private final FlushStrategy flushStrategy;
+	private final int poolSize;
 
 	@JsonCreator
 	public TCollectorUDPWriterFactory(
@@ -68,7 +69,8 @@ public class TCollectorUDPWriterFactory implements OutputWriterFactory {
 			@JsonProperty("metricNamingExpression") String metricNamingExpression,
 			@JsonProperty("addHostnameTag") Boolean addHostnameTag,
 			@JsonProperty("flushStrategy") String flushStrategy,
-			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds) throws LifecycleException, UnknownHostException {
+			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
+			@JsonProperty("poolSize") Integer poolSize) throws LifecycleException, UnknownHostException {
 
 		this.booleanAsNumber = booleanAsNumber;
 		this.server = new InetSocketAddress(
@@ -82,6 +84,7 @@ public class TCollectorUDPWriterFactory implements OutputWriterFactory {
 				metricNamingExpression, mergeTypeNamesTags,
 				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
+		this.poolSize = firstNonNull(poolSize, 1);
 	}
 	@Override
 	public OutputWriter create() {
@@ -91,6 +94,7 @@ public class TCollectorUDPWriterFactory implements OutputWriterFactory {
 						server,
 						new TCollectorUDPWriter2(messageFormatter))
 						.setFlushStrategy(flushStrategy)
+						.setPoolSize(poolSize)
 						.build());
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactoryIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactoryIT.java
@@ -57,7 +57,7 @@ public class StatsDWriterFactoryIT {
 				null, null, false, null,
 				udpLoggingServer.getLocalSocketAddress().getHostName(),
 				udpLoggingServer.getLocalSocketAddress().getPort(),
-				null, null
+				null, null, null
 		).create();
 
 		statsDWriter.doWrite(dummyServer(), dummyQuery(), dummyResults());


### PR DESCRIPTION
Introduce a `poolSize` parameters on OutputWriter that use a TCP or UDP pool.

The pool used for those output writers is stormpot [1]. Have a look at its
documentation [2] for details.

This fixes #432.

[1] https://github.com/chrisvest/stormpot
[2] http://chrisvest.github.io/stormpot/site/apidocs/stormpot/Config.html
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/436?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/436'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>