### PR TITLE
Spread queries over time

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/cli/JmxTransConfiguration.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/cli/JmxTransConfiguration.java
@@ -120,7 +120,7 @@ public class JmxTransConfiguration {
 			validateWith = PositiveInteger.class
 	)
 	@Getter @Setter
-	private int queryProcessorExecutorWorkQueueCapacity = 1000;
+	private int queryProcessorExecutorWorkQueueCapacity = 100000;
 
 	@Parameter(
 			names = {"--result-processor-executor-pool-size"},
@@ -136,6 +136,6 @@ public class JmxTransConfiguration {
 			validateWith = PositiveInteger.class
 	)
 	@Getter @Setter
-	private int resultProcessorExecutorWorkQueueCapacity = 1000;
+	private int resultProcessorExecutorWorkQueueCapacity = 100000;
 
 }

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java
@@ -1,0 +1,46 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans;
+
+import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JmxTransformerTest {
+
+	@Test
+	public void startDateIsSpreadAccordingToRunPeriod() {
+		JmxTransformer jmxTransformer = new JmxTransformer(null, new JmxTransConfiguration(), null, null, null, null);
+
+		Date now = new Date();
+
+		assertThat(jmxTransformer.computeSpreadStartDate(60))
+				.isBetween(now, new Date(now.getTime() + MILLISECONDS.convert(60, SECONDS)));
+	}
+
+}


### PR DESCRIPTION
Instead of querying averything at the 60 second mark (or whatever the
runPeriod is), spread them a bit.

Also increased the queue size of executor services to something more
reasonnable.

This should fix #443.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/444?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/444'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>