### PR TITLE
Truncate double values below C precision to zero

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
@@ -65,6 +65,21 @@ public final class ResultFixtures {
 				ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", 10));
 	}
 
+	public static Result numericBelowCPrecisionResult() {
+		return new Result(
+				0,
+				"ObjectPendingFinalizationCount",
+				"sun.management.MemoryImpl",
+				"ObjectDomainName",
+				"ObjectPendingFinalizationCount",
+				"type=Memory",
+				ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", Double.MIN_VALUE));
+	}
+
+	public static Iterable<Result> singleNumericBelowCPrecisionResult() {
+		return ImmutableList.of(numericBelowCPrecisionResult());
+	}
+
 	public static Result numericResultWithTypenames(String typeName) {
 		return new Result(
 				0,

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
@@ -32,6 +32,8 @@ import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.ValidationException;
 import com.googlecode.jmxtrans.model.naming.KeyUtils;
+import com.googlecode.jmxtrans.model.results.CPrecisionValueTransformer;
+import com.googlecode.jmxtrans.model.results.ValueTransformer;
 import com.googlecode.jmxtrans.monitoring.ManagedGenericKeyedObjectPool;
 import com.googlecode.jmxtrans.monitoring.ManagedObject;
 import lombok.EqualsAndHashCode;
@@ -85,6 +87,8 @@ public class StatsDWriter extends BaseOutputWriter {
 
 	private GenericKeyedObjectPool<SocketAddress, DatagramSocket> pool;
 	private ManagedObject mbean;
+
+	@Nonnull private final ValueTransformer valueTransformer = new CPrecisionValueTransformer();
 
 
 	/**
@@ -197,11 +201,12 @@ public class StatsDWriter extends BaseOutputWriter {
 	}
 
 	private String computeActualValue(Object value){
-		if(isNumeric(value)){
-			return ":" + value.toString();
+		Object transformedValue = valueTransformer.apply(value);
+		if(isNumeric(transformedValue)){
+			return ":" + transformedValue.toString();
 		}
 
-		return "." + value.toString() + ":" + stringValueDefaultCount.toString();
+		return "." + transformedValue.toString() + ":" + stringValueDefaultCount.toString();
 	}
 
 	private synchronized boolean doSend(String stat) {

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter2.java
@@ -27,6 +27,8 @@ import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.naming.KeyUtils;
 import com.googlecode.jmxtrans.model.output.support.WriterBasedOutputWriter;
+import com.googlecode.jmxtrans.model.results.CPrecisionValueTransformer;
+import com.googlecode.jmxtrans.model.results.ValueTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,6 +54,9 @@ public class StatsDWriter2 implements WriterBasedOutputWriter {
 	private final String bucketType;
 	@Nonnull
 	private final String stringValueDefaultCount;
+
+	@Nonnull
+	private final ValueTransformer valueTransformer = new CPrecisionValueTransformer();
 
 	public StatsDWriter2(
 			@Nonnull List<String> typeNames,
@@ -89,10 +94,11 @@ public class StatsDWriter2 implements WriterBasedOutputWriter {
 	}
 
 	private String computeActualValue(Object value) {
-		if (isNumeric(value)) {
-			return ":" + value.toString();
+		Object transformedValue = valueTransformer.apply(value);
+		if (isNumeric(transformedValue)) {
+			return ":" + transformedValue.toString();
 		}
 
-		return "." + value.toString() + ":" + stringValueDefaultCount;
+		return "." + transformedValue.toString() + ":" + stringValueDefaultCount;
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriter2Test.java
@@ -30,6 +30,7 @@ import java.io.StringWriter;
 
 import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
 import static com.googlecode.jmxtrans.model.ResultFixtures.dummyResults;
+import static com.googlecode.jmxtrans.model.ResultFixtures.singleNumericBelowCPrecisionResult;
 import static com.googlecode.jmxtrans.model.ResultFixtures.singleNumericResult;
 import static com.googlecode.jmxtrans.model.ResultFixtures.singleTrueResult;
 import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
@@ -46,6 +47,17 @@ public class StatsDWriter2Test {
 
 		assertThat(out.toString())
 				.isEqualTo("root.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount:10|c\n");
+	}
+
+	@Test
+	public void valuesTruncatedToCPrecision() throws IOException {
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L);
+
+		StringWriter out = new StringWriter();
+		writer.write(out, dummyServer(), dummyQuery(), singleNumericBelowCPrecisionResult());
+
+		assertThat(out.toString())
+				.isEqualTo("root.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount:0|c\n");
 	}
 
 	@Test


### PR DESCRIPTION
This fixes #448 in the same way it was fixed in #272.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/449?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/449'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>