### PR TITLE
Change Query's typeNames from Set to List

### DIFF
--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/QueryTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/QueryTests.java
@@ -1,0 +1,115 @@
+/**
+ * The MIT License
+ * Copyright (c) 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import static com.google.common.collect.ImmutableList.copyOf;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newLinkedHashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueryTests {
+	@Test
+	public void testBuilderTypeNamesListFooBar() {
+		List<String> expected = newArrayList("foo", "bar");
+
+		Query query = Query.builder()
+				.setObj("obj:key=val")
+				.setTypeNames(expected)
+				.build();
+		
+		List<String> actual = newArrayList(query.getTypeNames());
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void testBuilderTypeNamesListBarFoo() {
+		List<String> expected = newArrayList("bar", "foo");
+
+		Query query = Query.builder()
+				.setObj("obj:key=val")
+				.setTypeNames(expected)
+				.build();
+		
+		List<String> actual = newArrayList(query.getTypeNames());
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void testBuilderTypeNamesSetFooBar() {
+		List<String> expected = newArrayList("foo", "bar");
+
+		Query query = Query.builder()
+				.setObj("obj:key=val")
+				.setTypeNames(newLinkedHashSet(expected))
+				.build();
+		
+		List<String> actual = newArrayList(query.getTypeNames());
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void testBuilderTypeNamesSetBarFoo() {
+		List<String> expected = newArrayList("bar", "foo");
+
+		Query query = Query.builder()
+				.setObj("obj:key=val")
+				.setTypeNames(newLinkedHashSet(expected))
+				.build();
+		
+		List<String> actual = newArrayList(query.getTypeNames());
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	public void testBuilderTypeNameValueStringFooBar() {
+		List<String> typeNames = copyOf(newArrayList("foo", "bar"));
+		String typeNameStr = "foo=FOO,bar=BAR,baz=BAZ";
+		Query query = Query.builder()
+				.setObj("obj:" + typeNameStr)
+				.setTypeNames(typeNames)
+				.build();
+
+		String actual = query.makeTypeNameValueString(typeNames, typeNameStr);
+		
+		assertThat(actual).isEqualTo("FOO_BAR");
+	}
+
+	@Test
+	public void testBuilderTypeNameValueStringBarFoo() {
+		List<String> typeNames = copyOf(newArrayList("bar", "foo"));
+		String typeNameStr = "foo=FOO,bar=BAR,baz=BAZ";
+		Query query = Query.builder()
+				.setObj("obj:" + typeNameStr)
+				.setTypeNames(typeNames)
+				.build();
+
+		String actual = query.makeTypeNameValueString(typeNames, typeNameStr);
+		
+		assertThat(actual).isEqualTo("BAR_FOO");
+	}
+}


### PR DESCRIPTION
Storing `typeNames` as `Set` matches the fact that "key properties" of
an `ObjectName` are an unordered set [0]. But for `ObjectName`s like

  org.apache.cassandra.db:type=ColumnFamilies,keyspace=foo,columnfamily=bar

and `typeNames` of `["keyspace", "columnfamily"]`, the set nature gets
in the way, as it is unpredictable whether metrics will get reported
as `foo_bar`, or `bar_foo`. To avoid such issues, we store `typeNames`
in the order specified by the user. That way, we can provide
predictable names that matches user's preference.

Since such a change may affect downstream users, we're still exposing
the methods for typeName sets, but we deprecated them in favor of list
variants.

Fixes #463

[0] http://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/464%23issuecomment-220245771%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/464%23issuecomment-220245771%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20for%20the%20fix%21%20I%20actually%20would%20prefer%20to%20use%20a%20%5B%60LinkedHashSet%60%5D%28https%3A//docs.oracle.com/javase/7/docs/api/java/util/LinkedHashSet.html%29%20wrapped%20by%20%5B%60Collections.unmodifiableSet%28%29%60%5D%28https%3A//docs.oracle.com/javase/7/docs/api/java/util/Collections.html%23unmodifiableSet%28java.util.Set%29%29.%20That%20way%20we%20maintain%20the%20Set%20semantic%20%28it%20is%20clear%20that%20you%20can%27t%20duplicate%20typeNames%29%20and%20we%20fix%20the%20ordering%20issue.%20To%20ensure%20we%20don%27t%20loose%20the%20order%20at%20construction%2C%20%60Query%60s%20constructor%20should%20take%20a%20%60List%60%20as%20parameter%2C%20but%20the%20internal%20storage%20should%20keep%20a%20%60Set%60.%5Cr%5Cn%5Cr%5CnDoes%20it%20sound%20like%20a%20reasonable%20solution%20to%20you%3F%22%2C%20%22created_at%22%3A%20%222016-05-19T07%3A16%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/464#issuecomment-220245771'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Thanks for the fix! I actually would prefer to use a [`LinkedHashSet`](https://docs.oracle.com/javase/7/docs/api/java/util/LinkedHashSet.html) wrapped by [`Collections.unmodifiableSet()`](https://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#unmodifiableSet(java.util.Set)). That way we maintain the Set semantic (it is clear that you can't duplicate typeNames) and we fix the ordering issue. To ensure we don't loose the order at construction, `Query`s constructor should take a `List` as parameter, but the internal storage should keep a `Set`.
Does it sound like a reasonable solution to you?


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/464?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/464?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/464'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>