### PR TITLE
Fix default jmxtrans-all.jar location

### DIFF
--- a/jmxtrans/jmxtrans.sh
+++ b/jmxtrans/jmxtrans.sh
@@ -42,7 +42,7 @@ JAVA_HOME=${JAVA_HOME:-"/usr"}
 LOG_DIR=${LOG_DIR:-"."}
 LOG_FILE=${LOG_FILE:-"/dev/null"}
 
-JAR_FILE=${JAR_FILE:-"jmxtrans-all.jar"}
+JAR_FILE=${JAR_FILE:-"lib/jmxtrans-all.jar"}
 ADDITIONAL_JARS=${ADDITIONAL_JARS:-""}
 JSON_DIR=${JSON_DIR:-"."}
 SECONDS_BETWEEN_RUNS=${SECONDS_BETWEEN_RUNS:-"60"}


### PR DESCRIPTION
sysvinit initscript starts jmxtrans.sh under `/usr/share/jmxtrans`
so the default `JAR_FILE` location should be set relative to that
path: `/usr/share/jmxtrans/lib/jmxtrans-all.jar`

Usually `/etc/default/jmxtrans` sets `JAR_FILE` so it is shadowing the
default location bug.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/469%23issuecomment-225429602%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/469%23issuecomment-225429602%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20for%20the%20fix%21%22%2C%20%22created_at%22%3A%20%222016-06-12T12%3A25%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/469#issuecomment-225429602'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Thanks for the fix!


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/469?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/469?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/469'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>