### PR TITLE
Close invalidated JMX Connection when query execution fails.

### DIFF
--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
@@ -219,7 +219,7 @@ public class ServerTests {
 	}
 
 	@Test
-	public void testConnectionRepoolingSkippedOnError() throws Exception {
+	public void testConnectionRepoolingSkippedOnError_andConnectionIsClosed() throws Exception {
 		@SuppressWarnings("unchecked")
 		GenericKeyedObjectPool<JmxConnectionProvider, JMXConnection> pool = mock(GenericKeyedObjectPool.class);
 
@@ -250,7 +250,51 @@ public class ServerTests {
 			}
 		}
 
-		verify(pool, never()).returnObject(server, conn);;
+		verify(conn).close();
+
+		verify(pool, never()).returnObject(server, conn);
+
+		InOrder orderVerifier = inOrder(pool);
+		orderVerifier.verify(pool).borrowObject(server);
+		orderVerifier.verify(pool).invalidateObject(server, conn);
+	}
+
+	@Test
+	public void testConnectionRepoolingSkippedOnError_andErrorClosingConnectionIsIgnored() throws Exception {
+		@SuppressWarnings("unchecked")
+		GenericKeyedObjectPool<JmxConnectionProvider, JMXConnection> pool = mock(GenericKeyedObjectPool.class);
+
+		Server server = Server.builder()
+				.setHost("host.example.net")
+				.setPort("4321")
+				.setLocal(true)
+				.setPool(pool)
+				.build();
+
+		MBeanServerConnection mBeanConn = mock(MBeanServerConnection.class);
+
+		JMXConnection conn = mock(JMXConnection.class);
+		when(conn.getMBeanServerConnection()).thenReturn(mBeanConn);
+		doThrow(new IOException()).when(conn).close();
+
+		when(pool.borrowObject(server)).thenReturn(conn);
+
+		Query query = mock(Query.class);
+		IOException e = mock(IOException.class);
+		when(query.queryNames(mBeanConn)).thenThrow(e);
+
+		try {
+			server.execute(query);
+			fail("No exception got throws");
+		} catch (IOException e2) {
+			if (e != e2) {
+				fail("Wrong exception thrown (" + e + " instead of mock");
+			}
+		}
+
+		verify(conn).close();
+
+		verify(pool, never()).returnObject(server, conn);
 
 		InOrder orderVerifier = inOrder(pool);
 		orderVerifier.verify(pool).borrowObject(server);


### PR DESCRIPTION
When an error occurs during execution of a JMX query, the JMXConnection object is invalidated in the pool. This means that future queries will not reuse the existing JMXConnection, rather creating a new one.

We should ensure that the JMXConnection is closed before invalidating/discarding it in order to avoid resource leaks.

There is no knowledge about the original query error, which means that the JMXConnection may be in an invalid state. Hence just ignore and log any exceptions that may be thrown when we try to close it on error.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/470?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/470'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>