### PR TITLE
 Add custom tags to influxDbWriter

### DIFF
--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -1,17 +1,17 @@
 /**
  * The MIT License
  * Copyright © 2010 JmxTrans team
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -57,16 +57,11 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 
 	public static final String TAG_HOSTNAME = "hostname";
 
-	@Nonnull
-	private final InfluxDB influxDB;
-	@Nonnull
-	private final String database;
-	@Nonnull
-	private final ConsistencyLevel writeConsistency;
-	@Nonnull
-	private final String retentionPolicy;
-	@Nonnull
-	private final ImmutableMap<String, String> tags;
+	@Nonnull private final InfluxDB influxDB;
+	@Nonnull private final String database;
+	@Nonnull private final ConsistencyLevel writeConsistency;
+	@Nonnull private final String retentionPolicy;
+	@Nonnull private final ImmutableMap<String,String> tags;
 
 	/**
 	 * The {@link ImmutableSet} of {@link ResultAttribute} attributes of
@@ -81,7 +76,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 			@Nonnull String database,
 			@Nonnull ConsistencyLevel writeConsistency,
 			@Nonnull String retentionPolicy,
-			@Nonnull ImmutableMap<String, String> tags,
+			@Nonnull ImmutableMap<String,String> tags,
 			@Nonnull ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags,
 			boolean createDatabase) {
 		this.database = database;
@@ -157,8 +152,8 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 		BatchPoints.Builder batchPointsBuilder = BatchPoints.database(database).retentionPolicy(retentionPolicy)
 				.tag(TAG_HOSTNAME, server.getSource());
 
-		for (Map.Entry<String, String> tag : tags.entrySet()) {
-			batchPointsBuilder.tag(tag.getKey(), tag.getValue());
+		for(Map.Entry<String,String> tag : tags.entrySet()) {
+			batchPointsBuilder.tag(tag.getKey(),tag.getValue());
 		}
 		BatchPoints batchPoints = batchPointsBuilder.consistency(writeConsistency).build();
 		for (Result result : results) {

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -1,17 +1,17 @@
 /**
  * The MIT License
  * Copyright © 2010 JmxTrans team
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -57,11 +57,16 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 
 	public static final String TAG_HOSTNAME = "hostname";
 
-	@Nonnull private final InfluxDB influxDB;
-	@Nonnull private final String database;
-	@Nonnull private final ConsistencyLevel writeConsistency;
-	@Nonnull private final String retentionPolicy;
-	@Nonnull private final ImmutableMap<String,String> tags;
+	@Nonnull
+	private final InfluxDB influxDB;
+	@Nonnull
+	private final String database;
+	@Nonnull
+	private final ConsistencyLevel writeConsistency;
+	@Nonnull
+	private final String retentionPolicy;
+	@Nonnull
+	private final ImmutableMap<String, String> tags;
 
 	/**
 	 * The {@link ImmutableSet} of {@link ResultAttribute} attributes of
@@ -76,7 +81,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 			@Nonnull String database,
 			@Nonnull ConsistencyLevel writeConsistency,
 			@Nonnull String retentionPolicy,
-			@Nonnull ImmutableMap<String,String> tags,
+			@Nonnull ImmutableMap<String, String> tags,
 			@Nonnull ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags,
 			boolean createDatabase) {
 		this.database = database;
@@ -152,8 +157,8 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 		BatchPoints.Builder batchPointsBuilder = BatchPoints.database(database).retentionPolicy(retentionPolicy)
 				.tag(TAG_HOSTNAME, server.getSource());
 
-		for(Map.Entry<String,String> tag : tags.entrySet()) {
-			batchPointsBuilder.tag(tag.getKey(),tag.getValue());
+		for (Map.Entry<String, String> tag : tags.entrySet()) {
+			batchPointsBuilder.tag(tag.getKey(), tag.getValue());
 		}
 		BatchPoints batchPoints = batchPointsBuilder.consistency(writeConsistency).build();
 		for (Result result : results) {

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -23,6 +23,7 @@
 package com.googlecode.jmxtrans.model.output;
 
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.googlecode.jmxtrans.model.OutputWriterAdapter;
@@ -60,7 +61,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 	@Nonnull private final String database;
 	@Nonnull private final ConsistencyLevel writeConsistency;
 	@Nonnull private final String retentionPolicy;
-	private final Map<String,String> tags = new HashMap<String,String>();
+	@Nonnull private final ImmutableMap<String,String> tags;
 
 	/**
 	 * The {@link ImmutableSet} of {@link ResultAttribute} attributes of
@@ -75,16 +76,14 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 			@Nonnull String database,
 			@Nonnull ConsistencyLevel writeConsistency,
 			@Nonnull String retentionPolicy,
-			Map<String,String> tags,
+			@Nonnull ImmutableMap<String,String> tags,
 			@Nonnull ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags,
 			boolean createDatabase) {
 		this.database = database;
 		this.writeConsistency = writeConsistency;
 		this.retentionPolicy = retentionPolicy;
 		this.influxDB = influxDB;
-		if(tags != null) {
-			this.tags.putAll(tags);
-		}
+		this.tags = tags;
 		this.resultAttributesToWriteAsTags = resultAttributesToWriteAsTags;
 		this.createDatabase = createDatabase;
 	}

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -1,17 +1,17 @@
 /**
  * The MIT License
  * Copyright © 2010 JmxTrans team
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -63,6 +63,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
 	private final boolean booleanAsNumber;
 	private final boolean createDatabase;
+
 	/**
 	 * @param url
 	 *            - The url e.g http://localhost:8086 to InfluxDB
@@ -103,9 +104,9 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	}
 
 
-	private ImmutableMap<String,String> initCustomTagsMap(ImmutableMap<String, String> tags) {
+	private ImmutableMap<String, String> initCustomTagsMap(ImmutableMap<String, String> tags) {
 		ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-		if (tags != null){
+		if (tags != null) {
 			builder.putAll(tags);
 		}
 		return builder.build();
@@ -129,6 +130,6 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	@Override
 	public ResultTransformerOutputWriter<InfluxDbWriter> create() {
 		return ResultTransformerOutputWriter.booleanToNumber(booleanAsNumber, new InfluxDbWriter(influxDB, database,
-				writeConsistency, retentionPolicy, tags,resultAttributesToWriteAsTags, createDatabase));
+				writeConsistency, retentionPolicy, tags, resultAttributesToWriteAsTags, createDatabase));
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -36,6 +36,7 @@ import org.influxdb.InfluxDBFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -101,11 +102,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 
 
 	private ImmutableMap<String, String> initCustomTagsMap(ImmutableMap<String, String> tags) {
-		ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-		if (tags != null) {
-			builder.putAll(tags);
-		}
-		return builder.build();
+		return ImmutableMap.copyOf(firstNonNull(tags, Collections.<String,String>emptyMap()));
 	}
 
 	private ImmutableSet<ResultAttribute> initResultAttributesToWriteAsTags(List<String> resultTags) {

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -25,6 +25,7 @@ package com.googlecode.jmxtrans.model.output;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.ResultAttribute;
@@ -37,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.Sets.immutableEnumSet;
@@ -57,8 +57,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 
 	private final String database;
 	private final InfluxDB.ConsistencyLevel writeConsistency;
-	private final Map<String, String> tags;
-
+	private final ImmutableMap<String, String> tags;
 	private final String retentionPolicy;
 	private final InfluxDB influxDB;
 	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
@@ -82,7 +81,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 			@JsonProperty("username") String username,
 			@JsonProperty("password") String password,
 			@JsonProperty("database") String database,
-			@JsonProperty("tags") Map<String, String> tags,
+			@JsonProperty("tags") ImmutableMap<String, String> tags,
 			@JsonProperty("writeConsistency") String writeConsistency,
 			@JsonProperty("retentionPolicy") String retentionPolicy,
 			@JsonProperty("resultTags") List<String> resultTags,
@@ -97,10 +96,19 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 		this.retentionPolicy = StringUtils.isNotBlank(retentionPolicy) ? retentionPolicy : DEFAULT_RETENTION_POLICY;
 
 		this.resultAttributesToWriteAsTags = initResultAttributesToWriteAsTags(resultTags);
-		this.tags = tags;
+		this.tags = initCustomTagsMap(tags);
 		LOG.debug("Connecting to url: {} as: username: {}", url, username);
 
 		influxDB = InfluxDBFactory.connect(url, username, password);
+	}
+
+
+	private ImmutableMap<String,String> initCustomTagsMap(ImmutableMap<String, String> tags) {
+		ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+		if (tags != null){
+			builder.putAll(tags);
+		}
+		return builder.build();
 	}
 
 	private ImmutableSet<ResultAttribute> initResultAttributesToWriteAsTags(List<String> resultTags) {

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.Sets.immutableEnumSet;
@@ -56,13 +57,13 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 
 	private final String database;
 	private final InfluxDB.ConsistencyLevel writeConsistency;
+	private final Map<String, String> tags;
 
 	private final String retentionPolicy;
 	private final InfluxDB influxDB;
 	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
 	private final boolean booleanAsNumber;
 	private final boolean createDatabase;
-
 	/**
 	 * @param url
 	 *            - The url e.g http://localhost:8086 to InfluxDB
@@ -81,6 +82,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 			@JsonProperty("username") String username,
 			@JsonProperty("password") String password,
 			@JsonProperty("database") String database,
+			@JsonProperty("tags") Map<String, String> tags,
 			@JsonProperty("writeConsistency") String writeConsistency,
 			@JsonProperty("retentionPolicy") String retentionPolicy,
 			@JsonProperty("resultTags") List<String> resultTags,
@@ -95,7 +97,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 		this.retentionPolicy = StringUtils.isNotBlank(retentionPolicy) ? retentionPolicy : DEFAULT_RETENTION_POLICY;
 
 		this.resultAttributesToWriteAsTags = initResultAttributesToWriteAsTags(resultTags);
-
+		this.tags = tags;
 		LOG.debug("Connecting to url: {} as: username: {}", url, username);
 
 		influxDB = InfluxDBFactory.connect(url, username, password);
@@ -119,6 +121,6 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	@Override
 	public ResultTransformerOutputWriter<InfluxDbWriter> create() {
 		return ResultTransformerOutputWriter.booleanToNumber(booleanAsNumber, new InfluxDbWriter(influxDB, database,
-				writeConsistency, retentionPolicy, resultAttributesToWriteAsTags, createDatabase));
+				writeConsistency, retentionPolicy, tags,resultAttributesToWriteAsTags, createDatabase));
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -1,17 +1,17 @@
 /**
  * The MIT License
  * Copyright © 2010 JmxTrans team
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -65,14 +65,10 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	private final boolean createDatabase;
 
 	/**
-	 * @param url
-	 *            - The url e.g http://localhost:8086 to InfluxDB
-	 * @param username
-	 *            - The username for InfluxDB
-	 * @param password
-	 *            - The password for InfluxDB
-	 * @param database
-	 *            - The name of the database (created if does not exist) on
+	 * @param url      - The url e.g http://localhost:8086 to InfluxDB
+	 * @param username - The username for InfluxDB
+	 * @param password - The password for InfluxDB
+	 * @param database - The name of the database (created if does not exist) on
 	 */
 	@JsonCreator
 	public InfluxDbWriterFactory(

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
@@ -134,7 +134,7 @@ public class InfluxDbWriterTests {
 
 	@Test
 	public void customTagsAreWrittenToDb() throws Exception {
-		ImmutableMap<String, String> tags = ImmutableMap.<String, String>builder().put("customTag", "customValue").build();
+		ImmutableMap<String, String> tags = ImmutableMap.of("customTag", "customValue");
 		InfluxDbWriter writer = getTestInfluxDbWriterWithCustomTags(tags);
 		writer.doWrite(dummyServer(), dummyQuery(), results);
 

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
@@ -1,17 +1,17 @@
 /**
  * The MIT License
  * Copyright © 2010 JmxTrans team
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
@@ -1,17 +1,17 @@
 /**
  * The MIT License
  * Copyright © 2010 JmxTrans team
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -75,7 +75,8 @@ public class InfluxDbWriterTests {
 
 	private static final String DATABASE_NAME = "database";
 	private static final String HOST = "host.example.net";
-    private static final ImmutableMap<String,String> DEFAULT_CUSTOM_TAGS = ImmutableMap.of();
+	private static final ImmutableMap<String, String> DEFAULT_CUSTOM_TAGS = ImmutableMap.of();
+
 	@Mock
 	private InfluxDB influxDB;
 	@Captor
@@ -119,21 +120,21 @@ public class InfluxDbWriterTests {
 		assertThat(point.lineProtocol()).startsWith(lineProtocol);
 	}
 
-    @Test
-    public void emptyCustomTagsDoesntBotherWrite() throws Exception {
-        InfluxDbWriter writer = getTestInfluxDbWriterWithDefaultSettings();
-        writer.doWrite(dummyServer(), dummyQuery(), results);
-        verify(influxDB).write(messageCaptor.capture());
-        BatchPoints batchPoints = messageCaptor.getValue();
+	@Test
+	public void emptyCustomTagsDoesntBotherWrite() throws Exception {
+		InfluxDbWriter writer = getTestInfluxDbWriterWithDefaultSettings();
+		writer.doWrite(dummyServer(), dummyQuery(), results);
+		verify(influxDB).write(messageCaptor.capture());
+		BatchPoints batchPoints = messageCaptor.getValue();
 
-        assertThat(batchPoints.getDatabase()).isEqualTo(DATABASE_NAME);
-        List<Point> points = batchPoints.getPoints();
-        assertThat(points).hasSize(1);
-    }
+		assertThat(batchPoints.getDatabase()).isEqualTo(DATABASE_NAME);
+		List<Point> points = batchPoints.getPoints();
+		assertThat(points).hasSize(1);
+	}
 
 	@Test
 	public void customTagsAreWrittenToDb() throws Exception {
-        ImmutableMap<String,String> tags = ImmutableMap.<String,String>builder().put("customTag","customValue").build();
+		ImmutableMap<String, String> tags = ImmutableMap.<String, String>builder().put("customTag", "customValue").build();
 		InfluxDbWriter writer = getTestInfluxDbWriterWithCustomTags(tags);
 		writer.doWrite(dummyServer(), dummyQuery(), results);
 
@@ -141,11 +142,11 @@ public class InfluxDbWriterTests {
 		BatchPoints batchPoints = messageCaptor.getValue();
 
 		assertThat(batchPoints.getDatabase()).isEqualTo(DATABASE_NAME);
-        List<Point> points = batchPoints.getPoints();
-        assertThat(points).hasSize(1);
+		List<Point> points = batchPoints.getPoints();
+		assertThat(points).hasSize(1);
 
-        Point point = points.get(0);
-        assertThat(point.lineProtocol()).contains("customTag=customValue");
+		Point point = points.get(0);
+		assertThat(point.lineProtocol()).contains("customTag=customValue");
 	}
 
 	@Test
@@ -220,27 +221,29 @@ public class InfluxDbWriterTests {
 	}
 
 	private InfluxDbWriter getTestInfluxDbWriterWithDefaultSettings() {
-		return getTestInfluxDbWriter(DEFAULT_CONSISTENCY_LEVEL, DEFAULT_RETENTION_POLICY,DEFAULT_CUSTOM_TAGS, DEFAULT_RESULT_ATTRIBUTES, true);
+		return getTestInfluxDbWriter(DEFAULT_CONSISTENCY_LEVEL, DEFAULT_RETENTION_POLICY, DEFAULT_CUSTOM_TAGS, DEFAULT_RESULT_ATTRIBUTES, true);
 	}
 
 	private InfluxDbWriter getTestInfluxDbWriterWithResultTags(ImmutableSet<ResultAttribute> resultTags) {
-		return getTestInfluxDbWriter(DEFAULT_CONSISTENCY_LEVEL, DEFAULT_RETENTION_POLICY, DEFAULT_CUSTOM_TAGS,resultTags, true);
+		return getTestInfluxDbWriter(DEFAULT_CONSISTENCY_LEVEL, DEFAULT_RETENTION_POLICY, DEFAULT_CUSTOM_TAGS, resultTags, true);
 	}
-    private InfluxDbWriter getTestInfluxDbWriterWithCustomTags(ImmutableMap<String,String> tags) {
-        return getTestInfluxDbWriter(DEFAULT_CONSISTENCY_LEVEL, DEFAULT_RETENTION_POLICY,tags, DEFAULT_RESULT_ATTRIBUTES, true);
 
-    }
+	private InfluxDbWriter getTestInfluxDbWriterWithCustomTags(ImmutableMap<String, String> tags) {
+		return getTestInfluxDbWriter(DEFAULT_CONSISTENCY_LEVEL, DEFAULT_RETENTION_POLICY, tags, DEFAULT_RESULT_ATTRIBUTES, true);
+
+	}
+
 	private InfluxDbWriter getTestInfluxDbWriterWithWriteConsistency(ConsistencyLevel consistencyLevel) {
-		return getTestInfluxDbWriter(consistencyLevel, DEFAULT_RETENTION_POLICY,DEFAULT_CUSTOM_TAGS, DEFAULT_RESULT_ATTRIBUTES, true);
+		return getTestInfluxDbWriter(consistencyLevel, DEFAULT_RETENTION_POLICY, DEFAULT_CUSTOM_TAGS, DEFAULT_RESULT_ATTRIBUTES, true);
 	}
 
 	private InfluxDbWriter getTestInfluxDbWriterNoDatabaseCreation() {
-		return getTestInfluxDbWriter(DEFAULT_CONSISTENCY_LEVEL, DEFAULT_RETENTION_POLICY,DEFAULT_CUSTOM_TAGS, DEFAULT_RESULT_ATTRIBUTES, false);
+		return getTestInfluxDbWriter(DEFAULT_CONSISTENCY_LEVEL, DEFAULT_RETENTION_POLICY, DEFAULT_CUSTOM_TAGS, DEFAULT_RESULT_ATTRIBUTES, false);
 	}
 
-	private InfluxDbWriter getTestInfluxDbWriter(ConsistencyLevel consistencyLevel, String retentionPolicy,ImmutableMap<String,String> tags,
-												 ImmutableSet<ResultAttribute> resultTags,boolean createDatabase) {
-		return new InfluxDbWriter(influxDB, DATABASE_NAME, consistencyLevel, retentionPolicy,tags, resultTags, createDatabase);
+	private InfluxDbWriter getTestInfluxDbWriter(ConsistencyLevel consistencyLevel, String retentionPolicy, ImmutableMap<String, String> tags,
+												 ImmutableSet<ResultAttribute> resultTags, boolean createDatabase) {
+		return new InfluxDbWriter(influxDB, DATABASE_NAME, consistencyLevel, retentionPolicy, tags, resultTags, createDatabase);
 	}
 
 	private String enumValueToAttribute(ResultAttribute attribute) {

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/resources/influxDB.json
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/resources/influxDB.json
@@ -17,6 +17,10 @@
                      "username": "root",
               		 "password": "root",
               		 "database": "newDB",
+                     "tags" : {
+                       "custom":"tag1",
+                       "custom2":"tag2"
+                     },
               		 "url": "http://localhost:8086",
               		 "resultTags":["typeName","className"],
               		 "retentionPolicy":"default",


### PR DESCRIPTION
A simple Hasmap<String ,String> added to the influxDbFactory JSON descriptor, in order to add custom tags to an influxDB record.
Use case : I have a Kubernetes cluster with many app, replicated across the cluster.
My cluster is monitored  by heapster, InfluxDb and grafana.
I can easily monitor every single pod with the 'podname' var ( ie hostname in jmxTrans ), but i can't group by appName afaik.
I needed to write those customs tags to influxDB to be able to group by Application Name and not only by podname (which, by the way, change every time you redeploy or restart an app. I ended up with more than 50 different values of "podname" with almost 60% of them was stopped a long time ago).
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68580274%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68580634%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68580739%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68580848%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68580922%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68581133%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68581286%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23issuecomment-228755209%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23issuecomment-228787043%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23issuecomment-228790235%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68610916%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68611294%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68611617%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23issuecomment-228755209%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20good%21%20Minor%20comments%20inline.%5Cr%5Cn%5Cr%5CnThanks%20for%20the%20PR%21%22%2C%20%22created_at%22%3A%20%222016-06-27T14%3A05%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20must%20admit%20I%20don%27t%20understand%20this%20error%20%3Ap%20%5Cr%5Cn%5BERROR%5D%20Failed%20to%20execute%20goal%20io.fabric8%3Adocker-maven-plugin%3A0.15.5%3Astart%20%28start%29%20on%20project%20jmxtrans-docker-test%3A%20%5Bopensuse13.2/jmxtrans-docker-test%3A257-SNAPSHOT%5D%20%3A%20Timeout%20after%20120039%20ms%20while%20waiting%20on%20log%20out%20%27installation%20verified%27%20-%3E%20%5BHelp%201%5D%5Cr%5Cn%5Cr%5CnIt%20seems%20that%20in%20local%20environment%20those%20tests%20aren%27t%20run%20%28or%20run%20very%20fast%20%29%20since%20i%20was%20able%20to%20clean%20%26%20install%20with%20maven%20on%20my%20machine.%5Cr%5Cn%5Cr%5CnAny%20clue%20on%20this%20error%20%3F%20%22%2C%20%22created_at%22%3A%20%222016-06-27T15%3A48%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1491762%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Bair95%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20can%20probably%20ignore%20the%20docker%20issue.%20We%20use%20it%20to%20spot%20packaging%20issues%20by%20installing%20the%20.deb%20/%20.rpm%20packages%20in%20a%20few%20different%20distributions%20and%20checking%20that%20jmxtrans%20starts.%20The%20idea%20is%20pretty%20cool%2C%20but%20those%20tests%20are%20sometime%20unstable.%20You%20can%20always%20restart%20the%20travis%20build%20and%20there%20is%20a%20good%20chance%20that%20they%27ll%20run%20fine%20next%20time.%22%2C%20%22created_at%22%3A%20%222016-06-27T15%3A59%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20b90a8c7f09bd17cf65be30847afc781dbf08f051%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68611294%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20could%20be%20replaced%20by%20%60ImmutableSet.copyOf%28firstNotNull%28tags%2C%20Collections.emptyMap%28%29%29%29%60%22%2C%20%22created_at%22%3A%20%222016-06-27T16%3A40%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java%3AL93-114%22%7D%2C%20%22Pull%20b90a8c7f09bd17cf65be30847afc781dbf08f051%20jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68611617%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22More%20compact%20way%20to%20initialize%20this%20map%3A%20%60ImmutableMap.of%28%5C%22customTag%5C%22%2C%20%5C%22customValue%5C%22%29%60%20%28I%20think...%20I%20did%20not%20actually%20check%20it%29.%22%2C%20%22created_at%22%3A%20%222016-06-27T16%3A41%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java%3AL121-163%22%7D%2C%20%22Pull%20846960402515ab43e87a2234d7d7a6edd05ffb88%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68610916%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20could%20be%20replaced%20by%20%60ImmutableSet.copyOf%28firstNotNull%28tags%2C%20Collections.emptyMap%28%29%29%29%60%22%2C%20%22created_at%22%3A%20%222016-06-27T16%3A37%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java%3AL96-117%22%7D%2C%20%22Pull%20950f05c3384a3b4efaf796e7152bd8e7672a37e0%20jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java%2054%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68581286%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Something%20strange%20with%20indentation%20here...%22%2C%20%22created_at%22%3A%20%222016-06-27T14%3A03%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java%3AL117-161%22%7D%2C%20%22Pull%20950f05c3384a3b4efaf796e7152bd8e7672a37e0%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68580739%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22An%20%60ImmutableMap%60%20would%20be%20nicer.%22%2C%20%22created_at%22%3A%20%222016-06-27T14%3A00%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java%3AL57-70%22%7D%2C%20%22Pull%20950f05c3384a3b4efaf796e7152bd8e7672a37e0%20jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68580922%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22For%20non%20obvious%20reasons%2C%20we%20frown%20on%20star%20imports...%22%2C%20%22created_at%22%3A%20%222016-06-27T14%3A01%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java%3AL49-56%22%7D%2C%20%22Pull%20950f05c3384a3b4efaf796e7152bd8e7672a37e0%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68580634%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Just%20for%20clarity%2C%20%60tags%60%20should%20probably%20be%20annotated%20with%20%60%40NonNull%60.%22%2C%20%22created_at%22%3A%20%222016-06-27T13%3A59%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%3AL60-67%22%7D%2C%20%22Pull%20950f05c3384a3b4efaf796e7152bd8e7672a37e0%20jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68581133%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60TAGS%60%20should%20not%20be%20a%20class%20member%20%28and%20ALL%20CAPS%20variable%20names%20indicate%20a%20constant%29%20but%20should%20be%20moved%20to%20each%20test%20method.%22%2C%20%22created_at%22%3A%20%222016-06-27T14%3A02%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java%3AL72-85%22%7D%2C%20%22Pull%20950f05c3384a3b4efaf796e7152bd8e7672a37e0%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68580274%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20class%20is%20supposed%20to%20be%20threadsafe%2C%20and%20ideally%20immutable.%20I%27d%20prefer%20if%20%60this.tags%60%20was%20a%20Guava%20%60ImmutableMap%60%20and%20initialized%20in%20constructor.%22%2C%20%22created_at%22%3A%20%222016-06-27T13%3A57%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java%3AL75-91%22%7D%2C%20%22Pull%20950f05c3384a3b4efaf796e7152bd8e7672a37e0%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java%2036%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/476%23discussion_r68580848%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20case%20the%20%60tags%60%20param%20is%20%60null%60%2C%20%60this.tags%60%20should%20be%20initialized%20to%20an%20empty%20map.%22%2C%20%22created_at%22%3A%20%222016-06-27T14%3A00%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java%3AL97-104%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 950f05c3384a3b4efaf796e7152bd8e7672a37e0 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#discussion_r68580274'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java:L75-91</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This class is supposed to be threadsafe, and ideally immutable. I'd prefer if `this.tags` was a Guava `ImmutableMap` and initialized in constructor.
- [x] <a href='#crh-comment-Pull 950f05c3384a3b4efaf796e7152bd8e7672a37e0 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#discussion_r68580634'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java:L60-67</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Just for clarity, `tags` should probably be annotated with `@NonNull`.
- [x] <a href='#crh-comment-Pull 950f05c3384a3b4efaf796e7152bd8e7672a37e0 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#discussion_r68580739'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java:L57-70</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> An `ImmutableMap` would be nicer.
- [x] <a href='#crh-comment-Pull 950f05c3384a3b4efaf796e7152bd8e7672a37e0 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java 36'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#discussion_r68580848'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java:L97-104</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> In case the `tags` param is `null`, `this.tags` should be initialized to an empty map.
- [x] <a href='#crh-comment-Pull 950f05c3384a3b4efaf796e7152bd8e7672a37e0 jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#discussion_r68580922'>File: jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java:L49-56</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> For non obvious reasons, we frown on star imports...
- [x] <a href='#crh-comment-Pull 950f05c3384a3b4efaf796e7152bd8e7672a37e0 jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#discussion_r68581133'>File: jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java:L72-85</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> `TAGS` should not be a class member (and ALL CAPS variable names indicate a constant) but should be moved to each test method.
- [x] <a href='#crh-comment-Pull 950f05c3384a3b4efaf796e7152bd8e7672a37e0 jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java 54'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#discussion_r68581286'>File: jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java:L117-161</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Something strange with indentation here...
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#issuecomment-228755209'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Looks good! Minor comments inline.
Thanks for the PR!
- <a href='https://github.com/Bair95'><img border=0 src='https://avatars.githubusercontent.com/u/1491762?v=3' height=16 width=16'></a> I must admit I don't understand this error :p
[ERROR] Failed to execute goal io.fabric8:docker-maven-plugin:0.15.5:start (start) on project jmxtrans-docker-test: [opensuse13.2/jmxtrans-docker-test:257-SNAPSHOT] : Timeout after 120039 ms while waiting on log out 'installation verified' -> [Help 1]
It seems that in local environment those tests aren't run (or run very fast ) since i was able to clean & install with maven on my machine.
Any clue on this error ?
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> You can probably ignore the docker issue. We use it to spot packaging issues by installing the .deb / .rpm packages in a few different distributions and checking that jmxtrans starts. The idea is pretty cool, but those tests are sometime unstable. You can always restart the travis build and there is a good chance that they'll run fine next time.
- [x] <a href='#crh-comment-Pull 846960402515ab43e87a2234d7d7a6edd05ffb88 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java 40'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#discussion_r68610916'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java:L96-117</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This could be replaced by `ImmutableSet.copyOf(firstNotNull(tags, Collections.emptyMap()))`
- [x] <a href='#crh-comment-Pull b90a8c7f09bd17cf65be30847afc781dbf08f051 jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#discussion_r68611294'>File: jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java:L93-114</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> This could be replaced by `ImmutableSet.copyOf(firstNotNull(tags, Collections.emptyMap()))`
- [x] <a href='#crh-comment-Pull b90a8c7f09bd17cf65be30847afc781dbf08f051 jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java 40'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/476#discussion_r68611617'>File: jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java:L121-163</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> More compact way to initialize this map: `ImmutableMap.of("customTag", "customValue")` (I think... I did not actually check it).


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/476?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/476?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/476'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>