### PR TITLE
Issue #479 - Add better handling for pool timeouts and errors during slot release

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/WriterPoolOutputWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/WriterPoolOutputWriter.java
@@ -28,6 +28,8 @@ import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.output.support.pool.WriterPoolable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import stormpot.LifecycledPool;
 import stormpot.Timeout;
 
@@ -35,6 +37,8 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 public class WriterPoolOutputWriter<T extends WriterBasedOutputWriter> extends OutputWriterAdapter{
+
+	private static final Logger logger = LoggerFactory.getLogger(WriterPoolOutputWriter.class);
 
 	@Nonnull private final T target;
 	@Nonnull private final LifecycledPool<? extends WriterPoolable> writerPool;
@@ -48,24 +52,38 @@ public class WriterPoolOutputWriter<T extends WriterBasedOutputWriter> extends O
 
 	@Override
 	public void doWrite(Server server, Query query, Iterable<Result> results) throws Exception {
+		WriterPoolable writerPoolable = claimWriter();
 		try {
-			WriterPoolable writerPoolable = writerPool.claim(poolClaimTimeout);
-			try {
-				target.write(writerPoolable.getWriter(), server, query, results);
-			} catch (IOException ioe) {
-				writerPoolable.invalidate();
-				throw ioe;
-			} finally {
-				writerPoolable.release();
-			}
-		} catch (InterruptedException e) {
-			throw new IllegalStateException("Could not get writer from pool, please check if the server is available");
+			target.write(writerPoolable.getWriter(), server, query, results);
+		} catch (IOException ioe) {
+			writerPoolable.invalidate();
+			throw ioe;
+		} finally {
+			writerPoolable.release();
 		}
+
 	}
 
 	@Override
 	public void stop() throws LifecycleException {
 		writerPool.shutdown();
+	}
+
+	private WriterPoolable claimWriter() {
+		WriterPoolable result = null;
+
+		try {
+			result = writerPool.claim(poolClaimTimeout);
+		} catch (InterruptedException ex) {
+			logger.error("Interrupted while attempting to claim writer from pool", ex);
+			Thread.currentThread().interrupt();
+		}
+
+		if (result == null) {
+			throw new IllegalStateException("Could not get writer from pool, please check if the server is available");
+		}
+
+		return result;
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/WriterPoolable.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/pool/WriterPoolable.java
@@ -52,10 +52,11 @@ public class WriterPoolable implements Poolable {
 	public void release() {
 		try {
 			flushStrategy.flush(writer);
-			slot.release(this);
 		} catch (IOException ioe) {
 			logger.error("Could not flush writer", ioe);
 			invalidate();
+		} finally {
+			slot.release(this);
 		}
 	}
 

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/WriterPoolableTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/WriterPoolableTest.java
@@ -26,14 +26,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import stormpot.*;
+import stormpot.Allocator;
+import stormpot.BlazePool;
+import stormpot.Config;
+import stormpot.Slot;
+import stormpot.Timeout;
 
+import javax.annotation.Nonnull;
+import java.io.Flushable;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -52,12 +57,31 @@ public class WriterPoolableTest {
 		verify(writer).flush();
 	}
 
+	@Test
+	public void ensureSlotIsReleasedOnException() throws InterruptedException, IOException {
+		BlazePool<WriterPoolable> pool = createPool(new ExceptionOnFlush());
+
+		WriterPoolable writerPoolable = pool.claim(new Timeout(1, SECONDS));
+		writerPoolable.getWriter().write("some message");
+		writerPoolable.release();
+
+		// Slot should be able to be reclaimed
+		writerPoolable = pool.claim(new Timeout(1, SECONDS));
+
+		assertNotNull(writerPoolable);
+
+	}
+
 	private BlazePool<WriterPoolable> createPool() {
+		return createPool(new AlwaysFlush());
+	}
+
+	private BlazePool<WriterPoolable> createPool(final FlushStrategy flushStrategy) {
 		Config<WriterPoolable> config = new Config<>()
 				.setAllocator(new Allocator<WriterPoolable>() {
 					@Override
 					public WriterPoolable allocate(Slot slot) throws Exception {
-						return new WriterPoolable(slot, writer, new AlwaysFlush());
+						return new WriterPoolable(slot, writer, flushStrategy);
 					}
 
 					@Override
@@ -65,6 +89,13 @@ public class WriterPoolableTest {
 				})
 				.setSize(1);
 		return new BlazePool<>(config);
+	}
+
+	private class ExceptionOnFlush implements FlushStrategy {
+		@Override
+		public void flush(@Nonnull Flushable flushable) throws IOException {
+			throw new IOException();
+		}
 	}
 
 }


### PR DESCRIPTION
@gehel fixes for #479 in this PR.

Also included a related fix for an NPE that occurs when the request to claim a writer from the pool times out.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/480?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/480'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>