### PR TITLE
Added new StatsDTelegrafWriter to support JMX attributes as tags

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
@@ -55,14 +55,28 @@ public final class ResultFixtures {
 	}
 
 	public static Result numericResult() {
+		return numericResult(10);
+	}
+	public static Result numericResult(Object numericValue) {
 		return new Result(
 				0,
 				"ObjectPendingFinalizationCount",
 				"sun.management.MemoryImpl",
 				"ObjectDomainName",
-				"ObjectPendingFinalizationCount",
+				"MemoryAlias",
 				"type=Memory",
-				ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", 10));
+				ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", numericValue));
+	}
+
+	public static Result hashResult() {
+		return new Result(
+				0,
+				"NonHeapMemoryUsage",
+				"sun.management.MemoryImpl",
+				"ObjectDomainName",
+				"MemoryAlias",
+				"type=Memory",
+				ImmutableMap.<String, Object>of("committed", 12345, "init", 23456, "max", -1, "used", 45678));
 	}
 
 	public static Result numericBelowCPrecisionResult() {
@@ -71,7 +85,7 @@ public final class ResultFixtures {
 				"ObjectPendingFinalizationCount",
 				"sun.management.MemoryImpl",
 				"ObjectDomainName",
-				"ObjectPendingFinalizationCount",
+				"MemoryAlias",
 				"type=Memory",
 				ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", Double.MIN_VALUE));
 	}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
@@ -68,6 +68,17 @@ public final class ResultFixtures {
 				ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", numericValue));
 	}
 
+	public static Result stringResult() {
+		return new Result(
+				0,
+				"NonHeapMemoryUsage",
+				"sun.management.MemoryImpl",
+				"ObjectDomainName",
+				"MemoryAlias",
+				"type=Memory",
+				ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", "value is a string"));
+	}
+
 	public static Result hashResult() {
 		return new Result(
 				0,

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ServerFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ServerFixtures.java
@@ -38,14 +38,17 @@ public final class ServerFixtures {
 	private ServerFixtures() {}
 
 	public static Server createServerWithOneQuery(String host, String port, String queryObject) {
+		return getBuilder(host, port, queryObject).build();
+	}
+
+	private static Server.Builder getBuilder(String host, String port, String queryObject) {
 		return Server.builder()
 				.setHost(host)
 				.setPort(port)
 				.setPool(createPool())
 				.addQuery(Query.builder()
 					.setObj(queryObject)
-					.build())
-				.build();
+					.build());
 	}
 
 	public static Server serverWithNoQuery() {
@@ -67,6 +70,10 @@ public final class ServerFixtures {
 
 	public static Server dummyServer() {
 		return createServerWithOneQuery(DEFAULT_HOST, DEFAULT_PORT, DEFAULT_QUERY);
+	}
+
+	public static Server.Builder dummyServerBuilder() {
+		return getBuilder(DEFAULT_HOST, DEFAULT_PORT, "myQuery:key=val");
 	}
 
 	public static Server localServer() {

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDMetricType.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDMetricType.java
@@ -22,34 +22,17 @@
  */
 package com.googlecode.jmxtrans.model.output;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.google.common.collect.ImmutableList;
-import com.googlecode.jmxtrans.model.QueryFixtures;
-import com.googlecode.jmxtrans.model.ResultFixtures;
-import com.googlecode.jmxtrans.model.ServerFixtures;
-import org.junit.Test;
+public enum StatsDMetricType {
 
-import java.io.IOException;
-import java.io.StringWriter;
+	COUNTER("c"), GAUGE("g"), SET("s"), TIMING_MS("ms");
 
-import static org.assertj.core.api.Assertions.assertThat;
+	private final String key;
 
-public class SensuWriter2Test {
-
-	@Test
-	public void metricsAreFormattedCorrectly() throws IOException {
-		StringWriter writer = new StringWriter();
-		SensuWriter2 sensuWriter = new SensuWriter2(new GraphiteWriter2(ImmutableList.<String>of(), null), new JsonFactory());
-
-		sensuWriter.write(writer, ServerFixtures.dummyServer(), QueryFixtures.dummyQuery(), ResultFixtures.dummyResults());
-
-		assertThat(writer.toString()).isEqualTo(
-				"{\n" +
-				"  \"name\" : \"jmxtrans\",\n" +
-				"  \"type\" : \"metric\",\n" +
-				"  \"handler\" : \"graphite\",\n" +
-				"  \"output\" : \"host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount 10 0\\n\"\n" +
-				"}");
+	StatsDMetricType(String key) {
+		this.key = key;
 	}
 
+	public String getKey() {
+		return key;
+	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriter.java
@@ -22,8 +22,10 @@
  */
 package com.googlecode.jmxtrans.model.output;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.ResultAttribute;
@@ -51,14 +53,14 @@ public class StatsDTelegrafWriter implements WriterBasedOutputWriter {
 	@Nonnull
 	private final ValueTransformer valueTransformer = new CPrecisionValueTransformer();
 	@Nonnull
-	private final String[] bucketTypes;
+	private final ImmutableList<String> bucketTypes;
 	@Nonnull
 	private final ImmutableMap<String, String> tags;
 	@Nonnull
 	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
 
 	public StatsDTelegrafWriter(String[] bucketTypes, ImmutableMap<String, String> tags, ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags) {
-		this.bucketTypes = bucketTypes;
+		this.bucketTypes = ImmutableList.copyOf(bucketTypes);
 		this.tags = tags;
 		this.resultAttributesToWriteAsTags = resultAttributesToWriteAsTags;
 	}
@@ -116,10 +118,10 @@ public class StatsDTelegrafWriter implements WriterBasedOutputWriter {
 	}
 
 	private String getBucketType(int resultIndex) {
-		if( this.bucketTypes.length > resultIndex ){
-			return bucketTypes[resultIndex];
+		if( this.bucketTypes.size() > resultIndex ){
+			return bucketTypes.get(resultIndex);
 		}
-		return bucketTypes[bucketTypes.length - 1];
+		return Iterables.getLast(bucketTypes);
 	}
 
 	private boolean isNotValidValue(Object value) {

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriter.java
@@ -48,13 +48,17 @@ public class StatsDTelegrafWriter implements WriterBasedOutputWriter {
 
 	private static final Logger log = LoggerFactory.getLogger(StatsDTelegrafWriter.class);
 
+	@Nonnull
 	private final ValueTransformer valueTransformer = new CPrecisionValueTransformer();
+	@Nonnull
 	private final String[] bucketTypes;
+	@Nonnull
 	private final ImmutableMap<String, String> tags;
+	@Nonnull
 	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
 
-	public StatsDTelegrafWriter(String bucketType, ImmutableMap<String, String> tags, ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags) {
-		this.bucketTypes = StringUtils.split(bucketType, ",");
+	public StatsDTelegrafWriter(String[] bucketTypes, ImmutableMap<String, String> tags, ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags) {
+		this.bucketTypes = bucketTypes;
 		this.tags = tags;
 		this.resultAttributesToWriteAsTags = resultAttributesToWriteAsTags;
 	}
@@ -119,7 +123,7 @@ public class StatsDTelegrafWriter implements WriterBasedOutputWriter {
 	}
 
 	private boolean isNotValidValue(Object value) {
-		return !(isNumeric(value) /*|| stringsValuesAsKey*/);
+		return !isNumeric(value);
 	}
 
 	private Number computeActualValue(Object value) {
@@ -128,7 +132,7 @@ public class StatsDTelegrafWriter implements WriterBasedOutputWriter {
 			return transformedValue instanceof Number ?
 				(Number) transformedValue : Float.valueOf(transformedValue.toString());
 		}
-		return null;
+		throw new IllegalArgumentException("Only numeric values are supported, enable debug log level for more details.");
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriter.java
@@ -1,0 +1,134 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.ResultAttribute;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.output.support.WriterBasedOutputWriter;
+import com.googlecode.jmxtrans.model.results.CPrecisionValueTransformer;
+import com.googlecode.jmxtrans.model.results.ValueTransformer;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
+
+public class StatsDTelegrafWriter implements WriterBasedOutputWriter {
+
+	private static final Logger log = LoggerFactory.getLogger(StatsDTelegrafWriter.class);
+
+	private final ValueTransformer valueTransformer = new CPrecisionValueTransformer();
+	private final String[] bucketTypes;
+	private final ImmutableMap<String, String> tags;
+	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
+
+	public StatsDTelegrafWriter(String bucketType, ImmutableMap<String, String> tags, ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags) {
+		this.bucketTypes = StringUtils.split(bucketType, ",");
+		this.tags = tags;
+		this.resultAttributesToWriteAsTags = resultAttributesToWriteAsTags;
+	}
+
+	@Override
+	public void write(@Nonnull Writer writer, @Nonnull Server server, @Nonnull Query query, @Nonnull Iterable<Result> results) throws IOException {
+
+		int resultIndex = -1;
+		for (Result result : results) {
+			resultIndex++;
+			String bucketType = getBucketType(resultIndex);
+			String attributeName = result.getAttributeName();
+
+			List<String> resultTagList = new ArrayList<>();
+			resultTagList.add(",jmxport=" + server.getPort());
+			//tagList.add("objectName=" + query.getObjectName());
+			resultTagList.add("attribute=" + attributeName);
+
+			for (Map.Entry<String, Object> values : result.getValues().entrySet()) {
+
+				String field = values.getKey();
+				Object value = values.getValue();
+				if (isNotValidValue(value)) {
+					log.debug("Skipping message key[{}] with value: {}.", field, value);
+					continue;
+				}
+				List<String> tagList = new ArrayList(resultTagList);
+
+				boolean isSingleValueAttribute = StringUtils.equals(attributeName, field);
+				if( !isSingleValueAttribute ){
+					tagList.add("resultKey="+values.getKey());
+				}
+
+				for (Map.Entry e : tags.entrySet()) {
+					tagList.add(e.getKey() + "=" + e.getValue());
+				}
+
+				Number actualValue = computeActualValue(value);
+				StringBuilder sb = new StringBuilder(result.getKeyAlias())
+					.append(StringUtils.join(tagList, ","))
+					.append(":").append(actualValue)
+					.append("|").append(bucketType).append("\n");
+
+				String output = sb.toString();
+				if( actualValue.floatValue() < 0 && !StatsDMetricType.GAUGE.getKey().equals(bucketType) )
+				{
+					log.debug("Negative values are only supported for gauges, not sending: {}.", output);
+				}
+				else{
+					log.debug(output);
+					writer.write(output);
+				}
+			}
+		}
+	}
+
+	private String getBucketType(int resultIndex) {
+		if( this.bucketTypes.length > resultIndex ){
+			return bucketTypes[resultIndex];
+		}
+		return bucketTypes[bucketTypes.length - 1];
+	}
+
+	private boolean isNotValidValue(Object value) {
+		return !(isNumeric(value) /*|| stringsValuesAsKey*/);
+	}
+
+	private Number computeActualValue(Object value) {
+		Object transformedValue = valueTransformer.apply(value);
+		if (isNumeric(transformedValue)) {
+			return transformedValue instanceof Number ?
+				(Number) transformedValue : Float.valueOf(transformedValue.toString());
+		}
+		return null;
+	}
+
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterFactory.java
@@ -1,0 +1,124 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
+import com.googlecode.jmxtrans.model.ResultAttribute;
+import com.googlecode.jmxtrans.model.output.support.UdpOutputWriterBuilder;
+import com.googlecode.jmxtrans.model.output.support.WriterPoolOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.pool.FlushStrategy;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Sets.immutableEnumSet;
+import static com.googlecode.jmxtrans.model.output.support.pool.FlushStrategyUtils.createFlushStrategy;
+
+@EqualsAndHashCode
+@ToString
+public class StatsDTelegrafWriterFactory implements OutputWriterFactory {
+
+	private static final Logger LOG = LoggerFactory.getLogger(StatsDTelegrafWriterFactory.class);
+
+	@Nonnull
+	private final String bucketType;
+	@Nonnull
+	private final InetSocketAddress server;
+	@Nonnull
+	private final FlushStrategy flushStrategy;
+	private final int poolSize;
+	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
+	private final ImmutableMap<String, String> tags;
+
+	public StatsDTelegrafWriterFactory(
+		@JsonProperty("bucketType") String bucketType,
+		@JsonProperty("host") String host,
+		@JsonProperty("port") Integer port,
+		@JsonProperty("tags") ImmutableMap<String, String> tags,
+		@JsonProperty("resultTags") List<String> resultTags,
+		@JsonProperty("flushStrategy") String flushStrategy,
+		@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
+		@JsonProperty("poolSize") Integer poolSize) {
+		this.bucketType = firstNonNull(bucketType, "c");
+		this.server = new InetSocketAddress(
+			checkNotNull(host, "Host cannot be null."),
+			checkNotNull(port, "Port cannot be null."));
+		this.resultAttributesToWriteAsTags = initResultAttributesToWriteAsTags(resultTags);
+		this.tags = initCustomTagsMap(tags);
+		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
+		this.poolSize = firstNonNull(poolSize, 1);
+	}
+
+	/**
+	 * Copied from InfluxDbWriterFactory
+	 * @param tags
+	 * @return
+	 */
+	private ImmutableMap<String, String> initCustomTagsMap(ImmutableMap<String, String> tags) {
+		return ImmutableMap.copyOf(firstNonNull(tags, Collections.<String, String>emptyMap()));
+	}
+
+	/**
+	 * Copied from InfluxDbWriterFactory
+	 * @param resultTags
+	 * @return
+	 */
+	private ImmutableSet<ResultAttribute> initResultAttributesToWriteAsTags(List<String> resultTags) {
+		EnumSet<ResultAttribute> resultAttributes = EnumSet.noneOf(ResultAttribute.class);
+		if (resultTags != null) {
+			for (String resultTag : resultTags) {
+				resultAttributes.add(ResultAttribute.fromAttribute(resultTag));
+			}
+		} else {
+			resultAttributes = EnumSet.allOf(ResultAttribute.class);
+		}
+
+		ImmutableSet<ResultAttribute> result = immutableEnumSet(resultAttributes);
+		LOG.debug("Result Tags to write set to: {}", result);
+		return result;
+	}
+
+	@Override
+	public WriterPoolOutputWriter<StatsDTelegrafWriter> create() {
+		return UdpOutputWriterBuilder.builder(
+			server,
+			new StatsDTelegrafWriter(bucketType, tags, resultAttributesToWriteAsTags))
+			.setCharset(UTF_8)
+			.setFlushStrategy(flushStrategy)
+			.setPoolSize(poolSize)
+			.build();
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterFactory.java
@@ -32,6 +32,7 @@ import com.googlecode.jmxtrans.model.output.support.WriterPoolOutputWriter;
 import com.googlecode.jmxtrans.model.output.support.pool.FlushStrategy;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +55,7 @@ public class StatsDTelegrafWriterFactory implements OutputWriterFactory {
 	private static final Logger LOG = LoggerFactory.getLogger(StatsDTelegrafWriterFactory.class);
 
 	@Nonnull
-	private final String bucketType;
+	private final String[] bucketTypes;
 	@Nonnull
 	private final InetSocketAddress server;
 	@Nonnull
@@ -72,7 +73,7 @@ public class StatsDTelegrafWriterFactory implements OutputWriterFactory {
 		@JsonProperty("flushStrategy") String flushStrategy,
 		@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
 		@JsonProperty("poolSize") Integer poolSize) {
-		this.bucketType = firstNonNull(bucketType, "c");
+		this.bucketTypes = StringUtils.split(firstNonNull(bucketType, "c"), ",");
 		this.server = new InetSocketAddress(
 			checkNotNull(host, "Host cannot be null."),
 			checkNotNull(port, "Port cannot be null."));
@@ -115,7 +116,7 @@ public class StatsDTelegrafWriterFactory implements OutputWriterFactory {
 	public WriterPoolOutputWriter<StatsDTelegrafWriter> create() {
 		return UdpOutputWriterBuilder.builder(
 			server,
-			new StatsDTelegrafWriter(bucketType, tags, resultAttributesToWriteAsTags))
+			new StatsDTelegrafWriter(bucketTypes, tags, resultAttributesToWriteAsTags))
 			.setCharset(UTF_8)
 			.setFlushStrategy(flushStrategy)
 			.setPoolSize(poolSize)

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
@@ -117,21 +117,21 @@ public class GraphiteWriterTests {
 	public void writeSingleResult() throws Exception {
 		// check that Graphite format is respected
 		assertThat(getOutput(dummyServer(), dummyQuery(), numericResult()))
-				.startsWith("servers.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount 10");
+				.startsWith("servers.host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount 10");
 	}
 
 	@Test
 	public void useObjDomainWorks() throws Exception {
 		// check that Graphite format is respected
 		assertThat(getOutput(dummyServer(), queryUsingDomainAsKey(), numericResult()))
-				.startsWith("servers.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount 10 0");
+				.startsWith("servers.host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount 10 0");
 	}
 	
 	@Test
 	public void allowDottedWorks() throws Exception {
 		// check that Graphite format is respected
 		assertThat(getOutput(dummyServer(), queryAllowingDottedKeys(), numericResult()))
-				.startsWith("servers.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount 10 0");
+				.startsWith("servers.host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount 10 0");
 	}
 
 	@Test

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/LibratoWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/LibratoWriter2Test.java
@@ -51,7 +51,7 @@ public class LibratoWriter2Test {
 		assertThatJson(json)
 				.node("gauges").isArray().ofLength(1);
 		assertThatJson(json)
-				.node("gauges[0].name").isEqualTo("ObjectPendingFinalizationCount.ObjectPendingFinalizationCount")
+				.node("gauges[0].name").isEqualTo("MemoryAlias.ObjectPendingFinalizationCount")
 				.node("gauges[0].source").isEqualTo("host_example_net")
 				.node("gauges[0].measure_time").isEqualTo(0)
 				.node("gauges[0].value").isEqualTo(10);

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/LibratoWriterFactoryIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/LibratoWriterFactoryIT.java
@@ -71,7 +71,7 @@ public class LibratoWriterFactoryIT {
 				postRequestedFor(urlEqualTo("/endpoint"))
 						.withHeader("User-Agent", containing("jmxtrans"))
 						.withHeader("Authorization", containing("Basic"))
-						.withRequestBody(matchingJsonPath("$.gauges[?(@.name == 'ObjectPendingFinalizationCount.ObjectPendingFinalizationCount')]")));
+						.withRequestBody(matchingJsonPath("$.gauges[?(@.name == 'MemoryAlias.ObjectPendingFinalizationCount')]")));
 
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
@@ -127,7 +127,7 @@ public class OpenTSDBWriterTests {
 		writer.doWrite(dummyServer(), dummyQuery(), singleNumericResult());
 
 		// check that OpenTSDB format is respected
-		assertThat(out.toString()).startsWith("put ObjectPendingFinalizationCount.ObjectPendingFinalizationCount ")
+		assertThat(out.toString()).startsWith("put MemoryAlias.ObjectPendingFinalizationCount ")
 			.contains("host=")  // hostname is added by default
 			.endsWith("\n");
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/Slf4JOutputWriterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/Slf4JOutputWriterTest.java
@@ -56,7 +56,7 @@ public class Slf4JOutputWriterTest {
 			@Override
 			public Object answer(InvocationOnMock invocation) throws Throwable {
 				assertThat(MDC.get("server")).isEqualTo("host_example_net_4321");
-				assertThat(MDC.get("metric")).isEqualTo("host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount");
+				assertThat(MDC.get("metric")).isEqualTo("host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount");
 				assertThat(MDC.get("value")).isEqualTo("10");
 				assertThat(MDC.get("attributeName")).isEqualTo("ObjectPendingFinalizationCount");
 				assertThat(MDC.get("key")).isEqualTo("ObjectPendingFinalizationCount");

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterTest.java
@@ -47,7 +47,7 @@ public class StatsDTelegrafWriterTest {
 
     @Test
     public void hashResultAttribues() throws IOException {
-        StatsDTelegrafWriter w = new StatsDTelegrafWriter(StatsDMetricType.COUNTER.getKey(), ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+        StatsDTelegrafWriter w = new StatsDTelegrafWriter(new String[]{StatsDMetricType.COUNTER.getKey()}, ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
         w.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(hashResult()) );
         assertThat(writer.toString()).isEqualTo(
 			"MemoryAlias,jmxport=4321,attribute=NonHeapMemoryUsage,resultKey=committed:12345|c\n" +
@@ -57,32 +57,39 @@ public class StatsDTelegrafWriterTest {
 
     @Test
     public void countAttribute() throws IOException {
-        StatsDTelegrafWriter w = new StatsDTelegrafWriter(StatsDMetricType.COUNTER.getKey(), ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+        StatsDTelegrafWriter w = new StatsDTelegrafWriter(new String[]{StatsDMetricType.COUNTER.getKey()}, ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
         w.write(writer, dummyServer(), dummyQuery(), singleNumericResult());
         assertThat(writer.toString()).isEqualTo(expectedMeasureAndTags + "10|c\n");
     }
 
     @Test
     public void countAttribute_negativeValueIsIgnored() throws IOException {
-        StatsDTelegrafWriter w = new StatsDTelegrafWriter(StatsDMetricType.COUNTER.getKey(), ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+        StatsDTelegrafWriter w = new StatsDTelegrafWriter(new String[]{StatsDMetricType.COUNTER.getKey()}, ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
         w.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(numericResult(-10)));
         assertThat(writer.toString()).isEqualTo("");
     }
 
     @Test
     public void gaugeAttribute() throws IOException {
-        StatsDTelegrafWriter w = new StatsDTelegrafWriter(StatsDMetricType.GAUGE.getKey(), ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+        StatsDTelegrafWriter w = new StatsDTelegrafWriter(new String[]{StatsDMetricType.GAUGE.getKey()}, ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
         w.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(numericResult(-10)));
         assertThat(writer.toString()).isEqualTo(expectedMeasureAndTags + "-10|g\n");
     }
 
     @Test
     public void multipleBucketTypes() throws IOException {
-        StatsDTelegrafWriter w = new StatsDTelegrafWriter("s,ms,g", ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+        StatsDTelegrafWriter w = new StatsDTelegrafWriter(new String[]{"s","ms","g"}, ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
         w.write(writer, dummyServer(), dummyQuery(), ImmutableList.of( numericResult(5), numericResult(250), numericResult(10.5)));
         assertThat(writer.toString()).isEqualTo(
             expectedMeasureAndTags + "5|s\n" +
             expectedMeasureAndTags + "250|ms\n" +
             expectedMeasureAndTags + "10.5|g\n");
     }
+
+	@Test
+	public void nonNumericValue() throws IOException {
+		StatsDTelegrafWriter w = new StatsDTelegrafWriter(new String[]{StatsDMetricType.GAUGE.getKey()}, ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+		w.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(stringResult()));
+		assertThat(writer.toString()).isEqualTo("");
+	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterTest.java
@@ -1,0 +1,88 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.googlecode.jmxtrans.model.ResultAttribute;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.ResultFixtures.*;
+import static com.googlecode.jmxtrans.model.ResultFixtures.singleNumericResult;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by Nate Good on 10/21/16.
+ */
+public class StatsDTelegrafWriterTest {
+
+    private StringWriter writer = new StringWriter();
+    String expectedMeasureAndTags = "MemoryAlias,jmxport=4321,attribute=ObjectPendingFinalizationCount:"; //objectName=myQuery:key=val,
+
+    @Test
+    public void hashResultAttribues() throws IOException {
+        StatsDTelegrafWriter w = new StatsDTelegrafWriter(StatsDMetricType.COUNTER.getKey(), ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+        w.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(hashResult()) );
+        assertThat(writer.toString()).isEqualTo(
+			"MemoryAlias,jmxport=4321,attribute=NonHeapMemoryUsage,resultKey=committed:12345|c\n" +
+			"MemoryAlias,jmxport=4321,attribute=NonHeapMemoryUsage,resultKey=init:23456|c\n" +
+			"MemoryAlias,jmxport=4321,attribute=NonHeapMemoryUsage,resultKey=used:45678|c\n");
+    }
+
+    @Test
+    public void countAttribute() throws IOException {
+        StatsDTelegrafWriter w = new StatsDTelegrafWriter(StatsDMetricType.COUNTER.getKey(), ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+        w.write(writer, dummyServer(), dummyQuery(), singleNumericResult());
+        assertThat(writer.toString()).isEqualTo(expectedMeasureAndTags + "10|c\n");
+    }
+
+    @Test
+    public void countAttribute_negativeValueIsIgnored() throws IOException {
+        StatsDTelegrafWriter w = new StatsDTelegrafWriter(StatsDMetricType.COUNTER.getKey(), ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+        w.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(numericResult(-10)));
+        assertThat(writer.toString()).isEqualTo("");
+    }
+
+    @Test
+    public void gaugeAttribute() throws IOException {
+        StatsDTelegrafWriter w = new StatsDTelegrafWriter(StatsDMetricType.GAUGE.getKey(), ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+        w.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(numericResult(-10)));
+        assertThat(writer.toString()).isEqualTo(expectedMeasureAndTags + "-10|g\n");
+    }
+
+    @Test
+    public void multipleBucketTypes() throws IOException {
+        StatsDTelegrafWriter w = new StatsDTelegrafWriter("s,ms,g", ImmutableMap.<String, String>of(), ImmutableSet.<ResultAttribute>of());
+        w.write(writer, dummyServer(), dummyQuery(), ImmutableList.of( numericResult(5), numericResult(250), numericResult(10.5)));
+        assertThat(writer.toString()).isEqualTo(
+            expectedMeasureAndTags + "5|s\n" +
+            expectedMeasureAndTags + "250|ms\n" +
+            expectedMeasureAndTags + "10.5|g\n");
+    }
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriter2Test.java
@@ -46,7 +46,7 @@ public class StatsDWriter2Test {
 		writer.write(out, dummyServer(), dummyQuery(), singleNumericResult());
 
 		assertThat(out.toString())
-				.isEqualTo("root.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount:10|c\n");
+				.isEqualTo("root.host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount:10|c\n");
 	}
 
 	@Test
@@ -57,7 +57,7 @@ public class StatsDWriter2Test {
 		writer.write(out, dummyServer(), dummyQuery(), singleNumericBelowCPrecisionResult());
 
 		assertThat(out.toString())
-				.isEqualTo("root.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount:0|c\n");
+				.isEqualTo("root.host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount:0|c\n");
 	}
 
 	@Test
@@ -89,7 +89,7 @@ public class StatsDWriter2Test {
 		writer.write(out, dummyServer(), dummyQuery(), dummyResults());
 
 		assertThat(out.toString())
-				.isEqualTo("root.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount:10|g\n" +
+				.isEqualTo("root.host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount:10|g\n" +
 						"root.host_example_net_4321.VerboseMemory.Verbose.true:1|g\n" +
 						"root.host_example_net_4321.VerboseMemory.Verbose.false:1|g\n");
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactoryIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactoryIT.java
@@ -60,7 +60,7 @@ public class StatsDWriterFactoryIT {
 		statsDWriter.close();
 
 		await().atMost(200, MILLISECONDS)
-				.until(messageReceived("servers.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount:10|c\n"));
+				.until(messageReceived("servers.host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount:10|c\n"));
 	}
 
 	private Callable<Boolean> messageReceived(final String message) {

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -64,7 +64,7 @@ public class KafkaWriterTests {
 
 		assertThat(message.topic()).isEqualTo("myTopic");
 		assertThat(message.message())
-				.contains("\"keyspace\":\"rootPrefix.host_example_net_4321.ObjectPendingFinalizationCount.ObjectPendingFinalizationCount\"")
+				.contains("\"keyspace\":\"rootPrefix.host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount\"")
 				.contains("\"value\":\"10\"")
 				.contains("\"timestamp\":0")
 				.contains("\"tags\":{\"myTagKey1\":\"myTagValue1\"");


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23issuecomment-255544502%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23issuecomment-255544630%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23issuecomment-255681107%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23issuecomment-255682396%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23issuecomment-255699713%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23discussion_r84665578%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23discussion_r84677161%22%2C%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23discussion_r84677752%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23issuecomment-255544502%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Sample%20config%2C%20I%20can%20update%20the%20wiki%20once%20this%20is%20merged.%5Cr%5Cn%60%60%60%5Cr%5Cn%5C%22queries%5C%22%20%3A%20%5B%5Cr%5Cn%20%20%20%20%20%20%20%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22obj%5C%22%20%3A%20%5C%22java.lang%3Atype%3DMemory%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22attr%5C%22%20%3A%20%20%5B%5C%22HeapMemoryUsage%5C%22%2C%5C%22NonHeapMemoryUsage%5C%22%2C%5C%22ObjectPendingFinalizationCount%5C%22%5D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22resultAlias%5C%22%3A%20%5C%22JVMMemory%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%5C%22outputWriters%5C%22%20%3A%20%5B%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22%40class%5C%22%20%3A%20%5C%22com.googlecode.jmxtrans.model.output.StatsDTelegrafWriterFactory%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22port%5C%22%20%3A%208125%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22host%5C%22%20%3A%20%5C%22localhost%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22tags%5C%22%20%3A%20%7B%20%5C%22instance%5C%22%20%3A%20%5C%22tomcat01%5C%22%20%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22bucketType%5C%22%20%3A%20%5C%22c%2Cc%2Cc%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%5D%5Cr%5Cn%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnI%20added%20support%20for%20an%20array%20of%20bucketType%20values%20only%20to%20find%20out%20that%20Telegraf%20doesn%27t%20permit%20counters%20mixed%20with%20other%20types%20because%20the%20field_type%20will%20be%20incompatible.%20%20%28Counters%20are%20int64%2C%20everything%20else%20is%20a%20float%3B%20and%20this%20is%20assigned%20to%20the%20InfluxDB%20Measure%29%5Cr%5Cn%5Cr%5CnI%20was%20originally%20going%20to%20mix%20counters%20and%20gauges%20but%20decided%20to%20just%20go%20with%20counters%2C%20but%20I%20left%20the%20functionality%20intact.%5Cr%5Cn%5Cr%5CnIf%20a%20single%20value%20is%20specified%20it%20will%20work%20in%20a%20backwards%20compatible%20fashion%20and%20be%20applied%20to%20each%20line%20that%20is%20output.%20%20%22%2C%20%22created_at%22%3A%20%222016-10-22T18%3A13%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12678528%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecounselor%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20wasn%27t%20able%20to%20get%20the%20projects%20unit%20tests%20running%2C%20and%20I%20don%27t%20understand%20why%20Travis%20failed.%20%20If%20there%20are%20instructions%20I%20missed%20somewhere%20please%20point%20me%20that%20way%20and%20I%27ll%20try%20again.%22%2C%20%22created_at%22%3A%20%222016-10-22T18%3A15%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12678528%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecounselor%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ll%20have%20a%20look%20as%20soon%20as%20I%20can...%22%2C%20%22created_at%22%3A%20%222016-10-24T08%3A40%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20looks%20like%20an%20issue%20with%20LessIO%20security%20manager%20%28a%20security%20manager%20that%20tries%20to%20make%20sure%20that%20unit%20tests%20don%27t%20do%20IO%29.%20LessIO%20looked%20like%20a%20good%20idea%2C%20but%20it%20is%20causing%20more%20harm%20than%20good.%20This%20migth%20be%20hiding%20something%20else%20though...%20I%20think%20it%20is%20time%20to%20remove%20LessIO.%22%2C%20%22created_at%22%3A%20%222016-10-24T08%3A46%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Some%20cleanup%20of%20tests%20has%20been%20done%20in%20%23502.%20Could%20you%20try%20to%20rebase%20your%20PR%20on%20top%20of%20master%20%28as%20soon%20as%20%23502%20is%20merged%29%3F%20Thanks%20for%20your%20patience%21%22%2C%20%22created_at%22%3A%20%222016-10-24T10%3A04%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ffe474ad578c569d98f4a129c4c422936f720f3f%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriter.java%20131%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23discussion_r84665578%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Since%20this%20class%20only%20works%20with%20Numbers%2C%20we%20should%20throw%20an%20exception%20instead%20of%20returning%20%60null%60.%22%2C%20%22created_at%22%3A%20%222016-10-24T11%3A15%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriter.java%3AL1-135%22%7D%2C%20%22Pull%20ffe474ad578c569d98f4a129c4c422936f720f3f%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/jmxtrans/jmxtrans/pull/501%23discussion_r84677161%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20my%20test%20scenario%20I%20care%20about%20ensuring%20the%20alias%20was%20used.%20%20I%20suppose%20I%20could%20have%20tested%20with%20the%20%60ObjectPendingFinalizationCount%60%20value%2C%20but%20given%20that%20this%20is%20the%20alias%20field%20it%20made%20sense%20to%20me%20to%20provide%20a%20distinct%20value%20from%20the%20attribute%20name.%20%20%22%2C%20%22created_at%22%3A%20%222016-10-24T12%3A38%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12678528%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/codecounselor%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20isssue%20I%20see%20there%20is%20that%20the%20previous%20naming%20mostly%20matched%20what%20can%20actually%20be%20found%20in%20a%20JVM%2C%20while%20the%20new%20one%20does%20not%20make%20sense.%20I%20see%20the%20point%20in%20having%20an%20alias%20that%20is%20different%20to%20provide%20better%20test%2C%20but%20we%20should%20probably%20keep%20something%20that%20make%20sense%20in%20this%20context.%20For%20example%3A%20resultAlias%20%3A%20object_pending_finalization_count.%22%2C%20%22created_at%22%3A%20%222016-10-24T12%3A41%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java%3AL55-83%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/501#issuecomment-255544502'>General Comment</a></b>
- <a href='https://github.com/codecounselor'><img border=0 src='https://avatars.githubusercontent.com/u/12678528?v=3' height=16 width=16'></a> Sample config, I can update the wiki once this is merged.
```
"queries" : [
{
"obj" : "java.lang:type=Memory",
"attr" :  ["HeapMemoryUsage","NonHeapMemoryUsage","ObjectPendingFinalizationCount"],
"resultAlias": "JVMMemory",
"outputWriters" : [ {
"@class" : "com.googlecode.jmxtrans.model.output.StatsDTelegrafWriterFactory",
"port" : 8125,
"host" : "localhost",
"tags" : { "instance" : "tomcat01" },
"bucketType" : "c,c,c"
}]
}
```
I added support for an array of bucketType values only to find out that Telegraf doesn't permit counters mixed with other types because the field_type will be incompatible.  (Counters are int64, everything else is a float; and this is assigned to the InfluxDB Measure)
I was originally going to mix counters and gauges but decided to just go with counters, but I left the functionality intact.
If a single value is specified it will work in a backwards compatible fashion and be applied to each line that is output.
- <a href='https://github.com/codecounselor'><img border=0 src='https://avatars.githubusercontent.com/u/12678528?v=3' height=16 width=16'></a> I wasn't able to get the projects unit tests running, and I don't understand why Travis failed.  If there are instructions I missed somewhere please point me that way and I'll try again.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I'll have a look as soon as I can...
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> It looks like an issue with LessIO security manager (a security manager that tries to make sure that unit tests don't do IO). LessIO looked like a good idea, but it is causing more harm than good. This migth be hiding something else though... I think it is time to remove LessIO.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Some cleanup of tests has been done in #502. Could you try to rebase your PR on top of master (as soon as #502 is merged)? Thanks for your patience!
- [ ] <a href='#crh-comment-Pull ffe474ad578c569d98f4a129c4c422936f720f3f jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriter.java 131'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/501#discussion_r84665578'>File: jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriter.java:L1-135</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Since this class only works with Numbers, we should throw an exception instead of returning `null`.
- [ ] <a href='#crh-comment-Pull ffe474ad578c569d98f4a129c4c422936f720f3f jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/jmxtrans/jmxtrans/pull/501#discussion_r84677161'>File: jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java:L55-83</a></b>
- <a href='https://github.com/codecounselor'><img border=0 src='https://avatars.githubusercontent.com/u/12678528?v=3' height=16 width=16'></a> In my test scenario I care about ensuring the alias was used.  I suppose I could have tested with the `ObjectPendingFinalizationCount` value, but given that this is the alias field it made sense to me to provide a distinct value from the attribute name.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> The isssue I see there is that the previous naming mostly matched what can actually be found in a JVM, while the new one does not make sense. I see the point in having an alias that is different to provide better test, but we should probably keep something that make sense in this context. For example: resultAlias : object_pending_finalization_count.


<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/501?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/501?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/501'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>