### PR TITLE
Removed LessIO security manager

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/QueryFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/QueryFixtures.java
@@ -32,6 +32,13 @@ public final class QueryFixtures {
 				.build();
 	}
 
+	public static Query dummyQueryWithResultAlias() {
+		return Query.builder()
+				.setObj("myQuery:key=val")
+				.setResultAlias("resultAlias")
+				.build();
+	}
+
 	public static Query queryWithAllTypeNames() {
 		return Query.builder()
 				.setObj("myQuery:key=val")

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -68,6 +68,7 @@ import java.util.Set;
 import static com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.NON_NULL;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableSet.copyOf;
 import static javax.management.remote.JMXConnectorFactory.PROTOCOL_PROVIDER_PACKAGES;
@@ -152,7 +153,7 @@ public class Server implements JmxConnectionProvider {
 
 	@Nonnull @Getter private final Iterable<OutputWriter> outputWriters;
 
-	private final KeyedObjectPool<JmxConnectionProvider, JMXConnection> pool;
+	@Nonnull private final KeyedObjectPool<JmxConnectionProvider, JMXConnection> pool;
 	@Nonnull @Getter private final ImmutableList<OutputWriterFactory> outputWriterFactories;
 
 	@JsonCreator
@@ -252,7 +253,7 @@ public class Server implements JmxConnectionProvider {
 		else {
 			this.host = host;
 		}
-		this.pool = pool;
+		this.pool = checkNotNull(pool);
 		this.outputWriterFactories = ImmutableList.copyOf(firstNonNull(outputWriterFactories, ImmutableList.<OutputWriterFactory>of()));
 		this.outputWriters = ImmutableList.copyOf(firstNonNull(outputWriters, ImmutableList.<OutputWriter>of()));
 	}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ServerFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ServerFixtures.java
@@ -22,10 +22,18 @@
  */
 package com.googlecode.jmxtrans.model;
 
+import com.googlecode.jmxtrans.connections.JMXConnection;
+import com.googlecode.jmxtrans.connections.JmxConnectionProvider;
+import com.googlecode.jmxtrans.connections.MBeanServerConnectionFactory;
+import org.apache.commons.pool.KeyedObjectPool;
+import org.apache.commons.pool.impl.GenericKeyedObjectPool;
+
 public final class ServerFixtures {
 
 	public static final String DEFAULT_HOST = "host.example.net";
 	public static final String DEFAULT_PORT = "4321";
+	public static final String SERVER_ALIAS = "myAlias";
+	public static final String DEFAULT_QUERY = "myQuery:key=val";
 
 	private ServerFixtures() {}
 
@@ -33,6 +41,7 @@ public final class ServerFixtures {
 		return Server.builder()
 				.setHost(host)
 				.setPort(port)
+				.setPool(createPool())
 				.addQuery(Query.builder()
 					.setObj(queryObject)
 					.build())
@@ -43,18 +52,34 @@ public final class ServerFixtures {
 		return Server.builder()
 				.setHost(DEFAULT_HOST)
 				.setPort(DEFAULT_PORT)
+				.setPool(createPool())
+				.build();
+	}
+
+	public static Server serverWithAliasAndNoQuery() {
+		return Server.builder()
+				.setHost(DEFAULT_HOST)
+				.setPort(DEFAULT_PORT)
+				.setAlias(SERVER_ALIAS)
+				.setPool(createPool())
 				.build();
 	}
 
 	public static Server dummyServer() {
-		return createServerWithOneQuery(DEFAULT_HOST, DEFAULT_PORT, "myQuery:key=val");
+		return createServerWithOneQuery(DEFAULT_HOST, DEFAULT_PORT, DEFAULT_QUERY);
 	}
 
 	public static Server localServer() {
 		return Server.builder()
-				.setHost("host.example.net")
-				.setPort("4321")
+				.setHost(DEFAULT_HOST)
+				.setPort(DEFAULT_PORT)
 				.setLocal(true)
+				.setPool(createPool())
 				.build();
 	}
+
+	public static KeyedObjectPool<JmxConnectionProvider, JMXConnection> createPool() {
+		return new GenericKeyedObjectPool<>(new MBeanServerConnectionFactory());
+	}
+
 }

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/ConfigurationParserTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/ConfigurationParserTest.java
@@ -31,7 +31,6 @@ import com.googlecode.jmxtrans.model.ServerFixtures;
 import com.googlecode.jmxtrans.model.ValidationException;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.googlecode.jmxtrans.util.JsonUtils;
-import com.kaching.platform.testing.AllowLocalFileAccess;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -43,9 +42,10 @@ import java.util.List;
 
 import static com.google.common.collect.ImmutableList.of;
 import static com.googlecode.jmxtrans.guice.JmxTransModule.createInjector;
+import static com.googlecode.jmxtrans.model.ServerFixtures.createPool;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@AllowLocalFileAccess(paths = "*")
 @Category(RequiresIO.class)
 public class ConfigurationParserTest {
 
@@ -82,10 +82,10 @@ public class ConfigurationParserTest {
 	@Test
 	public void mergeAlreadyExistingServerDoesNotModifyList() throws ValidationException {
 		List<Server> existingServers = new ArrayList<Server>();
-		existingServers.add(ServerFixtures.createServerWithOneQuery("example.net", "123", "toto:key=val"));
+		existingServers.add(dummyServer());
 
 		List<Server> newServers = new ArrayList<Server>();
-		newServers.add(ServerFixtures.createServerWithOneQuery("example.net", "123", "toto:key=val"));
+		newServers.add(dummyServer());
 
 		List<Server> merged = configurationParser.mergeServerLists(existingServers, newServers);
 
@@ -146,6 +146,7 @@ public class ConfigurationParserTest {
 				.setAlias("alias")
 				.setHost("host")
 				.setPort("8004")
+				.setPool(createPool())
 				.setCronExpression("cron")
 				.setNumQueryThreads(123)
 				.setPassword("pass")
@@ -159,6 +160,7 @@ public class ConfigurationParserTest {
 				.setAlias("alias")
 				.setHost("host")
 				.setPort("8004")
+				.setPool(createPool())
 				.setCronExpression("cron")
 				.setNumQueryThreads(123)
 				.setPassword("pass")
@@ -171,6 +173,7 @@ public class ConfigurationParserTest {
 				.setAlias("alias")
 				.setHost("host3")
 				.setPort("8004")
+				.setPool(createPool())
 				.setCronExpression("cron")
 				.setNumQueryThreads(123)
 				.setPassword("pass")

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerIT.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerIT.java
@@ -30,8 +30,6 @@ import com.googlecode.jmxtrans.test.IntegrationTest;
 import com.googlecode.jmxtrans.test.MonitorableApp;
 import com.googlecode.jmxtrans.test.OutputCapture;
 import com.googlecode.jmxtrans.test.RequiresIO;
-import com.kaching.platform.testing.AllowDNSResolution;
-import com.kaching.platform.testing.AllowLocalFileAccess;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,8 +42,6 @@ import java.net.URISyntaxException;
 import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-@AllowDNSResolution
-@AllowLocalFileAccess(paths = "*")
 @Category({IntegrationTest.class, RequiresIO.class})
 public class JmxTransformerIT {
 	@Rule public OutputCapture output = new OutputCapture();

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/cli/CliArgumentParserBase.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/cli/CliArgumentParserBase.java
@@ -22,7 +22,6 @@
  */
 package com.googlecode.jmxtrans.cli;
 
-import com.kaching.platform.testing.AllowLocalFileAccess;
 import org.apache.commons.cli.ParseException;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -40,7 +39,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
-@AllowLocalFileAccess(paths = "*")
 public abstract class CliArgumentParserBase {
 	@Rule
 	public TemporaryFolder mockConfigurationDirectory = new TemporaryFolder();

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/connections/DatagramSocketFactoryTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/connections/DatagramSocketFactoryTest.java
@@ -23,8 +23,6 @@
 package com.googlecode.jmxtrans.connections;
 
 import com.googlecode.jmxtrans.test.RequiresIO;
-import com.kaching.platform.testing.AllowNetworkAccess;
-import com.kaching.platform.testing.AllowNetworkListen;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -35,8 +33,6 @@ import java.net.InetSocketAddress;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(RequiresIO.class)
-@AllowNetworkListen(ports = 0)
-@AllowNetworkAccess(endpoints = "*:" + DatagramSocketFactoryTest.PORT)
 public class DatagramSocketFactoryTest {
 
 	public static final int PORT = 50123;

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/connections/SocketFactoryTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/connections/SocketFactoryTests.java
@@ -25,8 +25,6 @@ package com.googlecode.jmxtrans.connections;
 import com.google.common.io.Closer;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.googlecode.jmxtrans.test.TCPEchoServer;
-import com.kaching.platform.testing.AllowNetworkAccess;
-import com.kaching.platform.testing.AllowNetworkListen;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -38,8 +36,6 @@ import java.net.Socket;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(RequiresIO.class)
-@AllowNetworkAccess(endpoints = "127.0.0.1:*")
-@AllowNetworkListen(ports = 0)
 public class SocketFactoryTests {
 
 	@Rule

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/jmx/JmxProcessingTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/jmx/JmxProcessingTests.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@Ignore("Incompatibility with LessIOSecurityManager")
+@Ignore("Needs some refactoring")
 public class JmxProcessingTests {
 
 	public static final String MBEAN_NAME = "domain:type=SomeType";

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/jmx/JmxResultProcessorTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/jmx/JmxResultProcessorTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.JmxResultProcessor;
 import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.QueryFixtures;
 import com.googlecode.jmxtrans.model.Result;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -48,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.collect.FluentIterable.from;
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQueryWithResultAlias;
 import static java.lang.Boolean.TRUE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,25 +60,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  * that this test will fail on some JVMs or that it depends too much on
  * specific platform properties.
  */
-@Ignore("Incompatibility with LessIOSecurityManager")
 public class JmxResultProcessorTest {
 
-	private Query query;
 	private final static String TEST_DOMAIN_NAME = "ObjectDomainName";
-
-	@Before
-	public void initConfiguration() {
-		query = Query.builder()
-				.setResultAlias("resultAlias")
-				.build();
-	}
 
 	@Test
 	public void canCreateBasicResultData() throws MalformedObjectNameException, InstanceNotFoundException {
 		Attribute integerAttribute = new Attribute("StartTime", 51L);
 		ObjectInstance runtime = getRuntime();
 		List<Result> results = new JmxResultProcessor(
-				query,
+				dummyQueryWithResultAlias(),
 				runtime,
 				ImmutableList.of(integerAttribute),
 				runtime.getClassName(),
@@ -97,7 +90,7 @@ public class JmxResultProcessorTest {
 		String className = "java.lang.SomeClass";
 		String propertiesOutOfOrder = "z-key=z-value,a-key=a-value,k-key=k-value";
 		List<Result> results = new JmxResultProcessor(
-				query,
+				dummyQueryWithResultAlias(),
 				new ObjectInstance(className + ":" + propertiesOutOfOrder, className),
 				ImmutableList.of(new Attribute("SomeAttribute", 1)),
 				className,
@@ -114,7 +107,7 @@ public class JmxResultProcessorTest {
 		Attribute integerAttribute = new Attribute("CollectionCount", 51L);
 		ObjectInstance runtime = getRuntime();
 		List<Result> results = new JmxResultProcessor(
-				query,
+				dummyQueryWithResultAlias(),
 				runtime,
 				ImmutableList.of(integerAttribute),
 				runtime.getClassName(),
@@ -138,7 +131,7 @@ public class JmxResultProcessorTest {
 		Attribute booleanAttribute = new Attribute("BootClassPathSupported", true);
 		ObjectInstance runtime = getRuntime();
 		List<Result> results = new JmxResultProcessor(
-				query,
+				dummyQueryWithResultAlias(),
 				runtime,
 				ImmutableList.of(booleanAttribute),
 				runtime.getClassName(),
@@ -164,7 +157,7 @@ public class JmxResultProcessorTest {
 		AttributeList attr = ManagementFactory.getPlatformMBeanServer().getAttributes(
 				runtime.getObjectName(), new String[]{"SystemProperties"});
 		List<Result> results = new JmxResultProcessor(
-				query,
+				dummyQueryWithResultAlias(),
 				runtime,
 				attr.asList(),
 				runtime.getClassName(),
@@ -194,7 +187,7 @@ public class JmxResultProcessorTest {
 		AttributeList attr = ManagementFactory.getPlatformMBeanServer().getAttributes(
 				memory.getObjectName(), new String[]{"HeapMemoryUsage"});
 		List<Result> results = new JmxResultProcessor(
-				query,
+				dummyQueryWithResultAlias(),
 				memory,
 				attr.asList(),
 				memory.getClassName(),
@@ -219,7 +212,7 @@ public class JmxResultProcessorTest {
 		Attribute mapAttribute = new Attribute("map", ImmutableMap.of("key1", "value1", "key2", "value2"));
 
 		List<Result> results = new JmxResultProcessor(
-				query,
+				dummyQueryWithResultAlias(),
 				new ObjectInstance("java.lang:type=Memory", "java.lang.SomeClass"),
 				ImmutableList.of(mapAttribute),
 				"java.lang.SomeClass",
@@ -238,7 +231,7 @@ public class JmxResultProcessorTest {
 		Attribute mapAttribute = new Attribute("map", ImmutableMap.of(1, "value1", 2, "value2"));
 
 		List<Result> results = new JmxResultProcessor(
-				query,
+				dummyQueryWithResultAlias(),
 				new ObjectInstance("java.lang:type=Memory", "java.lang.SomeClass"),
 				ImmutableList.of(mapAttribute),
 				"java.lang.SomeClass",

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/util/JsonUtilsTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/util/JsonUtilsTest.java
@@ -33,8 +33,6 @@ import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.googlecode.jmxtrans.test.ResetableSystemProperty;
-import com.kaching.platform.testing.AllowLocalFileAccess;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +41,6 @@ import org.junit.experimental.categories.Category;
 import javax.annotation.Nullable;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -52,7 +49,6 @@ import static com.google.common.collect.FluentIterable.from;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(RequiresIO.class)
-@AllowLocalFileAccess(paths = "*")
 public class JsonUtilsTest {
 
 	private JsonUtils jsonUtils;

--- a/jmxtrans-examples/src/test/java/com/googlecode/jmxtrans/example/JsonPrinterTest.java
+++ b/jmxtrans-examples/src/test/java/com/googlecode/jmxtrans/example/JsonPrinterTest.java
@@ -26,11 +26,13 @@ import com.google.common.io.Closer;
 import com.googlecode.jmxtrans.model.JmxProcess;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ServerFixtures;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonPrinterTest {
@@ -45,7 +47,7 @@ public class JsonPrinterTest {
 			new JsonPrinter(out).print(standardProcess());
 			String result = new String(baos.toByteArray());
 
-			assertThat(result).contains("\"url\":\"service:jmx:rmi:///jndi/rmi://example.org:123/jmxrmi\"");
+			assertThat(result).contains("\"url\":\"service:jmx:rmi:///jndi/rmi://host.example.net:4321/jmxrmi\"");
 		} catch (Throwable t) {
 			throw closer.rethrow(t);
 		} finally {
@@ -63,7 +65,7 @@ public class JsonPrinterTest {
 			new JsonPrinter(out).prettyPrint(standardProcess());
 			String result = new String(baos.toByteArray());
 
-			assertThat(result).contains("\"url\" : \"service:jmx:rmi:///jndi/rmi://example.org:123/jmxrmi\"");
+			assertThat(result).contains("\"url\" : \"service:jmx:rmi:///jndi/rmi://host.example.net:4321/jmxrmi\"");
 		} catch (Throwable t) {
 			throw closer.rethrow(t);
 		} finally {
@@ -72,15 +74,7 @@ public class JsonPrinterTest {
 	}
 
 	private JmxProcess standardProcess() {
-		Server server = Server.builder()
-				.setAlias("alias")
-				.setHost("example.org")
-				.setPort("123")
-				.addQuery(Query.builder()
-					.setObj("obj:key=val")
-					.build())
-				.build();
-		return new JmxProcess(server);
+		return new JmxProcess(dummyServer());
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-cloudwatch/src/test/java/com/googlecode/jmxtrans/model/output/CloudWatchWriterIT.java
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/src/test/java/com/googlecode/jmxtrans/model/output/CloudWatchWriterIT.java
@@ -29,8 +29,6 @@ import com.googlecode.jmxtrans.model.JmxProcess;
 import com.googlecode.jmxtrans.test.IntegrationTest;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.googlecode.jmxtrans.util.JsonUtils;
-import com.kaching.platform.testing.AllowDNSResolution;
-import com.kaching.platform.testing.AllowLocalFileAccess;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -57,8 +55,6 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
  *
  * @author <a href="mailto:sascha.moellering@gmail.com">Sascha Moellering</a>
  */
-@AllowDNSResolution
-@AllowLocalFileAccess(paths = "*")
 @Category({RequiresIO.class, IntegrationTest.class})
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")

--- a/jmxtrans-output/jmxtrans-output-cloudwatch/src/test/java/com/googlecode/jmxtrans/model/output/CloudWatchWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/src/test/java/com/googlecode/jmxtrans/model/output/CloudWatchWriterTests.java
@@ -27,7 +27,6 @@ import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
 import com.google.common.collect.ImmutableList;
-import com.kaching.platform.testing.AllowDNSResolution;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +46,6 @@ import static org.mockito.Mockito.verify;
  *
  * @author <a href="mailto:sascha.moellering@gmail.com">Sascha Moellering</a>
  */
-@AllowDNSResolution
 @RunWith(MockitoJUnitRunner.class)
 public class CloudWatchWriterTests {
 

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactoryIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactoryIT.java
@@ -36,7 +36,6 @@ import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWrite
 import com.googlecode.jmxtrans.test.IntegrationTest;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.googlecode.jmxtrans.test.ResetableSystemProperty;
-import com.kaching.platform.testing.AllowDNSResolution;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,7 +48,6 @@ import java.net.URISyntaxException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Category({IntegrationTest.class, RequiresIO.class})
-@AllowDNSResolution
 public class GraphiteWriterFactoryIT {
 
 	private ConfigurationParser configurationParser;

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
@@ -22,21 +22,13 @@
  */
 package com.googlecode.jmxtrans.model.output;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.googlecode.jmxtrans.ConfigurationParser;
-import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
-import com.googlecode.jmxtrans.guice.JmxTransModule;
 import com.googlecode.jmxtrans.model.Query;
-import com.googlecode.jmxtrans.model.QueryFixtures;
 import com.googlecode.jmxtrans.model.Result;
-import com.googlecode.jmxtrans.model.ResultFixtures;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.ServerFixtures;
 import com.googlecode.jmxtrans.model.ValidationException;
 import com.googlecode.jmxtrans.test.RequiresIO;
-import com.googlecode.jmxtrans.util.JsonUtils;
-import com.kaching.platform.testing.AllowDNSResolution;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -44,7 +36,6 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -62,12 +53,12 @@ import static com.googlecode.jmxtrans.model.ResultFixtures.numericResult;
 import static com.googlecode.jmxtrans.model.ResultFixtures.numericResultWithTypenames;
 import static com.googlecode.jmxtrans.model.ResultFixtures.singleTrueResult;
 import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
+import static com.googlecode.jmxtrans.model.ServerFixtures.serverWithNoQuery;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @Category(RequiresIO.class)
-@AllowDNSResolution
 public class GraphiteWriterTests {
 
 	@Test(expected = NullPointerException.class)
@@ -181,7 +172,7 @@ public class GraphiteWriterTests {
 	
 	@Test
 	public void checkEmptyTypeNamesAreIgnored() throws Exception {
-		Server server = Server.builder().setHost("host").setPort("123").build();
+		Server server = serverWithNoQuery();
 		// Set useObjDomain to true
 		Query query = Query.builder()
 				.setUseObjDomainAsKey(true)
@@ -206,7 +197,7 @@ public class GraphiteWriterTests {
 		writer.doWrite(server, query, of(result));
 
 		// check that the empty type "type" is ignored when allowDottedKeys is true
-		assertThat(out.toString()).startsWith("servers.host_123.yammer.metrics.uniqueName.Attribute 0 ");
+		assertThat(out.toString()).startsWith("servers.host_example_net_4321.yammer.metrics.uniqueName.Attribute 0 ");
 		
 		// check that this also works when literal " characters aren't included in the JMX ObjectName
 		query = Query.builder()
@@ -218,7 +209,7 @@ public class GraphiteWriterTests {
 		writer = getGraphiteWriter(out, typeNames);
 		
 		writer.doWrite(server, query, of(result));
-		assertThat(out.toString()).startsWith("servers.host_123.yammer.metrics.uniqueName.Attribute 0 ");
+		assertThat(out.toString()).startsWith("servers.host_example_net_4321.yammer.metrics.uniqueName.Attribute 0 ");
 		
 		// check that the empty type "type" is ignored when allowDottedKeys is false
 		query = Query.builder()
@@ -230,7 +221,7 @@ public class GraphiteWriterTests {
 		writer = getGraphiteWriter(out, typeNames);
 		
 		writer.doWrite(server, query, of(result));
-		assertThat(out.toString()).startsWith("servers.host_123.yammer_metrics.uniqueName.Attribute 0 ");
+		assertThat(out.toString()).startsWith("servers.host_example_net_4321.yammer_metrics.uniqueName.Attribute 0 ");
 	}
 
 	@Test

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/LibratoWriterFactoryIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/LibratoWriterFactoryIT.java
@@ -24,12 +24,10 @@ package com.googlecode.jmxtrans.model.output;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableList;
-import com.google.common.eventbus.AllowConcurrentEvents;
 import com.googlecode.jmxtrans.model.QueryFixtures;
 import com.googlecode.jmxtrans.model.ResultFixtures;
 import com.googlecode.jmxtrans.model.ServerFixtures;
 import com.googlecode.jmxtrans.test.IntegrationTest;
-import com.kaching.platform.testing.AllowLocalFileAccess;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,9 +44,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 
 @Category(IntegrationTest.class)
-@AllowLocalFileAccess(paths = "*")
 public class LibratoWriterFactoryIT {
-	@Rule public WireMockRule wireMockRule = new WireMockRule(1234);
+	@Rule public WireMockRule wireMockRule = new WireMockRule(0);
 
 	@Test
 	public void metricsAreSentToServer() throws Exception {
@@ -58,11 +55,10 @@ public class LibratoWriterFactoryIT {
 								.withBody("OK")
 								.withStatus(200)));
 
-
 		new LibratoWriterFactory(
 				ImmutableList.<String>of(),
 				true,
-				new URL("http://localhost:1234/endpoint"),
+				new URL("http://localhost:" + wireMockRule.port() + "/endpoint"),
 				100,
 				"username",
 				"token",

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriterTests.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
-import com.kaching.platform.testing.AllowDNSResolution;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,7 +50,6 @@ import static com.google.common.collect.Maps.newHashMap;
 /**
  * Tests for {@link OpenTSDBGenericWriter}.
  */
-@AllowDNSResolution
 public class OpenTSDBGenericWriterTests {
 
 	protected Query mockQuery;

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.test.RequiresIO;
-import com.kaching.platform.testing.AllowDNSResolution;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -55,7 +54,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link OpenTSDBWriter}.
  */
 @Category(RequiresIO.class)
-@AllowDNSResolution
 public class OpenTSDBWriterTests {
 	protected OpenTSDBWriter writer;
 	protected Query mockQuery;

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactoryIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactoryIT.java
@@ -27,8 +27,6 @@ import com.googlecode.jmxtrans.model.output.support.WriterPoolOutputWriter;
 import com.googlecode.jmxtrans.test.IntegrationTest;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.googlecode.jmxtrans.test.UdpLoggingServer;
-import com.kaching.platform.testing.AllowNetworkAccess;
-import com.kaching.platform.testing.AllowNetworkListen;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -43,8 +41,6 @@ import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @Category({IntegrationTest.class, RequiresIO.class})
-@AllowNetworkAccess(endpoints = "127.0.0.1:*")
-@AllowNetworkListen(ports = 0)
 public class StatsDWriterFactoryIT {
 
 	@Rule

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterTests.java
@@ -56,7 +56,6 @@ import static org.mockito.Matchers.eq;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({TCollectorUDPWriter.class, DatagramSocket.class})
-@Ignore("Incompatible with LessIOSecurityManager, investigation required")
 public class TCollectorUDPWriterTests {
 	protected TCollectorUDPWriter writer;
 	protected Query mockQuery;

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/HttpOutputWriterIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/HttpOutputWriterIT.java
@@ -48,9 +48,8 @@ import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 @Category(IntegrationTest.class)
 public class HttpOutputWriterIT {
 
-	private static final int WIREMOCK_PORT = 1234;
 	public static final String ENDPOINT = "/endpoint";
-	@Rule public WireMockRule wireMockRule = new WireMockRule(WIREMOCK_PORT);
+	@Rule public WireMockRule wireMockRule = new WireMockRule(0);
 
 	@Test
 	public void messageIsSentOverHttp() throws Exception {
@@ -89,7 +88,7 @@ public class HttpOutputWriterIT {
 	private HttpOutputWriter simpleOutputWriter() throws MalformedURLException {
 		return new HttpOutputWriter(
 				new DummyWriterBasedOutputWriter("message"),
-				new URL("http://localhost:" + WIREMOCK_PORT + ENDPOINT),
+				new URL("http://localhost:" + wireMockRule.port() + ENDPOINT),
 				null,
 				HttpUrlConnectionConfigurer.builder("POST").build(),
 				UTF_8

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriterBuilderIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriterBuilderIT.java
@@ -25,8 +25,6 @@ package com.googlecode.jmxtrans.model.output.support;
 import com.googlecode.jmxtrans.test.IntegrationTest;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.googlecode.jmxtrans.test.TCPEchoServer;
-import com.kaching.platform.testing.AllowNetworkAccess;
-import com.kaching.platform.testing.AllowNetworkListen;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,8 +38,6 @@ import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @Category({IntegrationTest.class, RequiresIO.class})
-@AllowNetworkAccess(endpoints = "127.0.0.1:*")
-@AllowNetworkListen(ports = 0)
 public class TcpOutputWriterBuilderIT {
 
 	@Rule public TCPEchoServer tcpEchoServer = new TCPEchoServer();

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/UdpOutputWriterBuilderIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/UdpOutputWriterBuilderIT.java
@@ -25,8 +25,6 @@ package com.googlecode.jmxtrans.model.output.support;
 import com.googlecode.jmxtrans.test.IntegrationTest;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.googlecode.jmxtrans.test.UdpLoggingServer;
-import com.kaching.platform.testing.AllowNetworkAccess;
-import com.kaching.platform.testing.AllowNetworkListen;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,8 +39,6 @@ import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @Category({IntegrationTest.class, RequiresIO.class})
-@AllowNetworkAccess(endpoints = "127.0.0.1:*")
-@AllowNetworkListen(ports = 0)
 public class UdpOutputWriterBuilderIT {
 
 	@Rule public UdpLoggingServer udpLoggingServer = new UdpLoggingServer(UTF_8);

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/SocketAllocatorTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/pool/SocketAllocatorTest.java
@@ -22,11 +22,9 @@
  */
 package com.googlecode.jmxtrans.model.output.support.pool;
 
+import com.googlecode.jmxtrans.test.IntegrationTest;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.googlecode.jmxtrans.test.TCPEchoServer;
-import com.googlecode.jmxtrans.test.IntegrationTest;
-import com.kaching.platform.testing.AllowDNSResolution;
-import com.kaching.platform.testing.AllowNetworkAccess;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import stormpot.Slot;
@@ -43,8 +41,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @Category(RequiresIO.class)
-@AllowDNSResolution
-@AllowNetworkAccess(endpoints = "127.0.0.1:*")
 public class SocketAllocatorTest {
 
 	@Category(IntegrationTest.class)

--- a/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-elastic/src/test/java/com/googlecode/jmxtrans/model/output/elastic/ElasticWriterTests.java
@@ -28,6 +28,7 @@ import com.google.gson.Gson;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ServerFixtures;
 import io.searchbox.action.Action;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
@@ -50,7 +51,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.ServerFixtures.DEFAULT_HOST;
+import static com.googlecode.jmxtrans.model.ServerFixtures.DEFAULT_PORT;
+import static com.googlecode.jmxtrans.model.ServerFixtures.SERVER_ALIAS;
 import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
+import static com.googlecode.jmxtrans.model.ServerFixtures.serverWithAliasAndNoQuery;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.isA;
@@ -143,11 +148,7 @@ public class ElasticWriterTests {
 	@Test
     public void sendMessageToElasticAndVerify() throws Exception {
 
-        String host = "myHost";
-        String port = "56677";
-
-		String serverAlias = "myAlias";
-		Server serverWithKnownValues = Server.builder().setHost(host).setPort(port).setAlias(serverAlias).build();
+		Server serverWithKnownValues = serverWithAliasAndNoQuery();
 
         int epoch = 1123455;
         String attributeName = "attributeName123";
@@ -172,8 +173,8 @@ public class ElasticWriterTests {
 
         Gson gson = new Gson();
         String data = argument.getValue().getData(gson);
-        assertTrue("Contains host", data.contains(host));
-        assertTrue("Contains port", data.contains(port));
+        assertTrue("Contains host", data.contains(DEFAULT_HOST));
+        assertTrue("Contains port", data.contains(DEFAULT_PORT));
         assertTrue("Contains attribute name", data.contains(attributeName));
         assertTrue("Contains class name", data.contains(className));
         assertTrue("Contains object domain", data.contains(objDomain));
@@ -182,7 +183,7 @@ public class ElasticWriterTests {
         assertTrue("Contains timestamp", data.contains(String.valueOf(epoch)));
         assertTrue("Contains key", data.contains(key));
         assertTrue("Contains value", data.contains(String.valueOf(value)));
-		assertTrue("Contains serverAlias", data.contains(serverAlias));
+		assertTrue("Contains serverAlias", data.contains(SERVER_ALIAS));
 
     }
 

--- a/jmxtrans-output/jmxtrans-output-ganglia/src/test/java/com/googlecode/jmxtrans/model/output/GangliaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-ganglia/src/test/java/com/googlecode/jmxtrans/model/output/GangliaWriterTests.java
@@ -24,7 +24,6 @@ package com.googlecode.jmxtrans.model.output;
 
 import com.googlecode.jmxtrans.model.ValidationException;
 import com.googlecode.jmxtrans.test.RequiresIO;
-import com.kaching.platform.testing.AllowDNSResolution;
 import info.ganglia.gmetric4j.gmetric.GMetric;
 import info.ganglia.gmetric4j.gmetric.GMetricSlope;
 import org.junit.Assert;
@@ -41,7 +40,6 @@ import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
  * @author Julien Nicoulaud <http://github.com/nicoulaj>
  */
 @Category(RequiresIO.class)
-@AllowDNSResolution
 public class GangliaWriterTests {
 
     /** Test validation when no parameter is set. */

--- a/jmxtrans-test-utils/pom.xml
+++ b/jmxtrans-test-utils/pom.xml
@@ -49,11 +49,6 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.kaching.platform</groupId>
-			<artifactId>kawala-testing</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>compile</scope>

--- a/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/JHadesBaseTest.java
+++ b/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/JHadesBaseTest.java
@@ -22,13 +22,11 @@
  */
 package com.googlecode.jmxtrans.test;
 
-import com.kaching.platform.testing.AllowLocalFileAccess;
 import org.jhades.JHades;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category({ IntegrationTest.class, RequiresIO.class })
-@AllowLocalFileAccess(paths = "*")
 public class JHadesBaseTest {
 
 	@Test

--- a/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/MonitorableApp.java
+++ b/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/MonitorableApp.java
@@ -24,7 +24,6 @@ package com.googlecode.jmxtrans.test;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.kaching.platform.testing.AllowExternalProcess;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.rules.ExternalResource;
 
@@ -35,7 +34,6 @@ import java.net.URLClassLoader;
 import static com.google.common.collect.FluentIterable.from;
 import static java.util.Arrays.asList;
 
-@AllowExternalProcess
 public class MonitorableApp extends ExternalResource {
 
 	private Process app;

--- a/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/classloader/ClassLoadingTests.java
+++ b/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/classloader/ClassLoadingTests.java
@@ -23,7 +23,6 @@
 package com.googlecode.jmxtrans.classloader;
 
 import com.googlecode.jmxtrans.test.IntegrationTest;
-import com.kaching.platform.testing.AllowLocalFileAccess;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -34,7 +33,6 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 
 @Category(IntegrationTest.class)
-@AllowLocalFileAccess(paths = "*")
 public class ClassLoadingTests {
 
 	@Test(expected = ClassNotFoundException.class)

--- a/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/WatchDirTest.java
+++ b/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/WatchDirTest.java
@@ -23,7 +23,6 @@
 package com.googlecode.jmxtrans.util;
 
 import com.googlecode.jmxtrans.test.IntegrationTest;
-import com.kaching.platform.testing.AllowLocalFileAccess;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -41,7 +40,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-@AllowLocalFileAccess(paths = "%TMP_DIR%")
 @Category(IntegrationTest.class)
 public class WatchDirTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -507,34 +507,6 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>com.kaching.platform</groupId>
-				<artifactId>kawala-testing</artifactId>
-				<version>0.1.6</version>
-				<scope>test</scope>
-				<exclusions>
-					<exclusion>
-						<groupId>jdepend</groupId>
-						<artifactId>jdepend</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>org.jmock</groupId>
-						<artifactId>jmock</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>org.jmock</groupId>
-						<artifactId>jmock-junit4</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>org.jmock</groupId>
-						<artifactId>jmock-legacy</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>asm</groupId>
-						<artifactId>asm-all</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>4.12</version>
@@ -619,11 +591,6 @@
 	</dependencyManagement>
 
 	<dependencies>
-		<dependency>
-			<groupId>com.kaching.platform</groupId>
-			<artifactId>kawala-testing</artifactId>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
@@ -983,7 +950,6 @@
 							<include>**/*TestCase.java</include>
 							<include>**/*Tests.java</include>
 						</includes>
-						<argLine>-Djava.security.manager=com.kaching.platform.testing.LessIOSecurityManager</argLine>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
LessIO was used to ensure that unit tests did not do IO (that would mark them
as integration tests instead). This looked like a good idea, but is actually
causing more problems than solving. This is now removed.

Some cleanup of unit test is done in the same change.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/jmxtrans/jmxtrans/pull/502?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/jmxtrans/jmxtrans/pull/502'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>