### PR TITLE
Singleton OutputWriter cleanup, implement stop() on ResultTransformerOutputWriter

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
@@ -261,6 +261,13 @@ public class JmxTransformer implements WatchedCallback {
 	 */
 	private void stopWriterAndClearMasterServerList() {
 		for (Server server : this.masterServersList) {
+			for (OutputWriter writer : server.getOutputWriters()) {
+				try {
+					writer.stop();
+				} catch (LifecycleException ex) {
+					log.error("Eror stopping writer: {}", writer);
+				}
+			}
 			for (Query query : server.getQueries()) {
 				for (OutputWriter writer : query.getOutputWriterInstances()) {
 					try {

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
@@ -31,6 +31,8 @@ import com.googlecode.jmxtrans.model.results.BooleanAsNumberValueTransformer;
 import com.googlecode.jmxtrans.model.results.IdentityValueTransformer;
 import com.googlecode.jmxtrans.model.results.ResultValuesTransformer;
 
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+
 import javax.annotation.Nonnull;
 
 import org.slf4j.Logger;
@@ -70,11 +72,11 @@ public class ResultTransformerOutputWriter<T extends OutputWriter> extends Outpu
 		return new ResultTransformerOutputWriter<>(new ResultValuesTransformer(new IdentityValueTransformer()), target);
 	}
 
-	public void stop() {
+	public void stop() throws LifecycleException {
 		try {
 			target.stop();
 		} catch (LifecycleException ex) {
-			logger.debug("error stopping writer");
+			throw(ex);
 		}
 	}
 

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
@@ -35,14 +35,10 @@ import com.googlecode.jmxtrans.exceptions.LifecycleException;
 
 import javax.annotation.Nonnull;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static com.google.common.collect.FluentIterable.from;
 
 public class ResultTransformerOutputWriter<T extends OutputWriter> extends OutputWriterAdapter {
 
-	private static final Logger logger = LoggerFactory.getLogger(ResultTransformerOutputWriter.class);
 	@Nonnull private final ResultValuesTransformer resultValuesTransformer;
 	@Nonnull private final T target;
 

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
@@ -33,10 +33,14 @@ import com.googlecode.jmxtrans.model.results.ResultValuesTransformer;
 
 import javax.annotation.Nonnull;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static com.google.common.collect.FluentIterable.from;
 
 public class ResultTransformerOutputWriter<T extends OutputWriter> extends OutputWriterAdapter {
 
+	private static final Logger logger = LoggerFactory.getLogger(ResultTransformerOutputWriter.class);
 	@Nonnull private final ResultValuesTransformer resultValuesTransformer;
 	@Nonnull private final T target;
 
@@ -66,5 +70,12 @@ public class ResultTransformerOutputWriter<T extends OutputWriter> extends Outpu
 		return new ResultTransformerOutputWriter<>(new ResultValuesTransformer(new IdentityValueTransformer()), target);
 	}
 
+	public void stop() {
+		try {
+			target.stop();
+		} catch (LifecycleException ex) {
+			logger.debug("error stopping writer");
+		}
+	}
 
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
@@ -69,11 +69,8 @@ public class ResultTransformerOutputWriter<T extends OutputWriter> extends Outpu
 	}
 
 	public void stop() throws LifecycleException {
-		try {
-			target.stop();
-		} catch (LifecycleException ex) {
-			throw(ex);
-		}
+		target.stop();
+
 	}
 
 }


### PR DESCRIPTION
This PR addresses #500 to fix cleanup of singleton output writers along with implementing a stop() method on ResultTransformerOutputWriter.  See issue #500 for additional details.