### PR TITLE
Fix encoding declaration in Python code

### DIFF
--- a/jmxtrans/tools/yaml2jmxtrans.py
+++ b/jmxtrans/tools/yaml2jmxtrans.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 # The MIT License
 # Copyright © 2010 JmxTrans team
@@ -22,7 +23,6 @@
 # THE SOFTWARE.
 #
 
-# -*- coding: latin-1 -*-
 # vim:ai:expandtab:ts=4 sw=4
 
 # yaml2jmxtrans.py: Generate jmxtrans config from YAML format


### PR DESCRIPTION
As of https://www.python.org/dev/peps/pep-0263/, magic comment must be the first or the second line of the file. Also, copyright symbol in license is UTF-8.

```
File "/usr/share/jmxtrans/tools/yaml2jmxtrans.py", line 4
SyntaxError: Non-ASCII character '\xc2' in file /usr/share/jmxtrans/tools/yaml2jmxtrans.py on line 4, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```