### PR TITLE
Allow InfluxDBWriter to connect to 1.0 out of the box

### DIFF
--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -50,11 +50,11 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 
 	/**
 	 * The deault <a href=
-	 * "https://influxdb.com/docs/v0.9/concepts/key_concepts.html#retention-policy">
+	 * "https://influxdb.com/docs/v1.0/concepts/key_concepts.html#retention-policy">
 	 * The retention policy</a> for each measuremen where no retentionPolicy
 	 * setting is provided in the json config
 	 */
-	private static final String DEFAULT_RETENTION_POLICY = "default";
+	private static final String DEFAULT_RETENTION_POLICY = "autogen";
 
 	private final String database;
 	private final InfluxDB.ConsistencyLevel writeConsistency;

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
 			<dependency>
 				<groupId>org.influxdb</groupId>
 				<artifactId>influxdb-java</artifactId>
-				<version>2.2</version>
+				<version>2.4</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jhades</groupId>


### PR DESCRIPTION
This uses the latest version of influxdb-java (2.4) to support connecting to InfluxDB 1.0. 

This also changes the default retention policy from "default" to "autogen"

This is a breaking change for anyone relying on the old defaults.

Resolves errors:

```sh
ava.lang.RuntimeException: {"error":"error parsing query: found NOT, expected ; at line 1, char 20"}
```

and 

```sh
java.lang.RuntimeException: {"error":"retention policy not found: default"}
```

As mentioned in:
https://github.com/jmxtrans/jmxtrans/issues/489