### PR TITLE
null check and defaults added

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -327,6 +327,11 @@ public class Server implements JmxConnectionProvider {
 		return ManagementFactory.getPlatformMBeanServer();
 	}
 
+	@JsonIgnore
+	public String getLabel() {
+		return firstNonNull(alias, host);
+	}
+
 	public String getHost() {
 		if (host == null && url == null) {
 			return null;

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
@@ -96,6 +96,21 @@ public class ServerTests {
 	}
 
 	@Test
+	public void testGetLabel() {
+		Server server = Server.builder()
+				.setAlias("alias")
+				.setHost("host")
+				.setPool(createPool())
+				.build();
+		assertEquals("server label should be 'alias'", "alias", server.getLabel());
+		server = Server.builder()
+				.setHost("host")
+				.setPool(createPool())
+				.build();
+		assertEquals("server label should be 'host'", "host", server.getLabel());
+	}
+
+	@Test
 	public void testEquals() {
 		Server s1 = Server.builder()
 				.setAlias("alias")

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriter.java
@@ -37,8 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Map;
 

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriter.java
@@ -73,7 +73,7 @@ public abstract class OpenTSDBGenericWriter extends BaseOutputWriter {
 			@JsonProperty("mergeTypeNamesTags") Boolean mergeTypeNamesTags,
 			@JsonProperty("metricNamingExpression") String metricNamingExpression,
 			@JsonProperty("addHostnameTag") Boolean addHostnameTag,
-			@JsonProperty("settings") Map<String, Object> settings) throws LifecycleException, UnknownHostException {
+			@JsonProperty("settings") Map<String, Object> settings) throws LifecycleException {
 		super(typeNames, booleanAsNumber, debugEnabled, settings);
 
 		this.host = MoreObjects.firstNonNull(host, (String) getSettings().get(HOST));
@@ -82,11 +82,6 @@ public abstract class OpenTSDBGenericWriter extends BaseOutputWriter {
 		if (metricNamingExpression == null) {
 			metricNamingExpression = Settings.getStringSetting(this.getSettings(), "metricNamingExpression", null);
 		}
-
-		addHostnameTag = firstNonNull(
-				addHostnameTag,
-				Settings.getBooleanSetting(this.getSettings(), "addHostnameTag", this.getAddHostnameTagDefault()),
-				getAddHostnameTagDefault());
 
 		ImmutableList<String> nonNullTypeNames = copyOf(MoreObjects.firstNonNull(typeNames, Collections.<String>emptyList()));
 
@@ -100,7 +95,7 @@ public abstract class OpenTSDBGenericWriter extends BaseOutputWriter {
 				MoreObjects.firstNonNull(
 						mergeTypeNamesTags,
 						Settings.getBooleanSetting(this.getSettings(), "mergeTypeNamesTags", DEFAULT_MERGE_TYPE_NAMES_TAGS)),
-				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);
+				addHostnameTag);
 	}
 
 	/**
@@ -151,7 +146,7 @@ public abstract class OpenTSDBGenericWriter extends BaseOutputWriter {
 	@Override
 	public void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
 		this.startOutput();
-		for (String formattedResult : messageFormatter.formatResults(results)) {
+		for (String formattedResult : messageFormatter.formatResults(results, server)) {
 				log.debug("Sending result: {}", formattedResult);
 				this.sendOutput(formattedResult);
 		}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
@@ -224,7 +224,7 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 					tagName,
 					mergeTypeNamesTags,
 					metricNamingExpression,
-					addHostnameTag,
+					(addHostnameTag == null) ? true : addHostnameTag,
 					null
 			);
 		}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
@@ -149,7 +149,7 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 		private String tagName;
 		private Boolean mergeTypeNamesTags;
 		private String metricNamingExpression;
-		private Boolean addHostnameTag;
+		private Boolean addHostnameTag = true;
 
 		private Builder() {}
 
@@ -224,7 +224,7 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 					tagName,
 					mergeTypeNamesTags,
 					metricNamingExpression,
-					(addHostnameTag == null) ? true : addHostnameTag,
+					addHostnameTag,
 					null
 			);
 		}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter.java
@@ -113,7 +113,7 @@ public class OpenTSDBWriter extends OpenTSDBGenericWriter {
 		socket = pool.borrowObject(address);
 		writer = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), UTF_8), true);
 
-		for (String formattedResult : messageFormatter.formatResults(results)) {
+		for (String formattedResult : messageFormatter.formatResults(results, server)) {
 			log.debug("OpenTSDB Message: {}", formattedResult);
 			writer.write("put " + formattedResult + "\n");
 		}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java
@@ -49,7 +49,7 @@ public class OpenTSDBWriter2 implements WriterBasedOutputWriter {
 	public void write(@Nonnull final Writer writer, @Nonnull Server server, @Nonnull Query query, @Nonnull Iterable<Result> results) throws IOException {
 
 		for(String resultString : messageFormatter.formatResults(results, server)) {
-            logger.trace(resultString);
+			logger.trace(resultString);
 			writer.write("put " + resultString + "\n");
 		}
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java
@@ -46,7 +46,11 @@ public class OpenTSDBWriter2 implements WriterBasedOutputWriter {
 	}
 
 	@Override
-	public void write(@Nonnull final Writer writer, @Nonnull Server server, @Nonnull Query query, @Nonnull Iterable<Result> results) throws IOException {
+	public void write(
+			@Nonnull Writer writer,
+			@Nonnull Server server,
+			@Nonnull Query query,
+			@Nonnull Iterable<Result> results) throws IOException {
 
 		for(String resultString : messageFormatter.formatResults(results, server)) {
 			logger.trace(resultString);

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2.java
@@ -27,6 +27,8 @@ import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.output.support.WriterBasedOutputWriter;
 import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
@@ -35,6 +37,7 @@ import java.io.Writer;
 
 @ThreadSafe
 public class OpenTSDBWriter2 implements WriterBasedOutputWriter {
+	private static final Logger logger = LoggerFactory.getLogger(OpenTSDBWriter2.class);
 
 	private final OpenTSDBMessageFormatter messageFormatter;
 
@@ -45,7 +48,8 @@ public class OpenTSDBWriter2 implements WriterBasedOutputWriter {
 	@Override
 	public void write(@Nonnull final Writer writer, @Nonnull Server server, @Nonnull Query query, @Nonnull Iterable<Result> results) throws IOException {
 
-		for(String resultString : messageFormatter.formatResults(results)) {
+		for(String resultString : messageFormatter.formatResults(results, server)) {
+            logger.trace(resultString);
 			writer.write("put " + resultString + "\n");
 		}
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
@@ -80,6 +80,8 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 		ImmutableMap<String, String> immutableTags =
 				tags == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(tags);
 
+		mergeTypeNamesTags = firstNonNull(mergeTypeNamesTags, true);
+
 		messageFormatter = new OpenTSDBMessageFormatter(typeNames, immutableTags, tagName,
 				metricNamingExpression, mergeTypeNamesTags,
 				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
@@ -82,8 +82,9 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 
 		mergeTypeNamesTags = firstNonNull(mergeTypeNamesTags, true);
 
-		messageFormatter = new OpenTSDBMessageFormatter(typeNames, immutableTags, tagName,
-				metricNamingExpression, mergeTypeNamesTags,
+		messageFormatter = new OpenTSDBMessageFormatter(
+				(typeNames == null) ? ImmutableList.<String>of() : typeNames,
+				immutableTags, tagName, metricNamingExpression, mergeTypeNamesTags,
 				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
 		this.poolSize = firstNonNull(poolSize, 1);

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
@@ -85,7 +85,7 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 		messageFormatter = new OpenTSDBMessageFormatter(
 				(typeNames == null) ? ImmutableList.<String>of() : typeNames,
 				immutableTags, tagName, metricNamingExpression, mergeTypeNamesTags,
-				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);
+				firstNonNull(addHostnameTag, false));
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
 		this.poolSize = firstNonNull(poolSize, 1);
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
@@ -93,11 +93,11 @@ public class OpenTSDBWriterFactory implements OutputWriterFactory {
 	public ResultTransformerOutputWriter<WriterPoolOutputWriter<OpenTSDBWriter2>> create() {
 		return ResultTransformerOutputWriter.booleanToNumber(
 				booleanAsNumber,
-				TcpOutputWriterBuilder.builder(
-						server,
-						new OpenTSDBWriter2(messageFormatter))
+				TcpOutputWriterBuilder
+						.builder(server, new OpenTSDBWriter2(messageFormatter))
 						.setFlushStrategy(flushStrategy)
 						.setPoolSize(poolSize)
-						.build());
+						.build()
+		);
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterFactory.java
@@ -38,7 +38,6 @@ import lombok.ToString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Map;

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter.java
@@ -68,7 +68,7 @@ public class TCollectorUDPWriter extends OpenTSDBGenericWriter {
 			@JsonProperty("tagName") String tagName,
 			@JsonProperty("mergeTypeNamesTags") Boolean mergeTypeNamesTags,
 			@JsonProperty("metricNamingExpression") String metricNamingExpression,
-			@JsonProperty("addHostnameTag") Boolean addHostnameTag,
+			@JsonProperty("addHostnameTag") boolean addHostnameTag,
 			@JsonProperty("settings") Map<String, Object> settings) throws LifecycleException, UnknownHostException {
 		super(typeNames, booleanAsNumber, debugEnabled, host, port, tags, tagName, mergeTypeNamesTags, metricNamingExpression,
 				addHostnameTag, settings);
@@ -93,7 +93,7 @@ public class TCollectorUDPWriter extends OpenTSDBGenericWriter {
 	@Override
 	public void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
 		this.startOutput();
-		for (String resultString : messageFormatter.formatResults(results)){
+		for (String resultString : messageFormatter.formatResults(results, server)){
 			log.debug("TCollectorUDP Message: {}", resultString);
 			this.sendOutput(resultString);
 		}
@@ -150,7 +150,7 @@ public class TCollectorUDPWriter extends OpenTSDBGenericWriter {
 		private String tagName;
 		private Boolean mergeTypeNamesTags;
 		private String metricNamingExpression;
-		private Boolean addHostnameTag;
+		private boolean addHostnameTag;
 
 		private Builder() {}
 

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2.java
@@ -46,7 +46,7 @@ public class TCollectorUDPWriter2 implements WriterBasedOutputWriter {
 	@Override
 	public void write(@Nonnull final Writer writer, @Nonnull Server server, @Nonnull Query query, @Nonnull Iterable<Result> results) throws IOException {
 
-		for(String resultString : messageFormatter.formatResults(results)) {
+		for(String resultString : messageFormatter.formatResults(results, server)) {
 			writer.write(resultString);
 		}
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java
@@ -82,7 +82,7 @@ public class TCollectorUDPWriterFactory implements OutputWriterFactory {
 
 		messageFormatter = new OpenTSDBMessageFormatter(typeNames, immutableTags, tagName,
 				metricNamingExpression, mergeTypeNamesTags,
-				addHostnameTag ? InetAddress.getLocalHost().getHostName() : null);
+				addHostnameTag);
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
 		this.poolSize = firstNonNull(poolSize, 1);
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterFactory.java
@@ -38,7 +38,6 @@ import lombok.ToString;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Map;

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
@@ -200,7 +200,7 @@ public class OpenTSDBMessageFormatter {
 				addTag(resultString, addTagName, addTagValue);
 			}
 
-			if ((typeNames != null) && (!typeNames.isEmpty())) {
+			if (!typeNames.isEmpty()) {
 				this.addTypeNamesTags(resultString, result);
 			}
 

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
@@ -46,7 +46,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.FluentIterable.from;
 import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
 

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
@@ -66,7 +66,6 @@ public class OpenTSDBMessageFormatter {
 
 	private final boolean mergeTypeNamesTags;
 	private final boolean hostnameTag;
-	private final Server server = null;
 
 	public OpenTSDBMessageFormatter(@Nonnull ImmutableList<String> typeNames,
 									@Nonnull ImmutableMap<String, String> tags) throws LifecycleException {

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.net.UnknownHostException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
@@ -76,7 +76,7 @@ public class OpenTSDBMessageFormatter {
 									@Nonnull String tagName,
 									@Nullable String metricNamingExpression,
 									boolean mergeTypeNamesTags,
-									Boolean hostnameTag) throws LifecycleException {
+									boolean hostnameTag) throws LifecycleException {
 		this.typeNames = typeNames;
 		this.tags = tags;
 		this.tagName = tagName;
@@ -90,7 +90,7 @@ public class OpenTSDBMessageFormatter {
 			metricNameStrategy = new ClassAttributeNamingStrategy();
 		}
 		this.mergeTypeNamesTags = mergeTypeNamesTags;
-		this.hostnameTag = firstNonNull(hostnameTag, true);
+		this.hostnameTag = hostnameTag;
 	}
 
 

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatter.java
@@ -193,7 +193,7 @@ public class OpenTSDBMessageFormatter {
 				addTag(resultString, addTagName, addTagValue);
 			}
 
-			if (!typeNames.isEmpty()) {
+			if ((typeNames != null) && (!typeNames.isEmpty())) {
 				this.addTypeNamesTags(resultString, result);
 			}
 

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriterTests.java
@@ -56,7 +56,6 @@ public class OpenTSDBGenericWriterTests {
 
 	protected Query mockQuery;
 	protected Result mockResult;
-	private Server server;
 
 	// Interactions with the custom, test subclass of OpenTSDBGenericWriter.
 	protected boolean tvAddHostnameTagDefault;
@@ -70,7 +69,6 @@ public class OpenTSDBGenericWriterTests {
 	public void setupTest() {
 		this.mockQuery = Mockito.mock(Query.class);
 		this.mockResult = Mockito.mock(Result.class);
-		this.server = ServerFixtures.dummyServer();
 
 		// Setup test data
 		tvAddHostnameTagDefault = true;
@@ -104,7 +102,7 @@ public class OpenTSDBGenericWriterTests {
 		Assertions.assertThat(writer.getTypeNames()).isEmpty();
 
 		writer.start();
-		writer.doWrite(server, this.mockQuery, ImmutableList.of(this.mockResult));
+		writer.doWrite(ServerFixtures.dummyServer(), this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.close();
 
 		Assert.assertTrue(
@@ -123,7 +121,7 @@ public class OpenTSDBGenericWriterTests {
 		OpenTSDBGenericWriter writer = createWriter("tags", tagMap);
 
 		writer.start();
-		writer.doWrite(server, this.mockQuery, ImmutableList.of(this.mockResult));
+		writer.doWrite(ServerFixtures.dummyServer(), this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.close();
 
 		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
@@ -160,7 +158,7 @@ public class OpenTSDBGenericWriterTests {
 		Assert.assertFalse(startOutputCalled);
 		Assert.assertFalse(finishOutputCalled);
 
-		writer.doWrite(server, this.mockQuery, ImmutableList.of(this.mockResult));
+		writer.doWrite(ServerFixtures.dummyServer(), this.mockQuery, ImmutableList.of(this.mockResult));
 		Assert.assertTrue(prepareSenderCalled);
 		Assert.assertFalse(shutdownSenderCalled);
 		Assert.assertTrue(startOutputCalled);
@@ -180,7 +178,7 @@ public class OpenTSDBGenericWriterTests {
 
 		writer.start();
 		writer.validateSetup(null, this.mockQuery);
-		writer.doWrite(server, this.mockQuery, ImmutableList.of(this.mockResult));
+		writer.doWrite(ServerFixtures.dummyServer(), this.mockQuery, ImmutableList.of(this.mockResult));
 	}
 
 	@Test

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriterTests.java
@@ -29,6 +29,7 @@ import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ServerFixtures;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
@@ -55,7 +56,7 @@ public class OpenTSDBGenericWriterTests {
 
 	protected Query mockQuery;
 	protected Result mockResult;
-	private Server mockServer;
+	private Server server;
 
 	// Interactions with the custom, test subclass of OpenTSDBGenericWriter.
 	protected boolean tvAddHostnameTagDefault;
@@ -69,7 +70,7 @@ public class OpenTSDBGenericWriterTests {
 	public void setupTest() {
 		this.mockQuery = Mockito.mock(Query.class);
 		this.mockResult = Mockito.mock(Result.class);
-		this.mockServer = Mockito.mock(Server.class);
+		this.server = ServerFixtures.dummyServer();
 
 		// Setup test data
 		tvAddHostnameTagDefault = true;
@@ -85,7 +86,6 @@ public class OpenTSDBGenericWriterTests {
 		Mockito.when(this.mockResult.getClassName()).thenReturn("X-DOMAIN.PKG.CLASS-X");
 		Mockito.when(this.mockResult.getTypeName()).
 				thenReturn("Type=x-type-x,Group=x-group-x,Other=x-other-x,Name=x-name-x");
-		Mockito.when(this.mockServer.getLabel()).thenReturn("myhostname");
 	}
 
 	@Test
@@ -104,7 +104,7 @@ public class OpenTSDBGenericWriterTests {
 		Assertions.assertThat(writer.getTypeNames()).isEmpty();
 
 		writer.start();
-		writer.doWrite(mockServer, this.mockQuery, ImmutableList.of(this.mockResult));
+		writer.doWrite(server, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.close();
 
 		Assert.assertTrue(
@@ -123,7 +123,7 @@ public class OpenTSDBGenericWriterTests {
 		OpenTSDBGenericWriter writer = createWriter("tags", tagMap);
 
 		writer.start();
-		writer.doWrite(mockServer, this.mockQuery, ImmutableList.of(this.mockResult));
+		writer.doWrite(server, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.close();
 
 		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
@@ -160,7 +160,7 @@ public class OpenTSDBGenericWriterTests {
 		Assert.assertFalse(startOutputCalled);
 		Assert.assertFalse(finishOutputCalled);
 
-		writer.doWrite(mockServer, this.mockQuery, ImmutableList.of(this.mockResult));
+		writer.doWrite(server, this.mockQuery, ImmutableList.of(this.mockResult));
 		Assert.assertTrue(prepareSenderCalled);
 		Assert.assertFalse(shutdownSenderCalled);
 		Assert.assertTrue(startOutputCalled);
@@ -180,7 +180,7 @@ public class OpenTSDBGenericWriterTests {
 
 		writer.start();
 		writer.validateSetup(null, this.mockQuery);
-		writer.doWrite(mockServer, this.mockQuery, ImmutableList.of(this.mockResult));
+		writer.doWrite(server, this.mockQuery, ImmutableList.of(this.mockResult));
 	}
 
 	@Test

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2Test.java
@@ -24,6 +24,8 @@ package com.googlecode.jmxtrans.model.output;
 
 import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ServerFixtures;
 import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
 import org.junit.Before;
 import org.junit.Test;

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriter2Test.java
@@ -56,7 +56,7 @@ public class OpenTSDBWriter2Test {
 		ImmutableList<Result> results = ImmutableList.of(result, result);
 		List<String> resultsString = ImmutableList.of("Result1", "Result2");
 
-		Mockito.when(openTSDBMessageFormatter.formatResults(results)).thenReturn(resultsString);
+		Mockito.when(openTSDBMessageFormatter.formatResults(results, null)).thenReturn(resultsString);
 
 		writer.write(outputWriter, null, null, results);
 

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
@@ -25,6 +25,7 @@ package com.googlecode.jmxtrans.model.output;
 import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.junit.Test;
@@ -59,6 +60,7 @@ public class OpenTSDBWriterTests {
 	protected Query mockQuery;
 	protected Result mockResult;
 	protected Socket mockSocket;
+	private Server mockServer;
 	protected DataOutputStream mockOut;
 	protected InputStreamReader mockInStreamRdr;
 	protected BufferedReader mockBufRdr;

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBWriterTests.java
@@ -60,7 +60,6 @@ public class OpenTSDBWriterTests {
 	protected Query mockQuery;
 	protected Result mockResult;
 	protected Socket mockSocket;
-	private Server mockServer;
 	protected DataOutputStream mockOut;
 	protected InputStreamReader mockInStreamRdr;
 	protected BufferedReader mockBufRdr;

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2Test.java
@@ -25,6 +25,7 @@ package com.googlecode.jmxtrans.model.output;
 import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ServerFixtures;
 import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,7 +49,7 @@ public class TCollectorUDPWriter2Test {
 		writer = new TCollectorUDPWriter2(openTSDBMessageFormatter);
 		outputWriter = Mockito.mock(Writer.class);
 		result = Mockito.mock(Result.class);
-		server = Mockito.mock(Server.class);
+		server = ServerFixtures.dummyServer();
 	}
 
 	@Test

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2Test.java
@@ -41,7 +41,6 @@ public class TCollectorUDPWriter2Test {
 	private TCollectorUDPWriter2 writer;
 	private Writer outputWriter;
 	private Result result;
-	private Server server;
 
 	@Before
 	public void setup() {
@@ -49,7 +48,6 @@ public class TCollectorUDPWriter2Test {
 		writer = new TCollectorUDPWriter2(openTSDBMessageFormatter);
 		outputWriter = Mockito.mock(Writer.class);
 		result = Mockito.mock(Result.class);
-		server = ServerFixtures.dummyServer();
 	}
 
 	@Test
@@ -58,9 +56,9 @@ public class TCollectorUDPWriter2Test {
 		ImmutableList<Result> results = ImmutableList.of(result, result);
 		List<String> resultsString = ImmutableList.of("Result1", "Result2");
 
-		Mockito.when(openTSDBMessageFormatter.formatResults(results, server)).thenReturn(resultsString);
+		Mockito.when(openTSDBMessageFormatter.formatResults(results, ServerFixtures.dummyServer())).thenReturn(resultsString);
 
-		writer.write(outputWriter, server, null, results);
+		writer.write(outputWriter, ServerFixtures.dummyServer(), null, results);
 
 		Mockito.verify(outputWriter).write("Result1");
 		Mockito.verify(outputWriter).write("Result2");

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriter2Test.java
@@ -24,6 +24,7 @@ package com.googlecode.jmxtrans.model.output;
 
 import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.output.support.opentsdb.OpenTSDBMessageFormatter;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,6 +40,7 @@ public class TCollectorUDPWriter2Test {
 	private TCollectorUDPWriter2 writer;
 	private Writer outputWriter;
 	private Result result;
+	private Server server;
 
 	@Before
 	public void setup() {
@@ -46,6 +48,7 @@ public class TCollectorUDPWriter2Test {
 		writer = new TCollectorUDPWriter2(openTSDBMessageFormatter);
 		outputWriter = Mockito.mock(Writer.class);
 		result = Mockito.mock(Result.class);
+		server = Mockito.mock(Server.class);
 	}
 
 	@Test
@@ -54,9 +57,9 @@ public class TCollectorUDPWriter2Test {
 		ImmutableList<Result> results = ImmutableList.of(result, result);
 		List<String> resultsString = ImmutableList.of("Result1", "Result2");
 
-		Mockito.when(openTSDBMessageFormatter.formatResults(results)).thenReturn(resultsString);
+		Mockito.when(openTSDBMessageFormatter.formatResults(results, server)).thenReturn(resultsString);
 
-		writer.write(outputWriter, null, null, results);
+		writer.write(outputWriter, server, null, results);
 
 		Mockito.verify(outputWriter).write("Result1");
 		Mockito.verify(outputWriter).write("Result2");

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterTests.java
@@ -61,7 +61,6 @@ public class TCollectorUDPWriterTests {
 	protected TCollectorUDPWriter writer;
 	protected Query mockQuery;
 	protected Result mockResult;
-	private Server server;
 	protected DatagramSocket mockDgSocket;
 	protected Logger mockLog;
 	protected ImmutableMap<String, Object> testValues;
@@ -72,7 +71,6 @@ public class TCollectorUDPWriterTests {
 		this.mockResult = Mockito.mock(Result.class);
 		this.mockDgSocket = Mockito.mock(DatagramSocket.class);
 		this.mockLog = Mockito.mock(Logger.class);
-		this.server = ServerFixtures.dummyServer();
 
 
 		// Setup common mock interactions.
@@ -108,7 +106,7 @@ public class TCollectorUDPWriterTests {
 
 		// Execute
 		this.writer.start();
-		this.writer.doWrite(server, this.mockQuery, ImmutableList.of(this.mockResult));
+		this.writer.doWrite(ServerFixtures.dummyServer(), this.mockQuery, ImmutableList.of(this.mockResult));
 		this.writer.close();
 
 		// Verifications

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterTests.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -59,6 +60,7 @@ public class TCollectorUDPWriterTests {
 	protected TCollectorUDPWriter writer;
 	protected Query mockQuery;
 	protected Result mockResult;
+	private Server mockServer;
 	protected DatagramSocket mockDgSocket;
 	protected Logger mockLog;
 	protected ImmutableMap<String, Object> testValues;
@@ -69,6 +71,7 @@ public class TCollectorUDPWriterTests {
 		this.mockResult = Mockito.mock(Result.class);
 		this.mockDgSocket = Mockito.mock(DatagramSocket.class);
 		this.mockLog = Mockito.mock(Logger.class);
+		this.mockServer = Mockito.mock(Server.class);
 
 
 		// Setup common mock interactions.
@@ -80,6 +83,7 @@ public class TCollectorUDPWriterTests {
 		Mockito.when(this.mockResult.getAttributeName()).thenReturn("X-ATT-X");
 		Mockito.when(this.mockResult.getClassName()).thenReturn("X-DOMAIN.PKG.CLASS-X");
 		Mockito.when(this.mockResult.getTypeName()).thenReturn("Type=x-type-x");
+		Mockito.when(this.mockServer.getLabel()).thenReturn("myhostname");
 
 
 		// Prepare the object under test and test data.
@@ -104,7 +108,7 @@ public class TCollectorUDPWriterTests {
 
 		// Execute
 		this.writer.start();
-		this.writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
+		this.writer.doWrite(mockServer, this.mockQuery, ImmutableList.of(this.mockResult));
 		this.writer.close();
 
 		// Verifications

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/TCollectorUDPWriterTests.java
@@ -28,6 +28,7 @@ import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ServerFixtures;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -60,7 +61,7 @@ public class TCollectorUDPWriterTests {
 	protected TCollectorUDPWriter writer;
 	protected Query mockQuery;
 	protected Result mockResult;
-	private Server mockServer;
+	private Server server;
 	protected DatagramSocket mockDgSocket;
 	protected Logger mockLog;
 	protected ImmutableMap<String, Object> testValues;
@@ -71,7 +72,7 @@ public class TCollectorUDPWriterTests {
 		this.mockResult = Mockito.mock(Result.class);
 		this.mockDgSocket = Mockito.mock(DatagramSocket.class);
 		this.mockLog = Mockito.mock(Logger.class);
-		this.mockServer = Mockito.mock(Server.class);
+		this.server = ServerFixtures.dummyServer();
 
 
 		// Setup common mock interactions.
@@ -83,7 +84,6 @@ public class TCollectorUDPWriterTests {
 		Mockito.when(this.mockResult.getAttributeName()).thenReturn("X-ATT-X");
 		Mockito.when(this.mockResult.getClassName()).thenReturn("X-DOMAIN.PKG.CLASS-X");
 		Mockito.when(this.mockResult.getTypeName()).thenReturn("Type=x-type-x");
-		Mockito.when(this.mockServer.getLabel()).thenReturn("myhostname");
 
 
 		// Prepare the object under test and test data.
@@ -108,7 +108,7 @@ public class TCollectorUDPWriterTests {
 
 		// Execute
 		this.writer.start();
-		this.writer.doWrite(mockServer, this.mockQuery, ImmutableList.of(this.mockResult));
+		this.writer.doWrite(server, this.mockQuery, ImmutableList.of(this.mockResult));
 		this.writer.close();
 
 		// Verifications

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java
@@ -28,8 +28,10 @@ import com.google.common.collect.Iterables;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -38,16 +40,19 @@ import java.util.Iterator;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
+import static com.googlecode.jmxtrans.model.ServerFixtures.createPool;
 
 public class OpenTSDBMessageFormatterTest {
 
-	protected Query mockQuery;
-	protected Result mockResult;
+	private Query mockQuery;
+	private Result mockResult;
+	private Server mockServer;
 
 	@Before
 	public void setupTest() {
 		this.mockQuery = Mockito.mock(Query.class);
 		this.mockResult = Mockito.mock(Result.class);
+		this.mockServer = Mockito.mock(Server.class);
 
 		// Setup common mock interactions.
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("x-att1-x", (Object) "120021"));
@@ -55,6 +60,7 @@ public class OpenTSDBMessageFormatterTest {
 		Mockito.when(this.mockResult.getClassName()).thenReturn("X-DOMAIN.PKG.CLASS-X");
 		Mockito.when(this.mockResult.getTypeName()).
 				thenReturn("Type=x-type-x,Group=x-group-x,Other=x-other-x,Name=x-name-x");
+		Mockito.when(this.mockServer.getLabel()).thenReturn("myhostname");
 
 	}
 
@@ -66,7 +72,7 @@ public class OpenTSDBMessageFormatterTest {
 	public void testMergedTypeNameValues() throws Exception {
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		String resultString = strings.iterator().next();
@@ -75,14 +81,27 @@ public class OpenTSDBMessageFormatterTest {
 		Assert.assertTrue(resultString.matches(".*\\bTypeGroupNameMissing=x-type-x_x-group-x_x-name-x\\b.*"));
 	}
 
+	@Ignore
+	@Test
+	public void testHostLabel() throws Exception {
+		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
+
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+
+		Assert.assertEquals(1, Iterables.size(strings));
+
+		String resultStr = strings.iterator().next();
+		Assert.assertTrue( resultStr.matches(".*\\bhost=myhostname\\b.*"));
+	}
+
 	@Test
 	public void testNonMergedTypeNameValues() throws Exception {
 
 		OpenTSDBMessageFormatter formatter =
 				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
-						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, null, false, null);
+						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, null, false, true);
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		String resultString = strings.iterator().next();
@@ -102,7 +121,7 @@ public class OpenTSDBMessageFormatterTest {
 
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertTrue(
@@ -123,7 +142,7 @@ public class OpenTSDBMessageFormatterTest {
 		OpenTSDBMessageFormatter formatter =
 				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"), ImmutableMap.copyOf(tagMap));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 
@@ -141,7 +160,7 @@ public class OpenTSDBMessageFormatterTest {
 	public void testAddHostnameTag() throws Exception {
 
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertTrue(strings.iterator().next().matches(".*host=.*"));
@@ -153,9 +172,9 @@ public class OpenTSDBMessageFormatterTest {
 
 		OpenTSDBMessageFormatter formatter =
 				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
-						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, null, true, null);
+						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, null, true, false);
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertFalse(strings.iterator().next().matches(".*host=.*"));
@@ -170,7 +189,7 @@ public class OpenTSDBMessageFormatterTest {
 		ImmutableMap<String, Object> values = ImmutableMap.of();
 		Mockito.when(this.mockResult.getValues()).thenReturn(values);
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 
 		Assert.assertEquals(0, Iterables.size(strings));
 
@@ -183,7 +202,7 @@ public class OpenTSDBMessageFormatterTest {
 
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		String resultString = strings.iterator().next();
@@ -202,7 +221,7 @@ public class OpenTSDBMessageFormatterTest {
 		Mockito.when(this.mockResult.getValues()).
 				thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021", "XX-ATT-XX", (Object) "210012"));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 
 		Assert.assertEquals(2, Iterables.size(strings));
 		Iterator<String> resultStringIterator = strings.iterator();
@@ -232,7 +251,7 @@ public class OpenTSDBMessageFormatterTest {
 
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "THIS-IS-NOT-A-NUMBER"));
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 		Assert.assertEquals(0, Iterables.size(strings));
 
 	}
@@ -242,10 +261,10 @@ public class OpenTSDBMessageFormatterTest {
 
 		OpenTSDBMessageFormatter formatter =
 				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
-						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, "'xx-jexl-constant-name-xx'", true, null);
+						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, "'xx-jexl-constant-name-xx'", true, true);
 
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult));
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertTrue(strings.iterator().next().matches("^xx-jexl-constant-name-xx 0 120021.*"));
 
@@ -255,7 +274,7 @@ public class OpenTSDBMessageFormatterTest {
 	public void testInvalidJexlNaming() throws Exception {
 
 		new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
-						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, "invalid expression here", true, null);
+						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, "invalid expression here", true, true);
 
 	}
 

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java
@@ -29,6 +29,7 @@ import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.ServerFixtures;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -46,13 +47,13 @@ public class OpenTSDBMessageFormatterTest {
 
 	private Query mockQuery;
 	private Result mockResult;
-	private Server mockServer;
+	private Server server;
 
 	@Before
 	public void setupTest() {
 		this.mockQuery = Mockito.mock(Query.class);
 		this.mockResult = Mockito.mock(Result.class);
-		this.mockServer = Mockito.mock(Server.class);
+		this.server = ServerFixtures.dummyServer();
 
 		// Setup common mock interactions.
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("x-att1-x", (Object) "120021"));
@@ -60,8 +61,6 @@ public class OpenTSDBMessageFormatterTest {
 		Mockito.when(this.mockResult.getClassName()).thenReturn("X-DOMAIN.PKG.CLASS-X");
 		Mockito.when(this.mockResult.getTypeName()).
 				thenReturn("Type=x-type-x,Group=x-group-x,Other=x-other-x,Name=x-name-x");
-		Mockito.when(this.mockServer.getLabel()).thenReturn("myhostname");
-
 	}
 
 	private OpenTSDBMessageFormatter createDefaultFormatter() throws LifecycleException, UnknownHostException {
@@ -72,7 +71,7 @@ public class OpenTSDBMessageFormatterTest {
 	public void testMergedTypeNameValues() throws Exception {
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		String resultString = strings.iterator().next();
@@ -86,12 +85,12 @@ public class OpenTSDBMessageFormatterTest {
 	public void testHostLabel() throws Exception {
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 
 		String resultStr = strings.iterator().next();
-		Assert.assertTrue( resultStr.matches(".*\\bhost=myhostname\\b.*"));
+		Assert.assertTrue( resultStr.matches(".*\\bhost=" + ServerFixtures.DEFAULT_HOST + "\\b.*"));
 	}
 
 	@Test
@@ -101,7 +100,7 @@ public class OpenTSDBMessageFormatterTest {
 				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
 						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, null, false, true);
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		String resultString = strings.iterator().next();
@@ -121,7 +120,7 @@ public class OpenTSDBMessageFormatterTest {
 
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertTrue(
@@ -142,7 +141,7 @@ public class OpenTSDBMessageFormatterTest {
 		OpenTSDBMessageFormatter formatter =
 				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"), ImmutableMap.copyOf(tagMap));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 
@@ -160,7 +159,7 @@ public class OpenTSDBMessageFormatterTest {
 	public void testAddHostnameTag() throws Exception {
 
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertTrue(strings.iterator().next().matches(".*host=.*"));
@@ -174,7 +173,7 @@ public class OpenTSDBMessageFormatterTest {
 				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
 						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, null, true, false);
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertFalse(strings.iterator().next().matches(".*host=.*"));
@@ -189,7 +188,7 @@ public class OpenTSDBMessageFormatterTest {
 		ImmutableMap<String, Object> values = ImmutableMap.of();
 		Mockito.when(this.mockResult.getValues()).thenReturn(values);
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 
 		Assert.assertEquals(0, Iterables.size(strings));
 
@@ -202,7 +201,7 @@ public class OpenTSDBMessageFormatterTest {
 
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		String resultString = strings.iterator().next();
@@ -221,7 +220,7 @@ public class OpenTSDBMessageFormatterTest {
 		Mockito.when(this.mockResult.getValues()).
 				thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021", "XX-ATT-XX", (Object) "210012"));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 
 		Assert.assertEquals(2, Iterables.size(strings));
 		Iterator<String> resultStringIterator = strings.iterator();
@@ -251,7 +250,7 @@ public class OpenTSDBMessageFormatterTest {
 
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "THIS-IS-NOT-A-NUMBER"));
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 		Assert.assertEquals(0, Iterables.size(strings));
 
 	}
@@ -264,7 +263,7 @@ public class OpenTSDBMessageFormatterTest {
 						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, "'xx-jexl-constant-name-xx'", true, true);
 
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), mockServer);
+		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertTrue(strings.iterator().next().matches("^xx-jexl-constant-name-xx 0 120021.*"));
 

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/opentsdb/OpenTSDBMessageFormatterTest.java
@@ -44,16 +44,11 @@ import static com.google.common.collect.Maps.newHashMap;
 import static com.googlecode.jmxtrans.model.ServerFixtures.createPool;
 
 public class OpenTSDBMessageFormatterTest {
-
-	private Query mockQuery;
 	private Result mockResult;
-	private Server server;
 
 	@Before
 	public void setupTest() {
-		this.mockQuery = Mockito.mock(Query.class);
 		this.mockResult = Mockito.mock(Result.class);
-		this.server = ServerFixtures.dummyServer();
 
 		// Setup common mock interactions.
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("x-att1-x", (Object) "120021"));
@@ -71,7 +66,9 @@ public class OpenTSDBMessageFormatterTest {
 	public void testMergedTypeNameValues() throws Exception {
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		String resultString = strings.iterator().next();
@@ -85,7 +82,9 @@ public class OpenTSDBMessageFormatterTest {
 	public void testHostLabel() throws Exception {
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 
 		Assert.assertEquals(1, Iterables.size(strings));
 
@@ -100,7 +99,9 @@ public class OpenTSDBMessageFormatterTest {
 				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
 						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, null, false, true);
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		String resultString = strings.iterator().next();
@@ -120,7 +121,9 @@ public class OpenTSDBMessageFormatterTest {
 
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertTrue(
@@ -141,7 +144,9 @@ public class OpenTSDBMessageFormatterTest {
 		OpenTSDBMessageFormatter formatter =
 				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"), ImmutableMap.copyOf(tagMap));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 
 		Assert.assertEquals(1, Iterables.size(strings));
 
@@ -159,7 +164,9 @@ public class OpenTSDBMessageFormatterTest {
 	public void testAddHostnameTag() throws Exception {
 
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertTrue(strings.iterator().next().matches(".*host=.*"));
@@ -173,7 +180,9 @@ public class OpenTSDBMessageFormatterTest {
 				new OpenTSDBMessageFormatter(ImmutableList.of("Type", "Group", "Name", "Missing"),
 						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, null, true, false);
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertFalse(strings.iterator().next().matches(".*host=.*"));
@@ -188,7 +197,9 @@ public class OpenTSDBMessageFormatterTest {
 		ImmutableMap<String, Object> values = ImmutableMap.of();
 		Mockito.when(this.mockResult.getValues()).thenReturn(values);
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 
 		Assert.assertEquals(0, Iterables.size(strings));
 
@@ -201,7 +212,9 @@ public class OpenTSDBMessageFormatterTest {
 
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 
 		Assert.assertEquals(1, Iterables.size(strings));
 		String resultString = strings.iterator().next();
@@ -220,7 +233,9 @@ public class OpenTSDBMessageFormatterTest {
 		Mockito.when(this.mockResult.getValues()).
 				thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021", "XX-ATT-XX", (Object) "210012"));
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 
 		Assert.assertEquals(2, Iterables.size(strings));
 		Iterator<String> resultStringIterator = strings.iterator();
@@ -250,7 +265,9 @@ public class OpenTSDBMessageFormatterTest {
 
 		OpenTSDBMessageFormatter formatter = createDefaultFormatter();
 		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "THIS-IS-NOT-A-NUMBER"));
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 		Assert.assertEquals(0, Iterables.size(strings));
 
 	}
@@ -263,7 +280,9 @@ public class OpenTSDBMessageFormatterTest {
 						ImmutableMap.<String, String>of(), OpenTSDBMessageFormatter.DEFAULT_TAG_NAME, "'xx-jexl-constant-name-xx'", true, true);
 
 
-		Iterable<String> strings = formatter.formatResults(ImmutableList.of(this.mockResult), server);
+		Iterable<String> strings = formatter.formatResults(
+				ImmutableList.of(this.mockResult),
+				ServerFixtures.dummyServer());
 		Assert.assertEquals(1, Iterables.size(strings));
 		Assert.assertTrue(strings.iterator().next().matches("^xx-jexl-constant-name-xx 0 120021.*"));
 


### PR DESCRIPTION
Added a default for mergeTypeNamesTags to match the docs as well as added a null check against typeNames since that item is supposed to be optional.

Made more changes to move around Server through OpenTSDBMessageFormatter and removed a couple getHostName() calls so that only Server resolves the hostname.  The property on outputWriters in the configuration now stays as a boolean value throughout.  Little larger change than the initial but tests for OpenTSDBWriter* and TCollectorUDPWriter* pass with the new configuration. 
