### PR TITLE
FileWriter Atomic Rename Improvement

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/FileWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/FileWriter.java
@@ -37,9 +37,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Map;
 
@@ -99,6 +97,6 @@ public class FileWriter extends BaseOutputWriter {
 				}
 			}
 		}
-		Files.move(this.outputTempFile.toPath(), this.outputFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		assert(this.outputTempFile.renameTo(this.outputFile));
 	}
 }


### PR DESCRIPTION
After running this for a while, I realised that `StandardCopyOption.REPLACE_EXISTING` will not use atomic moves even if they are possible. The `StandardCopyOption.ATOMIC_MOVE` will throw an exception if the underlying OS doesn't support atomic moves.

The `renameTo` function will do an atomic move if possible, and fall back to non-atomic if not possible.