### PR TITLE
Issue #539 Skip invalid "numbers" when reporting to graphite

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
@@ -69,14 +69,18 @@ public final class ResultFixtures {
 	}
 
 	public static Result stringResult() {
+		return stringResult("value is a string");
+	}
+
+	public static Result stringResult(String value) {
 		return new Result(
-				0,
-				"NonHeapMemoryUsage",
-				"sun.management.MemoryImpl",
-				"ObjectDomainName",
-				"MemoryAlias",
-				"type=Memory",
-				ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", "value is a string"));
+			0,
+			"NonHeapMemoryUsage",
+			"sun.management.MemoryImpl",
+			"ObjectDomainName",
+			"MemoryAlias",
+			"type=Memory",
+			ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", value));
 	}
 
 	public static Result hashResult() {

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
 import static com.googlecode.jmxtrans.util.NumberUtils.isValidNumber;
 
 /**
@@ -124,7 +123,7 @@ public class GraphiteWriter extends BaseOutputWriter {
 				Map<String, Object> resultValues = result.getValues();
 				for (Entry<String, Object> values : resultValues.entrySet()) {
 					Object value = values.getValue();
-					if (isNumeric(value) && isValidNumber(value)) {
+					if (isValidNumber(value)) {
 
 						String line = KeyUtils.getKeyString(server, query, result, values, typeNames, rootPrefix)
 								.replaceAll("[()]", "_") + " " + value.toString() + " "

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter.java
@@ -49,6 +49,7 @@ import java.util.Map.Entry;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
+import static com.googlecode.jmxtrans.util.NumberUtils.isValidNumber;
 
 /**
  * This low latency and thread safe output writer sends data to a host/port combination
@@ -123,7 +124,7 @@ public class GraphiteWriter extends BaseOutputWriter {
 				Map<String, Object> resultValues = result.getValues();
 				for (Entry<String, Object> values : resultValues.entrySet()) {
 					Object value = values.getValue();
-					if (isNumeric(value)) {
+					if (isNumeric(value) && isValidNumber(value)) {
 
 						String line = KeyUtils.getKeyString(server, query, result, values, typeNames, rootPrefix)
 								.replaceAll("[()]", "_") + " " + value.toString() + " "

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter2.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Map;
 
-import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
 import static com.googlecode.jmxtrans.util.NumberUtils.isValidNumber;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -69,7 +68,7 @@ public class GraphiteWriter2 implements WriterBasedOutputWriter {
 			Map<String, Object> resultValues = result.getValues();
 			for (Map.Entry<String, Object> values : resultValues.entrySet()) {
 				Object value = values.getValue();
-				if (isNumeric(value) && isValidNumber(value)) {
+				if (isValidNumber(value)) {
 
 					String line = KeyUtils.getKeyString(server, query, result, values, typeNames, rootPrefix)
 							.replaceAll("[()]", "_") + " " + value.toString() + " "

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriter2.java
@@ -40,6 +40,7 @@ import java.io.Writer;
 import java.util.Map;
 
 import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
+import static com.googlecode.jmxtrans.util.NumberUtils.isValidNumber;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -68,7 +69,7 @@ public class GraphiteWriter2 implements WriterBasedOutputWriter {
 			Map<String, Object> resultValues = result.getValues();
 			for (Map.Entry<String, Object> values : resultValues.entrySet()) {
 				Object value = values.getValue();
-				if (isNumeric(value)) {
+				if (isNumeric(value) && isValidNumber(value)) {
 
 					String line = KeyUtils.getKeyString(server, query, result, values, typeNames, rootPrefix)
 							.replaceAll("[()]", "_") + " " + value.toString() + " "

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriter2Test.java
@@ -31,6 +31,7 @@ import java.io.StringWriter;
 
 import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
 import static com.googlecode.jmxtrans.model.ResultFixtures.dummyResults;
+import static com.googlecode.jmxtrans.model.ResultFixtures.numericResult;
 import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,6 +50,16 @@ public class GraphiteWriter2Test {
 				.startsWith("servers")
 				.contains("example_net_4321")
 				.endsWith(" 10 0\n");
+	}
+
+	@Test
+	public void invalidNumbersFiltered() throws Exception {
+		WriterBasedOutputWriter outputWriter = new GraphiteWriter2(ImmutableList.<String>of(), "servers");
+		StringWriter writer = new StringWriter();
+
+		outputWriter.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(numericResult(Double.NEGATIVE_INFINITY)));
+
+		assertThat(writer.toString()).isEmpty();
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriter2Test.java
@@ -32,6 +32,7 @@ import java.io.StringWriter;
 import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
 import static com.googlecode.jmxtrans.model.ResultFixtures.dummyResults;
 import static com.googlecode.jmxtrans.model.ResultFixtures.numericResult;
+import static com.googlecode.jmxtrans.model.ResultFixtures.stringResult;
 import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,6 +61,27 @@ public class GraphiteWriter2Test {
 		outputWriter.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(numericResult(Double.NEGATIVE_INFINITY)));
 
 		assertThat(writer.toString()).isEmpty();
+	}
+
+	@Test
+	public void invalidNumericStringFiltered() throws Exception {
+		WriterBasedOutputWriter outputWriter = new GraphiteWriter2(ImmutableList.<String>of(), "servers");
+		StringWriter writer = new StringWriter();
+
+		outputWriter.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(stringResult(String.valueOf(Double.NEGATIVE_INFINITY))));
+
+		assertThat(writer.toString()).isEmpty();
+	}
+
+	@Test
+	public void stringNumericValue() throws Exception {
+		WriterBasedOutputWriter outputWriter = new GraphiteWriter2(ImmutableList.<String>of(), "servers");
+		StringWriter writer = new StringWriter();
+
+		outputWriter.write(writer, dummyServer(), dummyQuery(), ImmutableList.of(stringResult("10")));
+
+		assertThat(writer.toString())
+			.startsWith("servers.host_example_net_4321.MemoryAlias.NonHeapMemoryUsage_ObjectPendingFinalizationCount 10 0");
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
-import com.googlecode.jmxtrans.model.ServerFixtures;
 import com.googlecode.jmxtrans.model.ValidationException;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
@@ -132,6 +131,13 @@ public class GraphiteWriterTests {
 		// check that Graphite format is respected
 		assertThat(getOutput(dummyServer(), queryAllowingDottedKeys(), numericResult()))
 				.startsWith("servers.host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount 10 0");
+	}
+
+	@Test
+	public void invalidNumbersFiltered() throws Exception {
+		// check that Graphite format is respected
+		assertThat(getOutput(dummyServer(), queryAllowingDottedKeys(), numericResult(Double.NEGATIVE_INFINITY)))
+			.isEmpty();
 	}
 
 	@Test

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterTests.java
@@ -51,6 +51,7 @@ import static com.googlecode.jmxtrans.model.ResultFixtures.dummyResults;
 import static com.googlecode.jmxtrans.model.ResultFixtures.numericResult;
 import static com.googlecode.jmxtrans.model.ResultFixtures.numericResultWithTypenames;
 import static com.googlecode.jmxtrans.model.ResultFixtures.singleTrueResult;
+import static com.googlecode.jmxtrans.model.ResultFixtures.stringResult;
 import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static com.googlecode.jmxtrans.model.ServerFixtures.serverWithNoQuery;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -134,9 +135,18 @@ public class GraphiteWriterTests {
 	}
 
 	@Test
-	public void invalidNumbersFiltered() throws Exception {
+	public void stringNumericValue() throws Exception {
 		// check that Graphite format is respected
+		assertThat(getOutput(dummyServer(), queryAllowingDottedKeys(), stringResult("10")))
+			.startsWith("servers.host_example_net_4321.MemoryAlias.NonHeapMemoryUsage.ObjectPendingFinalizationCount 10 0");
+	}
+
+	@Test
+	public void invalidNumbersFiltered() throws Exception {
 		assertThat(getOutput(dummyServer(), queryAllowingDottedKeys(), numericResult(Double.NEGATIVE_INFINITY)))
+			.isEmpty();
+
+		assertThat(getOutput(dummyServer(), queryAllowingDottedKeys(), stringResult(String.valueOf(Double.NEGATIVE_INFINITY))))
 			.isEmpty();
 	}
 

--- a/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/util/NumberUtils.java
+++ b/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/util/NumberUtils.java
@@ -43,4 +43,26 @@ public final class NumberUtils {
 		return false;
 	}
 
+	public static boolean isValidNumber(Object value) {
+		if (!(value instanceof Number)) {
+			return false;
+		}
+
+		Number number = (Number) value;
+
+		if (number instanceof Double) {
+			if (Double.isNaN(number.doubleValue()) || Double.isInfinite(number.doubleValue())) {
+				return false;
+			}
+		}
+
+		if (number instanceof Float) {
+			if (Float.isNaN(number.floatValue()) || Float.isInfinite(number.floatValue())) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 }

--- a/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/util/NumberUtils.java
+++ b/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/util/NumberUtils.java
@@ -44,12 +44,22 @@ public final class NumberUtils {
 	}
 
 	public static boolean isValidNumber(Object value) {
-		if (!(value instanceof Number)) {
+		if (value == null) {
 			return false;
 		}
 
-		Number number = (Number) value;
+		if (value instanceof Number) {
+			return isValidNumber((Number) value);
+		}
 
+		if (value instanceof String) {
+			return isNumeric(value);
+		}
+
+		return false;
+	}
+
+	public static boolean isValidNumber(Number number) {
 		if (number instanceof Double) {
 			if (Double.isNaN(number.doubleValue()) || Double.isInfinite(number.doubleValue())) {
 				return false;

--- a/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/NumberUtilsTest.java
+++ b/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/NumberUtilsTest.java
@@ -49,6 +49,8 @@ public class NumberUtilsTest {
 		assertThat(isNumeric((Object) "3.2")).isTrue();
 		assertThat(isNumeric((Object) "abc")).isFalse();
 		assertThat(isNumeric(FALSE)).isFalse();
+
+		assertThat(isNumeric(String.valueOf(Double.NEGATIVE_INFINITY))).isFalse();
 	}
 
 	@Test
@@ -63,13 +65,25 @@ public class NumberUtilsTest {
 		assertThat(isValidNumber(0D)).isTrue();
 		assertThat(isValidNumber(0)).isTrue();
 		assertThat(isValidNumber(0x0F)).isTrue();
+		assertThat(isValidNumber("1")).isTrue();
+		assertThat(isValidNumber("1.00")).isTrue();
+		assertThat(isValidNumber("-1.00")).isTrue();
+		assertThat(isValidNumber("-1")).isTrue();
 
 		assertThat(isValidNumber(Double.NaN)).isFalse();
 		assertThat(isValidNumber(Double.POSITIVE_INFINITY)).isFalse();
 		assertThat(isValidNumber(Double.NEGATIVE_INFINITY)).isFalse();
 
+		assertThat(isValidNumber(String.valueOf(Double.NaN))).isFalse();
+		assertThat(isValidNumber(String.valueOf(Double.POSITIVE_INFINITY))).isFalse();
+		assertThat(isValidNumber(String.valueOf(Double.NEGATIVE_INFINITY))).isFalse();
+
 		assertThat(isValidNumber(Float.NaN)).isFalse();
 		assertThat(isValidNumber(Float.POSITIVE_INFINITY)).isFalse();
 		assertThat(isValidNumber(Float.NEGATIVE_INFINITY)).isFalse();
+
+		assertThat(isValidNumber(String.valueOf(Float.NaN))).isFalse();
+		assertThat(isValidNumber(String.valueOf(Float.POSITIVE_INFINITY))).isFalse();
+		assertThat(isValidNumber(String.valueOf(Float.NEGATIVE_INFINITY))).isFalse();
 	}
 }

--- a/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/NumberUtilsTest.java
+++ b/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/NumberUtilsTest.java
@@ -25,6 +25,7 @@ package com.googlecode.jmxtrans.util;
 import org.junit.Test;
 
 import static com.googlecode.jmxtrans.util.NumberUtils.isNumeric;
+import static com.googlecode.jmxtrans.util.NumberUtils.isValidNumber;
 import static java.lang.Boolean.FALSE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,5 +49,27 @@ public class NumberUtilsTest {
 		assertThat(isNumeric((Object) "3.2")).isTrue();
 		assertThat(isNumeric((Object) "abc")).isFalse();
 		assertThat(isNumeric(FALSE)).isFalse();
+	}
+
+	@Test
+	public void testIsValidNumber() {
+		assertThat(isValidNumber(Long.MAX_VALUE)).isTrue();
+		assertThat(isValidNumber(Long.MIN_VALUE)).isTrue();
+		assertThat(isValidNumber(Double.MIN_VALUE)).isTrue();
+		assertThat(isValidNumber(Double.MAX_VALUE)).isTrue();
+		assertThat(isValidNumber(Float.MAX_VALUE)).isTrue();
+		assertThat(isValidNumber(Float.MIN_VALUE)).isTrue();
+		assertThat(isValidNumber(0L)).isTrue();
+		assertThat(isValidNumber(0D)).isTrue();
+		assertThat(isValidNumber(0)).isTrue();
+		assertThat(isValidNumber(0x0F)).isTrue();
+
+		assertThat(isValidNumber(Double.NaN)).isFalse();
+		assertThat(isValidNumber(Double.POSITIVE_INFINITY)).isFalse();
+		assertThat(isValidNumber(Double.NEGATIVE_INFINITY)).isFalse();
+
+		assertThat(isValidNumber(Float.NaN)).isFalse();
+		assertThat(isValidNumber(Float.POSITIVE_INFINITY)).isFalse();
+		assertThat(isValidNumber(Float.NEGATIVE_INFINITY)).isFalse();
 	}
 }


### PR DESCRIPTION
@gehel This PR fixes the issue reported in #539 

I added a utility method `isValidNumber` that ensures that the number is not NaN or infinity.