### PR TITLE
kafka output writer does not close connection after producing to a topic

### DIFF
--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
@@ -118,6 +118,7 @@ public class KafkaWriter extends BaseOutputWriter {
 					for(String topic : this.topics) {
 						log.debug("Topic: [{}] ; Kafka Message: [{}]", topic, message);
 						producer.send(new KeyedMessage<String, String>(topic, message));
+						producer.close();
 					}
 				} else {
 					log.warn("Unable to submit non-numeric value to Kafka: [{}] from result [{}]", value, result);


### PR DESCRIPTION
This PR fixes a bug found when shipping a significant amount of metrics. Upon producing a message to a topic, it appears that the Kafka producer does not close the connection. In cases where a significant amount of messages are sent, connection are kept in CLOSED_WAIT state for a long.