### PR TITLE
Add socket timeout settings and udp support for graphite writer

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/support/ResultTransformerOutputWriter.java
@@ -22,6 +22,7 @@
  */
 package com.googlecode.jmxtrans.model.output.support;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.googlecode.jmxtrans.model.OutputWriter;
 import com.googlecode.jmxtrans.model.OutputWriterAdapter;
 import com.googlecode.jmxtrans.model.Query;
@@ -72,4 +73,8 @@ public class ResultTransformerOutputWriter<T extends OutputWriter> extends Outpu
 		target.close();
 	}
 
+	@VisibleForTesting
+	T getTarget() {
+		return target;
+	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter;
 import com.googlecode.jmxtrans.model.output.support.TcpOutputWriterBuilder;
+import com.googlecode.jmxtrans.model.output.support.UdpOutputWriterBuilder;
 import com.googlecode.jmxtrans.model.output.support.WriterPoolOutputWriter;
 import com.googlecode.jmxtrans.model.output.support.pool.FlushStrategy;
 import lombok.EqualsAndHashCode;
@@ -54,6 +55,7 @@ import static com.googlecode.jmxtrans.model.output.support.pool.FlushStrategyUti
 public class GraphiteWriterFactory implements OutputWriterFactory {
 
 	private static final String DEFAULT_ROOT_PREFIX = "servers";
+	private static final String DEFAULT_PROTOCOL = "tcp";
 
 	@Nonnull private final String rootPrefix;
 	@Nonnull private final InetSocketAddress graphiteServer;
@@ -63,6 +65,12 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 	private final int poolSize;
 	private final int socketTimeoutMs;
 	private final Integer poolClaimTimeoutSeconds;
+
+	/**
+	 * protocol to use to send metrics to graphite server.
+	 * Default to "tcp". Possible values: "udp" or omit the value to use tcp protocol.
+	 */
+	private final String protocol;
 
 	@JsonCreator
 	public GraphiteWriterFactory(
@@ -75,7 +83,8 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
 			@JsonProperty("poolSize") Integer poolSize,
 			@JsonProperty("socketTimeoutMs") Integer socketTimeoutMs,
-			@JsonProperty("poolClaimTimeoutSeconds") Integer poolClaimTimeoutSeconds) {
+			@JsonProperty("poolClaimTimeoutSeconds") Integer poolClaimTimeoutSeconds,
+			@JsonProperty("protocol") String protocol) {
 
 		this.typeNames = typeNames;
 		this.booleanAsNumber = booleanAsNumber;
@@ -88,20 +97,34 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 		this.poolSize = firstNonNull(poolSize, 1);
 		this.socketTimeoutMs = firstNonNull(socketTimeoutMs, 200);
 		this.poolClaimTimeoutSeconds = firstNonNull(poolClaimTimeoutSeconds, 1);
+		this.protocol = firstNonNull(protocol, DEFAULT_PROTOCOL);
 	}
 
 	@Override
 	public ResultTransformerOutputWriter<WriterPoolOutputWriter<GraphiteWriter2>> create() {
-		return ResultTransformerOutputWriter.booleanToNumber(
-				booleanAsNumber,
-				TcpOutputWriterBuilder.builder(graphiteServer, new GraphiteWriter2(typeNames, rootPrefix))
-						.setCharset(UTF_8)
-						.setFlushStrategy(flushStrategy)
-						.setPoolSize(poolSize)
-						.setSocketTimeoutMillis(socketTimeoutMs)
-						.setPoolClaimTimeoutSeconds(poolClaimTimeoutSeconds)
-						.build()
-		);
+
+		WriterPoolOutputWriter<GraphiteWriter2> writerPoolOutputWriter;
+		// check if we want to use udp protocol or fallback on default tcp protocol
+		if ("udp".equals(this.protocol)) {
+			writerPoolOutputWriter = UdpOutputWriterBuilder.builder(graphiteServer, new GraphiteWriter2(typeNames, rootPrefix))
+					.setCharset(UTF_8)
+					.setFlushStrategy(flushStrategy)
+					.setPoolSize(poolSize)
+					.setPoolClaimTimeoutSeconds(poolClaimTimeoutSeconds)
+					.build();
+		} else {
+			writerPoolOutputWriter = TcpOutputWriterBuilder.builder(graphiteServer, new GraphiteWriter2(typeNames, rootPrefix))
+					.setCharset(UTF_8)
+					.setFlushStrategy(flushStrategy)
+					.setPoolSize(poolSize)
+					.setSocketTimeoutMillis(socketTimeoutMs)
+					.setPoolClaimTimeoutSeconds(poolClaimTimeoutSeconds)
+					.build();
+
+		}
+
+		return ResultTransformerOutputWriter.booleanToNumber(booleanAsNumber, writerPoolOutputWriter);
+
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
@@ -61,6 +61,8 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 	private final boolean booleanAsNumber;
 	@Nonnull private final FlushStrategy flushStrategy;
 	private final int poolSize;
+	private final int socketTimeoutMs;
+	private final Integer poolClaimTimeoutSeconds;
 
 	@JsonCreator
 	public GraphiteWriterFactory(
@@ -71,7 +73,10 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 			@JsonProperty("port") Integer port,
 			@JsonProperty("flushStrategy") String flushStrategy,
 			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
-			@JsonProperty("poolSize") Integer poolSize) {
+			@JsonProperty("poolSize") Integer poolSize,
+			@JsonProperty("socketTimeoutMs") Integer socketTimeoutMs,
+			@JsonProperty("poolClaimTimeoutSeconds") Integer poolClaimTimeoutSeconds) {
+
 		this.typeNames = typeNames;
 		this.booleanAsNumber = booleanAsNumber;
 		this.rootPrefix = firstNonNull(rootPrefix, DEFAULT_ROOT_PREFIX);
@@ -81,6 +86,8 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 				checkNotNull(port, "Port cannot be null."));
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
 		this.poolSize = firstNonNull(poolSize, 1);
+		this.socketTimeoutMs = firstNonNull(socketTimeoutMs, 200);
+		this.poolClaimTimeoutSeconds = firstNonNull(poolClaimTimeoutSeconds, 1);
 	}
 
 	@Override
@@ -91,6 +98,8 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 						.setCharset(UTF_8)
 						.setFlushStrategy(flushStrategy)
 						.setPoolSize(poolSize)
+						.setSocketTimeoutMillis(socketTimeoutMs)
+						.setPoolClaimTimeoutSeconds(poolClaimTimeoutSeconds)
 						.build()
 		);
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriterBuilder.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriterBuilder.java
@@ -48,6 +48,7 @@ public class TcpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
 	@Nonnull private final T target;
 	@Nonnull @Setter private Charset charset = Charsets.UTF_8;
 	@Setter private int socketTimeoutMillis = 200;
+	@Setter private int poolClaimTimeoutSeconds = 1;
 	@Setter private int poolSize = 1;
 	@Nonnull @Setter private FlushStrategy flushStrategy = new NeverFlush();
 
@@ -76,6 +77,6 @@ public class TcpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
 
 	public WriterPoolOutputWriter<T> build() {
 		LifecycledPool<SocketPoolable> pool = createPool();
-		return new WriterPoolOutputWriter<>(target, pool, new Timeout(1, SECONDS));
+		return new WriterPoolOutputWriter<>(target, pool, new Timeout(poolClaimTimeoutSeconds, SECONDS), socketTimeoutMillis);
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/UdpOutputWriterBuilder.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/UdpOutputWriterBuilder.java
@@ -49,6 +49,7 @@ public class UdpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
 	@Setter private int bufferSize = 1472;
 	@Setter private int poolSize = 1;
 	@Nonnull @Setter private FlushStrategy flushStrategy = new NeverFlush();
+	@Setter private int poolClaimTimeoutSeconds = 1;
 
 	private UdpOutputWriterBuilder(@Nonnull InetSocketAddress server, @Nonnull T target) {
 		this.server = server;
@@ -75,6 +76,6 @@ public class UdpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
 
 	public WriterPoolOutputWriter<T> build() {
 		LifecycledPool<DatagramChannelPoolable> pool = createPool();
-		return new WriterPoolOutputWriter<>(target, pool, new Timeout(1, SECONDS));
+		return new WriterPoolOutputWriter<>(target, pool, new Timeout(poolClaimTimeoutSeconds, SECONDS));
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/WriterPoolOutputWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/WriterPoolOutputWriter.java
@@ -22,6 +22,7 @@
  */
 package com.googlecode.jmxtrans.model.output.support;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.OutputWriterAdapter;
 import com.googlecode.jmxtrans.model.Query;
@@ -34,6 +35,7 @@ import stormpot.LifecycledPool;
 import stormpot.Timeout;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 public class WriterPoolOutputWriter<T extends WriterBasedOutputWriter> extends OutputWriterAdapter{
@@ -43,12 +45,21 @@ public class WriterPoolOutputWriter<T extends WriterBasedOutputWriter> extends O
 	@Nonnull private final T target;
 	@Nonnull private final LifecycledPool<? extends WriterPoolable> writerPool;
 	@Nonnull private final Timeout poolClaimTimeout;
+	@Nullable private int socketTimeoutMs;
 
 	public WriterPoolOutputWriter(@Nonnull T target, @Nonnull LifecycledPool<? extends WriterPoolable> writerPool, @Nonnull Timeout poolClaimTimeout) {
 		this.target = target;
 		this.writerPool = writerPool;
 		this.poolClaimTimeout = poolClaimTimeout;
 	}
+
+	public WriterPoolOutputWriter(@Nonnull T target, @Nonnull LifecycledPool<? extends WriterPoolable> writerPool, @Nonnull Timeout poolClaimTimeout, @Nullable int socketTimeoutMs) {
+		this.target = target;
+		this.writerPool = writerPool;
+		this.poolClaimTimeout = poolClaimTimeout;
+		this.socketTimeoutMs = socketTimeoutMs;
+	}
+
 
 	@Override
 	public void doWrite(Server server, Query query, Iterable<Result> results) throws Exception {
@@ -84,6 +95,16 @@ public class WriterPoolOutputWriter<T extends WriterBasedOutputWriter> extends O
 		}
 
 		return result;
+	}
+
+	@VisibleForTesting
+	public int getSocketTimeoutMs() {
+		return socketTimeoutMs;
+	}
+
+	@VisibleForTesting
+	Timeout getPoolClaimTimeout() {
+		return poolClaimTimeout;
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/WriterPoolOutputWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/WriterPoolOutputWriter.java
@@ -107,4 +107,8 @@ public class WriterPoolOutputWriter<T extends WriterBasedOutputWriter> extends O
 		return poolClaimTimeout;
 	}
 
+	@VisibleForTesting
+	public LifecycledPool<? extends WriterPoolable> getWriterPool() {
+		return writerPool;
+	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/GraphiteWriterFactoryTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/GraphiteWriterFactoryTest.java
@@ -23,7 +23,6 @@
 package com.googlecode.jmxtrans.model.output.support;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.Closer;
 import com.google.inject.Injector;
 import com.googlecode.jmxtrans.ConfigurationParser;
 import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
@@ -32,21 +31,22 @@ import com.googlecode.jmxtrans.guice.JmxTransModule;
 import com.googlecode.jmxtrans.model.OutputWriter;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Server;
-import com.googlecode.jmxtrans.model.output.GraphiteWriter;
-import com.googlecode.jmxtrans.model.output.GraphiteWriter2;
+import com.googlecode.jmxtrans.model.output.support.pool.DatagramChannelAllocator;
+import com.googlecode.jmxtrans.model.output.support.pool.RetryingAllocator;
 import com.googlecode.jmxtrans.test.IntegrationTest;
 import com.googlecode.jmxtrans.test.RequiresIO;
-import com.googlecode.jmxtrans.test.ResetableSystemProperty;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import stormpot.BlazePool;
+import stormpot.LifecycledPool;
 
 import java.io.File;
-import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.URISyntaxException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 @Category({IntegrationTest.class, RequiresIO.class})
 public class GraphiteWriterFactoryTest {
@@ -84,6 +84,98 @@ public class GraphiteWriterFactoryTest {
 
 		assertThat(writerPoolOutputWriter.getSocketTimeoutMs()).isEqualTo(1000);
 		assertThat(writerPoolOutputWriter.getPoolClaimTimeout().getTimeout()).isEqualTo(2);
+	}
+
+	@Test
+	public void use_tcp_protocol_by_default() throws LifecycleException, URISyntaxException {
+		ImmutableList<Server> servers = configurationParser.parseServers(ImmutableList.of(file("/graphite-writer-factory-example2.json")), false);
+
+		assertThat(servers).hasSize(1);
+		Server server = servers.get(0);
+
+		assertThat(server.getQueries()).hasSize(1);
+		Query query = server.getQueries().iterator().next();
+
+		assertThat(query.getOutputWriterInstances()).hasSize(1);
+		OutputWriter outputWriter = query.getOutputWriterInstances().iterator().next();
+
+		assertThat(outputWriter).isInstanceOf(ResultTransformerOutputWriter.class);
+
+		ResultTransformerOutputWriter resultTransformerOutputWriter = (ResultTransformerOutputWriter) outputWriter;
+		OutputWriter target = resultTransformerOutputWriter.getTarget();
+
+		assertThat(target).isInstanceOf(WriterPoolOutputWriter.class);
+
+		LifecycledPool writerPool = ((WriterPoolOutputWriter) target).getWriterPool();
+
+		assertThat(writerPool).isInstanceOf(BlazePool.class);
+
+		BlazePool blazePool = (BlazePool) writerPool;
+
+		// using TcpOutputWriterBuilder
+		try {
+			// first level allocator
+			Field allocator = blazePool.getClass().getDeclaredField("allocator");
+			allocator.setAccessible(true);
+			Object insideAllocator = allocator.get(blazePool);
+			// second level allocator
+			Field allocatorLv2 = insideAllocator.getClass().getDeclaredField("allocator");
+			allocatorLv2.setAccessible(true);
+			Object level2Allocator = allocatorLv2.get(insideAllocator);
+			// third level
+			Field allocatorLv3 = level2Allocator.getClass().getDeclaredField("allocator");
+			allocatorLv3.setAccessible(true);
+			Object level3Allocator = allocatorLv3.get(level2Allocator);
+			assertThat(level3Allocator).isInstanceOf(RetryingAllocator.class);
+		} catch (IllegalAccessException | NoSuchFieldException e) {
+			fail();
+		}
+	}
+
+	@Test
+	public void writer_using_udp_protocol() throws LifecycleException, URISyntaxException {
+		ImmutableList<Server> servers = configurationParser.parseServers(ImmutableList.of(file("/graphite-writer-factory-example-with-udp.json")), false);
+
+		assertThat(servers).hasSize(1);
+		Server server = servers.get(0);
+
+		assertThat(server.getQueries()).hasSize(1);
+		Query query = server.getQueries().iterator().next();
+
+		assertThat(query.getOutputWriterInstances()).hasSize(1);
+		OutputWriter outputWriter = query.getOutputWriterInstances().iterator().next();
+
+		assertThat(outputWriter).isInstanceOf(ResultTransformerOutputWriter.class);
+
+		ResultTransformerOutputWriter resultTransformerOutputWriter = (ResultTransformerOutputWriter) outputWriter;
+		OutputWriter target = resultTransformerOutputWriter.getTarget();
+
+		assertThat(target).isInstanceOf(WriterPoolOutputWriter.class);
+
+		LifecycledPool writerPool = ((WriterPoolOutputWriter) target).getWriterPool();
+
+		assertThat(writerPool).isInstanceOf(BlazePool.class);
+
+		BlazePool blazePool = (BlazePool) writerPool;
+
+		// using UdpOutputWriterBuilder
+		try {
+			// first level allocator
+			Field allocator = blazePool.getClass().getDeclaredField("allocator");
+			allocator.setAccessible(true);
+			Object insideAllocator = allocator.get(blazePool);
+			// second level allocator
+			Field allocatorLv2 = insideAllocator.getClass().getDeclaredField("allocator");
+			allocatorLv2.setAccessible(true);
+			Object level2Allocator = allocatorLv2.get(insideAllocator);
+			// third level
+			Field allocatorLv3 = level2Allocator.getClass().getDeclaredField("allocator");
+			allocatorLv3.setAccessible(true);
+			Object level3Allocator = allocatorLv3.get(level2Allocator);
+			assertThat(level3Allocator).isInstanceOf(DatagramChannelAllocator.class);
+		} catch (IllegalAccessException | NoSuchFieldException e) {
+			fail();
+		}
 	}
 
 	private File file(String filename) throws URISyntaxException {

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/GraphiteWriterFactoryTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/GraphiteWriterFactoryTest.java
@@ -1,0 +1,93 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output.support;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
+import com.google.inject.Injector;
+import com.googlecode.jmxtrans.ConfigurationParser;
+import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.guice.JmxTransModule;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.output.GraphiteWriter;
+import com.googlecode.jmxtrans.model.output.GraphiteWriter2;
+import com.googlecode.jmxtrans.test.IntegrationTest;
+import com.googlecode.jmxtrans.test.RequiresIO;
+import com.googlecode.jmxtrans.test.ResetableSystemProperty;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category({IntegrationTest.class, RequiresIO.class})
+public class GraphiteWriterFactoryTest {
+
+	private ConfigurationParser configurationParser;
+
+	@Before
+	public void createConfigurationParser() {
+		JmxTransConfiguration configuration = new JmxTransConfiguration();
+		Injector injector = JmxTransModule.createInjector(configuration);
+		configurationParser = injector.getInstance(ConfigurationParser.class);
+	}
+
+	@Test
+	public void canParseConfigurationFileWithCustomParameters() throws LifecycleException, URISyntaxException {
+		ImmutableList<Server> servers = configurationParser.parseServers(ImmutableList.of(file("/graphite-writer-factory-example2.json")), false);
+
+		assertThat(servers).hasSize(1);
+		Server server = servers.get(0);
+
+		assertThat(server.getQueries()).hasSize(1);
+		Query query = server.getQueries().iterator().next();
+
+		assertThat(query.getOutputWriterInstances()).hasSize(1);
+		OutputWriter outputWriter = query.getOutputWriterInstances().iterator().next();
+
+		assertThat(outputWriter).isInstanceOf(ResultTransformerOutputWriter.class);
+
+		ResultTransformerOutputWriter resultTransformerOutputWriter = (ResultTransformerOutputWriter) outputWriter;
+		OutputWriter target = resultTransformerOutputWriter.getTarget();
+
+		assertThat(target).isInstanceOf(WriterPoolOutputWriter.class);
+
+		WriterPoolOutputWriter writerPoolOutputWriter = (WriterPoolOutputWriter) target;
+
+		assertThat(writerPoolOutputWriter.getSocketTimeoutMs()).isEqualTo(1000);
+		assertThat(writerPoolOutputWriter.getPoolClaimTimeout().getTimeout()).isEqualTo(2);
+	}
+
+	private File file(String filename) throws URISyntaxException {
+		return new File(GraphiteWriterFactoryTest.class.getResource(filename).toURI());
+	}
+
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/resources/graphite-writer-factory-example-with-udp.json
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/resources/graphite-writer-factory-example-with-udp.json
@@ -1,0 +1,19 @@
+{
+  "servers" : [ {
+    "port" : "1099",
+    "host" : "w2",
+    "queries" : [ {
+      "obj" : "kafka.server:type=BrokerTopicMetrics,name=*",
+      "resultAlias" : "brokerTopic",
+      "attr" : ["Count","OneMinuteRate","FifteenMinuteRate"],
+      "outputWriters" : [ {
+        "@class" : "com.googlecode.jmxtrans.model.output.GraphiteWriterFactory",
+        "port" : 2003,
+        "host" : "192.168.192.133",
+        "typeNames" : ["name"],
+        "protocol" : "udp",
+        "poolClaimTimeoutSeconds" : 2
+      } ]
+    } ]
+  } ]
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/resources/graphite-writer-factory-example2.json
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/resources/graphite-writer-factory-example2.json
@@ -1,0 +1,19 @@
+{
+  "servers" : [ {
+    "port" : "1099",
+    "host" : "w2",
+    "queries" : [ {
+      "obj" : "kafka.server:type=BrokerTopicMetrics,name=*",
+      "resultAlias" : "brokerTopic",
+      "attr" : ["Count","OneMinuteRate","FifteenMinuteRate"],
+      "outputWriters" : [ {
+        "@class" : "com.googlecode.jmxtrans.model.output.GraphiteWriterFactory",
+        "port" : 2003,
+        "host" : "192.168.192.133",
+        "typeNames" : ["name"],
+        "socketTimeoutMs" : 1000,
+        "poolClaimTimeoutSeconds" : 2
+      } ]
+    } ]
+  } ]
+}


### PR DESCRIPTION
Hello,

I'm in the case where i have a central graphite server for all my datacenter (US, EU and APAC). I have seen that there is a hard coded value (200ms) on socket timeout and this PR will allow to set some additional settings for socket timeout and pool claim timeout. This add the possibility to use the UdpOutputWriter instead of the TcpOutputWriter (udp vs tcp).

I have deploy this version in production to fix the issue. I don't find where you generate the documentation to add some details for these new settings.

Some configuration examples:
```
"outputWriters" : [ {
        "@class" : "com.googlecode.jmxtrans.model.output.GraphiteWriterFactory",
        "port" : 2003,
        "host" : "your_host",
        "protocol" : "udp",
        "poolClaimTimeoutSeconds" : 2
      } ]
```
```
"outputWriters" : [ {
        "@class" : "com.googlecode.jmxtrans.model.output.GraphiteWriterFactory",
        "port" : 2003,
        "host" : "your_host",
        "socketTimeoutMs" : 1000,
        "poolClaimTimeoutSeconds" : 2
      } ]
```

Enjoy.
