### PR TITLE
Ensure KeyOutWriter, DailyKeyOutWriter, and TimeBasedRollingKeyOutWriter populate maxLogBackupFiles correctly.

### DIFF
--- a/jmxtrans-output/jmxtrans-output-log4j/src/main/java/com/googlecode/jmxtrans/model/output/DailyKeyOutWriter.java
+++ b/jmxtrans-output/jmxtrans-output-log4j/src/main/java/com/googlecode/jmxtrans/model/output/DailyKeyOutWriter.java
@@ -63,7 +63,7 @@ public class DailyKeyOutWriter extends KeyOutWriter {
 			@JsonProperty("debug") Boolean debugEnabled,
 			@JsonProperty("outputFile") String outputFile,
 			@JsonProperty("maxLogFileSize") String maxLogFileSize,
-			@JsonProperty("maxLogBackupFiles") int maxLogBackupFiles,
+			@JsonProperty("maxLogBackupFiles") Integer maxLogBackupFiles,
 			@JsonProperty("delimiter") String delimiter,
 			@JsonProperty("datePattern") String datePattern,
 			@JsonProperty("settings") Map<String, Object> settings) {

--- a/jmxtrans-output/jmxtrans-output-log4j/src/main/java/com/googlecode/jmxtrans/model/output/KeyOutWriter.java
+++ b/jmxtrans-output/jmxtrans-output-log4j/src/main/java/com/googlecode/jmxtrans/model/output/KeyOutWriter.java
@@ -85,7 +85,7 @@ public class KeyOutWriter extends BaseOutputWriter {
 			@JsonProperty("debug") Boolean debugEnabled,
 			@JsonProperty("outputFile") String outputFile,
 			@JsonProperty("maxLogFileSize") String maxLogFileSize,
-			@JsonProperty("maxLogBackupFiles") int maxLogBackupFiles,
+			@JsonProperty("maxLogBackupFiles") Integer maxLogBackupFiles,
 			@JsonProperty("delimiter") String delimiter,
 			@JsonProperty("settings") Map<String, Object> settings) {
 		super(typeNames, booleanAsNumber, debugEnabled, settings);

--- a/jmxtrans-output/jmxtrans-output-log4j/src/main/java/com/googlecode/jmxtrans/model/output/TimeBasedRollingKeyOutWriter.java
+++ b/jmxtrans-output/jmxtrans-output-log4j/src/main/java/com/googlecode/jmxtrans/model/output/TimeBasedRollingKeyOutWriter.java
@@ -69,7 +69,7 @@ public class TimeBasedRollingKeyOutWriter extends KeyOutWriter {
 			@JsonProperty("debug") Boolean debugEnabled,
 			@JsonProperty("outputFile") String outputFile,
 			@JsonProperty("maxLogFileSize") String maxLogFileSize,
-			@JsonProperty("maxLogBackupFiles") int maxLogBackupFiles,
+			@JsonProperty("maxLogBackupFiles") Integer maxLogBackupFiles,
 			@JsonProperty("delimiter") String delimiter,
 			@JsonProperty("settings") Map<String, Object> settings) {
 		super(typeNames, booleanAsNumber, debugEnabled, outputFile, maxLogFileSize, maxLogBackupFiles, delimiter, settings);


### PR DESCRIPTION
  - Change type in constructor from `int` to `Integer`.

This fixes #559.