### PR TITLE
Add circuit breakers on Server and OutputWriters

### DIFF
--- a/jmxtrans-core/pom.xml
+++ b/jmxtrans-core/pom.xml
@@ -98,6 +98,10 @@
 			<artifactId>javax.inject</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>net.jodah</groupId>
+			<artifactId>failsafe</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-jexl</artifactId>
 		</dependency>

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/CircuitBreakerOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/CircuitBreakerOutputWriter.java
@@ -1,0 +1,85 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model;
+
+import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import lombok.EqualsAndHashCode;
+import net.jodah.failsafe.CircuitBreaker;
+import net.jodah.failsafe.function.CheckedRunnable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static net.jodah.failsafe.Failsafe.with;
+
+@EqualsAndHashCode(exclude = "breaker")
+public class CircuitBreakerOutputWriter<T extends OutputWriter> extends OutputWriterAdapter {
+
+	private static final Logger logger = LoggerFactory.getLogger(CircuitBreakerOutputWriter.class);
+	private final T target;
+	private final CircuitBreaker breaker;
+
+	public CircuitBreakerOutputWriter(final T target) {
+		this.target = target;
+		this.breaker = new CircuitBreaker()
+				.withFailureThreshold(2, 4)
+				.withSuccessThreshold(1)
+				.withDelay(1, MINUTES)
+				.withTimeout(250, MILLISECONDS)
+				.onOpen(createLogger("Circuit breaker opened for output writer {}",false))
+				.onClose(createLogger("Circuit breaker closed for output writer {}", true))
+				.onHalfOpen(createLogger("Circuit breaker half opened for output writer {}", true));
+	}
+
+	private CheckedRunnable createLogger(final String message, final boolean isSuccess) {
+		return new CheckedRunnable() {
+			@Override
+			public void run() throws Exception {
+				if (isSuccess) logger.warn(message, target);
+				else logger.info(message, target);
+			}
+		};
+	}
+
+
+	@Override
+	public void close() throws LifecycleException {
+		target.close();
+	}
+
+	@Override
+	public void doWrite(final Server server, final Query query, final Iterable<Result> results) throws Exception {
+		with(breaker).run(new CheckedRunnable() {
+			@Override
+			public void run() throws Exception {
+				target.doWrite(server, query, results);
+			}
+		});
+	}
+
+	@Override
+	public String toString() {
+		return target.toString();
+	}
+}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -24,9 +24,9 @@ package com.googlecode.jmxtrans.model;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -40,6 +40,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+import net.jodah.failsafe.CircuitBreaker;
+import net.jodah.failsafe.FailsafeException;
+import net.jodah.failsafe.function.CheckedRunnable;
 import org.apache.commons.pool.KeyedObjectPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +67,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 import static com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.NON_NULL;
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -71,9 +75,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableSet.copyOf;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static javax.management.remote.JMXConnectorFactory.PROTOCOL_PROVIDER_PACKAGES;
 import static javax.naming.Context.SECURITY_CREDENTIALS;
 import static javax.naming.Context.SECURITY_PRINCIPAL;
+import static net.jodah.failsafe.Failsafe.with;
 
 /**
  * Represents a jmx server that we want to connect to. This also stores the
@@ -96,7 +103,7 @@ import static javax.naming.Context.SECURITY_PRINCIPAL;
 })
 @Immutable
 @ThreadSafe
-@EqualsAndHashCode(exclude = {"queries", "pool", "outputWriters", "outputWriterFactories"})
+@EqualsAndHashCode(exclude = {"queries", "pool", "outputWriters", "outputWriterFactories", "breaker"})
 @ToString(of = {"pid", "host", "port", "url", "cronExpression", "numQueryThreads"})
 public class Server implements JmxConnectionProvider {
 
@@ -155,6 +162,7 @@ public class Server implements JmxConnectionProvider {
 
 	@Nonnull private final KeyedObjectPool<JmxConnectionProvider, JMXConnection> pool;
 	@Nonnull @Getter private final ImmutableList<OutputWriterFactory> outputWriterFactories;
+	private final CircuitBreaker breaker;
 
 	@JsonCreator
 	public Server(
@@ -256,9 +264,43 @@ public class Server implements JmxConnectionProvider {
 		this.pool = checkNotNull(pool);
 		this.outputWriterFactories = ImmutableList.copyOf(firstNonNull(outputWriterFactories, ImmutableList.<OutputWriterFactory>of()));
 		this.outputWriters = ImmutableList.copyOf(firstNonNull(outputWriters, ImmutableList.<OutputWriter>of()));
+		this.breaker = new CircuitBreaker()
+				.withFailureThreshold(2, 4)
+				.withSuccessThreshold(1)
+				.withDelay(1, MINUTES)
+				.withTimeout(250, MILLISECONDS)
+				.onOpen(createLogger("Circuit breaker opened for server {}", this, false))
+				.onClose(createLogger("Circuit breaker closed for server {}", this, true))
+				.onHalfOpen(createLogger("Circuit breaker half opened for server {}", this, true));
 	}
 
-	public Iterable<Result> execute(Query query) throws Exception {
+	private CheckedRunnable createLogger(final String message, final Server server, final boolean isSuccess) {
+		return new CheckedRunnable() {
+			@Override
+			public void run() throws Exception {
+				if (isSuccess) logger.warn(message, server);
+				else logger.info(message, server);
+			}
+		};
+	}
+
+	public Iterable<Result> execute(final Query query) throws Exception {
+		try {
+			return with(breaker).get(new Callable<Iterable<Result>>() {
+				@Override
+				public Iterable<Result> call() throws Exception {
+					return doExecute(query);
+				}
+			});
+		} catch (FailsafeException fe) {
+			// Failsafe wraps non runtime exceptions, but we can unwrap them now
+			Throwable cause = fe.getCause();
+			if (cause != null && cause instanceof Exception) throw (Exception) cause;
+			throw fe;
+		}
+	}
+
+	private Iterable<Result> doExecute(Query query) throws Exception {
 		JMXConnection jmxConnection = pool.borrowObject(this);
 		try {
 			ImmutableList.Builder<Result> results = ImmutableList.builder();

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/SingletonOutputWriterFactory.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/SingletonOutputWriterFactory.java
@@ -29,19 +29,19 @@ import javax.annotation.Nonnull;
 
 @ToString
 @EqualsAndHashCode(of = "outputWriterFactory")
-public class SingletonOutputWriterFactory<T extends OutputWriter> implements OutputWriterFactory<T> {
+public class SingletonOutputWriterFactory<T extends OutputWriter> implements OutputWriterFactory<CircuitBreakerOutputWriter<T>> {
 
-	@Nonnull private final T outputWriter;
+	@Nonnull private final CircuitBreakerOutputWriter<T> outputWriter;
 
 	@Nonnull private final OutputWriterFactory<T> outputWriterFactory;
 
 	public SingletonOutputWriterFactory(@Nonnull OutputWriterFactory<T> outputWriterFactory) {
 		this.outputWriterFactory = outputWriterFactory;
-		outputWriter = outputWriterFactory.create();
+		outputWriter = new CircuitBreakerOutputWriter<>(outputWriterFactory.create());
 	}
 
 	@Override
-	public T create() {
+	public CircuitBreakerOutputWriter<T> create() {
 		return outputWriter;
 	}
 }

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/CircuitBreakerOutputWriterTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/CircuitBreakerOutputWriterTest.java
@@ -1,0 +1,97 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model;
+
+import com.googlecode.jmxtrans.test.SlowTest;
+import net.jodah.failsafe.CircuitBreakerOpenException;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.ResultFixtures.dummyResults;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CircuitBreakerOutputWriterTest {
+
+	@Mock private OutputWriter target;
+
+	@Test
+	public void writesArePassedToTheTargetOutputWriter() throws Exception {
+		CircuitBreakerOutputWriter<OutputWriter> circuitBreaker = new CircuitBreakerOutputWriter<>(target);
+		circuitBreaker.doWrite(dummyServer(), dummyQuery(), dummyResults());
+
+		verify(target).doWrite(dummyServer(), dummyQuery(), dummyResults());
+	}
+
+	@Test
+	public void circuitBreakerOpensAfterThreeFailures() throws Exception {
+		CircuitBreakerOutputWriter<OutputWriter> circuitBreaker = new CircuitBreakerOutputWriter<>(target);
+
+		doThrow(new IllegalStateException("failing output writer")).when(target).doWrite(dummyServer(), dummyQuery(), dummyResults());
+
+		for (int i = 0; i < 10; i++) {
+			try {
+				circuitBreaker.doWrite(dummyServer(), dummyQuery(), dummyResults());
+				fail("Exception should have been thrown");
+			} catch (IllegalStateException ignore) {
+				assertThat(ignore).hasMessage("failing output writer");
+			} catch (CircuitBreakerOpenException ignore) {}
+		}
+
+		verify(target, times(4)).doWrite(dummyServer(), dummyQuery(), dummyResults());
+	}
+
+	@Test
+	@Category(SlowTest.class)
+	@Ignore("Long running test, don't run it each time.")
+	public void circuitBreakerOpensOnTimeouts() throws Exception {
+		CircuitBreakerOutputWriter<OutputWriter> circuitBreaker = new CircuitBreakerOutputWriter<>(target);
+
+		doAnswer(new Answer() {
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				Thread.sleep(260);
+				return null;
+			}
+		}).when(target).doWrite(dummyServer(), dummyQuery(), dummyResults());
+
+		for (int i = 0; i < 7; i++) {
+			try {
+				circuitBreaker.doWrite(dummyServer(), dummyQuery(), dummyResults());
+			} catch (Exception ignore) {
+			}
+		}
+
+		verify(target, times(4)).doWrite(dummyServer(), dummyQuery(), dummyResults());
+	}
+}

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
@@ -298,7 +298,7 @@ public class ServerTests {
 			fail("No exception got throws");
 		} catch (IOException e2) {
 			if (e != e2) {
-				fail("Wrong exception thrown (" + e + " instead of mock");
+				fail("Wrong exception thrown (" + e + ") instead of mock");
 			}
 		}
 

--- a/jmxtrans-docker-test/pom.xml
+++ b/jmxtrans-docker-test/pom.xml
@@ -57,7 +57,7 @@
 				<artifactId>docker-maven-plugin</artifactId>
 				<configuration>
 					<showLogs>true</showLogs>
-					<images />
+					<images></images>
 				</configuration>
 				<executions>
 					<execution>

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactoryIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactoryIT.java
@@ -29,6 +29,7 @@ import com.googlecode.jmxtrans.ConfigurationParser;
 import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.guice.JmxTransModule;
+import com.googlecode.jmxtrans.model.CircuitBreakerOutputWriter;
 import com.googlecode.jmxtrans.model.OutputWriter;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Server;
@@ -88,7 +89,7 @@ public class GraphiteWriterFactoryIT {
 		assertThat(query.getOutputWriterInstances()).hasSize(1);
 		OutputWriter outputWriter = query.getOutputWriterInstances().iterator().next();
 
-		assertThat(outputWriter).isInstanceOf(ResultTransformerOutputWriter.class);
+		assertThat(outputWriter).isInstanceOf(CircuitBreakerOutputWriter.class);
 	}
 
 	private File file(String filename) throws URISyntaxException {

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,11 @@
 				<version>1.2.17</version>
 			</dependency>
 			<dependency>
+				<groupId>net.jodah</groupId>
+				<artifactId>failsafe</artifactId>
+				<version>1.0.4</version>
+			</dependency>
+			<dependency>
 				<groupId>net.sf.jpathwatch</groupId>
 				<artifactId>jpathwatch</artifactId>
 				<version>0.95</version>
@@ -796,7 +801,7 @@
 							<phase>test-compile</phase>
 							<configuration>
 								<rules>
-									<NoPackageCyclesRule implementation="de.andrena.tools.nopackagecycles.NoPackageCyclesRule" />
+									<NoPackageCyclesRule implementation="de.andrena.tools.nopackagecycles.NoPackageCyclesRule"></NoPackageCyclesRule>
 								</rules>
 							</configuration>
 						</execution>


### PR DESCRIPTION
This shoudl help in the case where a server or a backend becomes unresponsive.
The circuit breaker will open and no time will be wasted in trying to contact
a node that is down.

fixes #565.