### PR TITLE
567 - fix influx output writer to properly use typeNames 

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/KeyUtils.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/KeyUtils.java
@@ -74,6 +74,23 @@ public final class KeyUtils {
 		return sb.toString();
 	}
 
+	/**
+	 * Gets the key string, without rootPrefix or Alias
+	 *
+	 * @param query     the query
+	 * @param result    the result
+	 * @param values    the values
+	 * @param typeNames the type names
+	 * @param key       the base key name
+	 * @return the key string
+	 */
+	public static String getPrefixedKeyString(Query query, Result result, Map.Entry<String, Object> values, List<String> typeNames, String key) {
+		StringBuilder sb = new StringBuilder();
+		addTypeName(query, result, typeNames, sb);
+		sb.append(StringUtils.cleanupStr(key, query.isAllowDottedKeys()));
+		return sb.toString();
+	}
+
 	private static void addRootPrefix(String rootPrefix, StringBuilder sb) {
 		if (rootPrefix != null) {
 			sb.append(rootPrefix);

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -64,6 +64,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
 	private final boolean booleanAsNumber;
 	private final boolean createDatabase;
+	private final ImmutableList<String> typeNames;
 
 	/**
 	 * @param url      - The url e.g http://localhost:8086 to InfluxDB
@@ -84,6 +85,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 			@JsonProperty("retentionPolicy") String retentionPolicy,
 			@JsonProperty("resultTags") List<String> resultTags,
 			@JsonProperty("createDatabase") Boolean createDatabase) {
+		this.typeNames = typeNames;
 		this.booleanAsNumber = booleanAsNumber;
 		this.database = database;
 		this.createDatabase = firstNonNull(createDatabase, TRUE);
@@ -123,6 +125,6 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	@Override
 	public ResultTransformerOutputWriter<InfluxDbWriter> create() {
 		return ResultTransformerOutputWriter.booleanToNumber(booleanAsNumber, new InfluxDbWriter(influxDB, database,
-				writeConsistency, retentionPolicy, tags, resultAttributesToWriteAsTags, createDatabase));
+				writeConsistency, retentionPolicy, tags, resultAttributesToWriteAsTags, typeNames, createDatabase));
 	}
 }


### PR DESCRIPTION
Currently when using wildcards with influxdb output writer it does not use the specified typeNames at all, which causes non-unique names and errors.   Update to use typeNames properly, they are prepended to the key name to make a unique key.