### PR TITLE
Change default log level to INFO

### DIFF
--- a/jmxtrans/src/deb/control/postinst
+++ b/jmxtrans/src/deb/control/postinst
@@ -72,7 +72,7 @@ case "$1" in
             echo "export SECONDS_BETWEEN_RUNS=60" >> "$CONFIG"
             echo "export JSON_DIR=\"/var/lib/jmxtrans\"" >> "$CONFIG"
             echo "export HEAP_SIZE=${HEAP_SIZE}" >> "$CONFIG"
-            echo "export LOG_LEVEL=debug" >> "$CONFIG"
+            echo "export LOG_LEVEL=info" >> "$CONFIG"
             echo "export JAR_FILE=/usr/share/jmxtrans/lib/jmxtrans-all.jar" >> "$CONFIG"
         fi
 


### PR DESCRIPTION
On Ubuntu/Debian, the default log level is DEBUG, which I think is too verbose. Most user don't need debug level, and if needed it's easy to change the default on their setup.
My log file is about 700Mb per day (I don't monitor lots of metrics - about 26 metrics, but I do it every 10 seconds).

This PR change the default on .deb package from DEBUG to INFO.
Note: .rpm package are already at info level