### PR TITLE
Add purge of old logs file

### DIFF
--- a/jmxtrans/cron.daily/jmxtrans
+++ b/jmxtrans/cron.daily/jmxtrans
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+find /var/log/jmxtrans -type f -mtime +32 -name "jmxtrans-*.log.gz" -print0 | xargs -0 rm -f

--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -393,6 +393,14 @@
 									</sources>
 								</mapping>
 								<mapping>
+									<directory>${package.install.dir}/tools</directory>
+									<sources>
+										<source>
+											<location>${project.basedir}/tools</location>
+										</source>
+									</sources>
+								</mapping>
+								<mapping>
 									<directory>/usr/bin</directory>
 									<directoryIncluded>false</directoryIncluded>
 									<filemode>755</filemode>
@@ -405,12 +413,13 @@
 									</sources>
 								</mapping>
 								<mapping>
-									<directory>/etc/${package.daemon.name}</directory>
+									<directory>/etc/cron.daily</directory>
 									<configuration>true</configuration>
+									<filemode>755</filemode>
 									<sources>
-										<softlinkSource>
-											<location>${package.install.dir}/etc</location>
-										</softlinkSource>
+										<source>
+											<location>${project.basedir}/cron.daily</location>
+										</source>
 									</sources>
 								</mapping>
 								<mapping>
@@ -483,6 +492,18 @@
 											<mapper>
 												<type>perm</type>
 												<prefix>/etc/init.d</prefix>
+												<filemode>755</filemode>
+												<user>root</user>
+												<group>root</group>
+											</mapper>
+										</data>
+										<data>
+											<src>${project.basedir}/cron.daily</src>
+											<type>directory</type>
+											<excludes>.DS_Store</excludes>
+											<mapper>
+												<type>perm</type>
+												<prefix>/etc/cron.daily</prefix>
 												<filemode>755</filemode>
 												<user>root</user>
 												<group>root</group>


### PR DESCRIPTION
It seems that currently nothing purge old logs file. Which means that after a while a lots of files may be present in /var/log/jmxtrans and consume disk space.

I'm not sure logs older that few weeks are still useful.

The PR add a daily cron script that remove all archived logs older than 32 days.