### PR TITLE
Fix tests on Windows

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/SensuWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/SensuWriter2Test.java
@@ -42,13 +42,13 @@ public class SensuWriter2Test {
 		SensuWriter2 sensuWriter = new SensuWriter2(new GraphiteWriter2(ImmutableList.<String>of(), null), new JsonFactory());
 
 		sensuWriter.write(writer, ServerFixtures.dummyServer(), QueryFixtures.dummyQuery(), ResultFixtures.dummyResults());
-
+		String lineSep = System.lineSeparator();
 		assertThat(writer.toString()).isEqualTo(
-				"{\n" +
-				"  \"name\" : \"jmxtrans\",\n" +
-				"  \"type\" : \"metric\",\n" +
-				"  \"handler\" : \"graphite\",\n" +
-				"  \"output\" : \"host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount 10 0\\n\"\n" +
+				"{" + lineSep +
+				"  \"name\" : \"jmxtrans\"," + lineSep +
+				"  \"type\" : \"metric\"," + lineSep +
+				"  \"handler\" : \"graphite\"," + lineSep +
+				"  \"output\" : \"host_example_net_4321.MemoryAlias.ObjectPendingFinalizationCount 10 0\\n\"" + lineSep +
 				"}");
 	}
 

--- a/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/MonitorableApp.java
+++ b/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/MonitorableApp.java
@@ -28,6 +28,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.rules.ExternalResource;
 
 import javax.annotation.Nullable;
+import java.io.File;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -61,14 +63,18 @@ public class MonitorableApp extends ExternalResource {
 		ClassLoader cl = ClassLoader.getSystemClassLoader();
 		URL[] urls = ((URLClassLoader)cl).getURLs();
 
-		return  Joiner.on(":")
+		return  Joiner.on(File.pathSeparator)
 				.join(
 						from(asList(urls))
 								.transform(new Function<URL, String>() {
 									@Nullable
 									@Override
 									public String apply(URL input) {
-										return input.toString();
+										try {
+											return new File(input.toURI()).getPath();
+										} catch(URISyntaxException e) {
+											return input.getPath();
+										}
 									}
 								}));
 	}


### PR DESCRIPTION
Build fails on Windows due to differences with:
* File path separator and file separator
```
Running com.googlecode.jmxtrans.JmxTransformerIT
Erreur : impossible de trouver ou charger la classe principale com.googlecode.jmxtrans.test.DummyApp
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 7.135 sec <<< FAILURE! - in com.googlecode.jmxtrans.JmxTransformerIT
metricsAreSentToStdout(com.googlecode.jmxtrans.JmxTransformerIT)  Time elapsed: 7.135 sec  <<< ERROR!
com.jayway.awaitility.core.ConditionTimeoutException: Condition returned by method "hasLineContaining" in class com.googlecode.jmxtrans.test.OutputCapture was not fulfilled within 5 seconds.
        at com.googlecode.jmxtrans.JmxTransformerIT.metricsAreSentToStdout(JmxTransformerIT.java:67)


Results :

Tests in error:
  JmxTransformerIT.metricsAreSentToStdout:67 ▒ ConditionTimeout Condition return...
```
* Line separator
