### PR TITLE
InfluxDb output : allowing to report JMX port as a tag

### DIFF
--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 
 public class InfluxDbWriterFactory implements OutputWriterFactory {
@@ -63,6 +64,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
 	private final boolean booleanAsNumber;
 	private final boolean createDatabase;
+	private final boolean reportJmxPortAsTag;
 	private final ImmutableList<String> typeNames;
 
 	/**
@@ -83,7 +85,8 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 			@JsonProperty("writeConsistency") String writeConsistency,
 			@JsonProperty("retentionPolicy") String retentionPolicy,
 			@JsonProperty("resultTags") List<String> resultTags,
-			@JsonProperty("createDatabase") Boolean createDatabase) {
+			@JsonProperty("createDatabase") Boolean createDatabase,
+			@JsonProperty("reportJmxPortAsTag") Boolean reportJmxPortAsTag) {
 		this.typeNames = typeNames;
 		this.booleanAsNumber = booleanAsNumber;
 		this.database = database;
@@ -99,6 +102,8 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 		LOG.debug("Connecting to url: {} as: username: {}", url, username);
 
 		influxDB = InfluxDBFactory.connect(url, username, password);
+
+		this.reportJmxPortAsTag = firstNonNull(reportJmxPortAsTag, FALSE);
 	}
 
 
@@ -120,6 +125,6 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	@Override
 	public ResultTransformerOutputWriter<InfluxDbWriter> create() {
 		return ResultTransformerOutputWriter.booleanToNumber(booleanAsNumber, new InfluxDbWriter(influxDB, database,
-				writeConsistency, retentionPolicy, tags, resultAttributesToWriteAsTags, typeNames, createDatabase));
+				writeConsistency, retentionPolicy, tags, resultAttributesToWriteAsTags, typeNames, createDatabase, reportJmxPortAsTag));
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
@@ -33,8 +33,6 @@ import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.ResultAttribute;
 import com.googlecode.jmxtrans.model.ResultAttributes;
 import com.googlecode.jmxtrans.util.ProcessConfigUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.WordUtils;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDB.ConsistencyLevel;
 import org.influxdb.dto.BatchPoints;
@@ -45,20 +43,28 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.verification.VerificationMode;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
-import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static com.googlecode.jmxtrans.model.ServerFixtures.DEFAULT_PORT;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static com.googlecode.jmxtrans.model.output.InfluxDbWriter.JMX_PORT_KEY;
 import static com.googlecode.jmxtrans.model.output.InfluxDbWriter.TAG_HOSTNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link InfluxDbWriter}.
@@ -89,19 +95,16 @@ public class InfluxDbWriterTests {
 
 	@Test
 	public void pointsAreWrittenToInfluxDb() throws Exception {
-		InfluxDbWriter writer = getTestInfluxDbWriterWithDefaultSettings();
-		writer.doWrite(dummyServer(), dummyQuery(), results);
+		BatchPoints batchPoints = writeToInfluxDb(getTestInfluxDbWriterWithDefaultSettings());
 
-		verify(influxDB).write(messageCaptor.capture());
-		BatchPoints batchPoints = messageCaptor.getValue();
-
+		// The database name is present
 		assertThat(batchPoints.getDatabase()).isEqualTo(DATABASE_NAME);
 
 		// Point only exposes its state via a line protocol so we have to
 		// make assertions against this.
 		// Format is:
 		// measurement,<comma separated key=val tags>" " <comma separated
-		// key=val fields>
+		// key=val fields>" "time
 		Map<String, String> expectedTags = new TreeMap<String, String>();
 		expectedTags.put(ResultAttributes.ATTRIBUTE_NAME.getName() , result.getAttributeName());
 		expectedTags.put(ResultAttributes.CLASS_NAME.getName(), result.getClassName());
@@ -114,70 +117,28 @@ public class InfluxDbWriterTests {
 		assertThat(points).hasSize(1);
 
 		Point point = points.get(0);
-		String pointLineProtocol = point.lineProtocol();
-		assertThat(pointLineProtocol).startsWith(lineProtocol);
-		// JMX port is written as field by default :
-		// cf Point.lineProtocol() : there is a space after the tags and one after the fields
-		String[] split = pointLineProtocol.split(" ");
-		assertThat(split).hasSize(3);
-		assertThat(split[1]).contains(JMX_PORT_KEY + "=" + DEFAULT_PORT);
-	}
-
-	@Test
-	public void emptyCustomTagsDoesntBotherWrite() throws Exception {
-		InfluxDbWriter writer = getTestInfluxDbWriterWithDefaultSettings();
-		writer.doWrite(dummyServer(), dummyQuery(), results);
-		verify(influxDB).write(messageCaptor.capture());
-		BatchPoints batchPoints = messageCaptor.getValue();
-
-		assertThat(batchPoints.getDatabase()).isEqualTo(DATABASE_NAME);
-		List<Point> points = batchPoints.getPoints();
-		assertThat(points).hasSize(1);
+		assertThat(point.lineProtocol()).startsWith(lineProtocol);
 	}
 
 	@Test
 	public void customTagsAreWrittenToDb() throws Exception {
 		ImmutableMap<String, String> tags = ImmutableMap.of("customTag", "customValue");
-		InfluxDbWriter writer = getTestInfluxDbWriterWithCustomTags(tags);
-		writer.doWrite(dummyServer(), dummyQuery(), results);
-
-		verify(influxDB).write(messageCaptor.capture());
-		BatchPoints batchPoints = messageCaptor.getValue();
-
-		assertThat(batchPoints.getDatabase()).isEqualTo(DATABASE_NAME);
-		List<Point> points = batchPoints.getPoints();
-		assertThat(points).hasSize(1);
-
-		Point point = points.get(0);
-		assertThat(point.lineProtocol()).contains("customTag=customValue");
+		BatchPoints batchPoints = writeToInfluxDb(getTestInfluxDbWriterWithCustomTags(tags));
+		assertThat(batchPoints.getPoints().get(0).lineProtocol()).contains("customTag=customValue");
 	}
 
 	@Test
 	public void attributeNameIncludesTypeNames() throws Exception {
 		ImmutableList<String> typeNames = ImmutableList.of("name");
-		InfluxDbWriter writer = getTestInfluxDbWriterWithTypeNames(typeNames);
-		writer.doWrite(dummyServer(), dummyQuery(), results);
-
-		verify(influxDB).write(messageCaptor.capture());
-		BatchPoints batchPoints = messageCaptor.getValue();
-
-		assertThat(batchPoints.getDatabase()).isEqualTo(DATABASE_NAME);
-		List<Point> points = batchPoints.getPoints();
-		assertThat(points).hasSize(1);
-
-		Point point = points.get(0);
-		assertThat(point.lineProtocol()).contains("name.attributeName_key");
+		BatchPoints batchPoints = writeToInfluxDb(getTestInfluxDbWriterWithTypeNames(typeNames));
+		assertThat(batchPoints.getPoints().get(0).lineProtocol()).contains("name.attributeName_key");
 	}
 
 	@Test
 	public void writeConsistencyLevelsAreAppliedToBatchPointsBeingWritten() throws Exception {
 		for (ConsistencyLevel consistencyLevel : ConsistencyLevel.values()) {
-			InfluxDbWriter writer = getTestInfluxDbWriterWithWriteConsistency(consistencyLevel);
-
-			writer.doWrite(dummyServer(), dummyQuery(), results);
-
-			verify(influxDB, atLeastOnce()).write(messageCaptor.capture());
-			BatchPoints batchPoints = messageCaptor.getValue();
+			BatchPoints batchPoints = writeAtLeastOnceToInfluxDb(
+					getTestInfluxDbWriterWithWriteConsistency(consistencyLevel));
 			assertThat(batchPoints.getConsistency()).isEqualTo(consistencyLevel);
 		}
 	}
@@ -186,11 +147,7 @@ public class InfluxDbWriterTests {
 	public void onlyRequestedResultPropertiesAreAppliedAsTags() throws Exception {
 		for (ResultAttribute expectedResultTag : ResultAttributes.values()) {
 			ImmutableSet<ResultAttribute> expectedResultTags = ImmutableSet.of(expectedResultTag);
-			InfluxDbWriter writer = getTestInfluxDbWriterWithResultTags(expectedResultTags);
-			writer.doWrite(dummyServer(), dummyQuery(), results);
-
-			verify(influxDB, atLeastOnce()).write(messageCaptor.capture());
-			BatchPoints batchPoints = messageCaptor.getValue();
+			BatchPoints batchPoints = writeAtLeastOnceToInfluxDb(getTestInfluxDbWriterWithResultTags(expectedResultTags));
 			String lineProtocol = batchPoints.getPoints().get(0).lineProtocol();
 
 			assertThat(lineProtocol).contains(expectedResultTag.getName()+"=");
@@ -204,39 +161,39 @@ public class InfluxDbWriterTests {
 
 	@Test
 	public void databaseIsCreated() throws Exception {
-		InfluxDbWriter writer = getTestInfluxDbWriterWithDefaultSettings();
-		writer.doWrite(dummyServer(), dummyQuery(), results);
-
+		writeToInfluxDb(getTestInfluxDbWriterWithDefaultSettings());
 		verify(influxDB).createDatabase(DATABASE_NAME);
 	}
 
 	@Test
 	public void databaseIsNotCreated() throws Exception {
-		InfluxDbWriter writer = getTestInfluxDbWriterNoDatabaseCreation();
-		writer.doWrite(dummyServer(), dummyQuery(), results);
-
+		writeToInfluxDb(getTestInfluxDbWriterNoDatabaseCreation());
 		verify(influxDB, never()).createDatabase(anyString());
 	}
 
 	@Test
+	public void jmxPortIsReportedAsFieldByDefault() throws Exception {
+		BatchPoints batchPoints = writeToInfluxDb(getTestInfluxDbWriterWithDefaultSettings());
+		verifyJMXPortOnlyInToken(batchPoints.getPoints().get(0).lineProtocol(), 1 /*Fields token*/);
+	}
+
+	@Test
 	public void jmxPortIsReportedAsTag() throws Exception {
-		InfluxDbWriter writer = getTestInfluxDbWriterWithReportJmxPortAsTag();
-		writer.doWrite(dummyServer(), dummyQuery(), results);
+		BatchPoints batchPoints = writeToInfluxDb(getTestInfluxDbWriterWithReportJmxPortAsTag());
+		verifyJMXPortOnlyInToken(batchPoints.getPoints().get(0).lineProtocol(), 0 /*Tags token*/);
+	}
 
-		verify(influxDB).write(messageCaptor.capture());
-		BatchPoints batchPoints = messageCaptor.getValue();
-
-		assertThat(batchPoints.getDatabase()).isEqualTo(DATABASE_NAME);
-		List<Point> points = batchPoints.getPoints();
-		assertThat(points).hasSize(1);
-
-		Point point = points.get(0);
-		// JMX port is written as tag :
-		// cf Point.lineProtocol() : there is a space after the tags and one after the fields
-		String[] split = point.lineProtocol().split(" ");
-		assertThat(split).hasSize(3);
-		assertThat(split[0]).contains(JMX_PORT_KEY + "=" + DEFAULT_PORT); // JMX port is a tag
-		assertThat(split[1]).doesNotContain(JMX_PORT_KEY); // JMX port is not a field
+	private void verifyJMXPortOnlyInToken(String lineProtocol, int tokenContainingJMXPort) {
+		// lineProtocol is from Point.lineProtocol() :
+		// The format is
+		//  measurement,<comma separated key=val tags>" " <comma separated key=val fields>" "time
+		// So splitted by space we have three tokens : the tags are in the first one ([0])
+		// and the fields are in the second one ([1])
+		// so we check between  the 0 and 1 indexes (tag and fields)
+		String[] protocolTokens = lineProtocol.split(" ");
+		assertThat(protocolTokens).hasSize(3);
+		assertThat(protocolTokens[tokenContainingJMXPort]).contains(JMX_PORT_KEY + "=" + DEFAULT_PORT);
+		assertThat(protocolTokens[1 - tokenContainingJMXPort]).doesNotContain(JMX_PORT_KEY);
 	}
 
 	@Test
@@ -246,6 +203,20 @@ public class InfluxDbWriterTests {
 		ProcessConfigUtils processConfigUtils = injector.getInstance(ProcessConfigUtils.class);
 		JmxProcess process = processConfigUtils.parseProcess(input);
 		assertThat(process.getName()).isEqualTo("influxDB.json");
+	}
+
+	private BatchPoints writeToInfluxDb(InfluxDbWriter writer) throws Exception {
+		return writeToInfluxDb(writer, times(1));
+	}
+
+	private BatchPoints writeAtLeastOnceToInfluxDb(InfluxDbWriter writer) throws Exception {
+		return writeToInfluxDb(writer, atLeastOnce());
+	}
+
+	private BatchPoints writeToInfluxDb(InfluxDbWriter writer, VerificationMode mode) throws Exception {
+		writer.doWrite(dummyServer(), dummyQuery(), results);
+		verify(influxDB, mode).write(messageCaptor.capture());
+		return messageCaptor.getValue();
 	}
 
 	private String buildLineProtocol(String measurement, Map<String, String> expectedTags) {

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/resources/influxDB.json
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/resources/influxDB.json
@@ -24,7 +24,9 @@
               		 "url": "http://localhost:8086",
               		 "resultTags":["typeName","className"],
               		 "retentionPolicy":"default",
-              		 "writeConsistency":"ALL"
+              		 "writeConsistency":"ALL",
+              		 "createDatabase":"false",
+              		 "reportJmxPortAsTag":"true"
                   }
                ]
             }


### PR DESCRIPTION
Add a property "reportJmxPortAsTag" to InfluxDbWriter allowing users to specify if the JMX port is written as a field (current and default behavior) or as a tag (cf. issue #371).
