### PR TITLE
InfluxDB Writer: Write tags for typeNames instead of prefixing the Field names

### DIFF
--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -180,12 +180,8 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 			for (Map.Entry<String, Object> values : resultValues.entrySet()) {
 				Object value = values.getValue();
 				if (isValidNumber(value)) {
-					String key;
-					if(typeNamesAsTags) {
-						key = KeyUtils.getPrefixedKeyString(query, result, values, Collections.<String>emptyList(), values.getKey());
-					} else {
-						key = KeyUtils.getPrefixedKeyString(query, result, values, typeNames, values.getKey());
-					}
+					typeNames = typeNamesAsTags ? typeNames : Collections.<String>emptyList();
+					String key = KeyUtils.getPrefixedKeyString(query, result, values, typeNames, values.getKey());
 					filteredValues.put(key, value);
 				}
 			}
@@ -213,7 +209,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 			resultAttribute.addAttribute(resultTagMap, result);
 		}
 
-		if(typeNamesAsTags) {
+		if (typeNamesAsTags) {
 			Map<String, String> typeNameValueMap = TypeNameValue.extractMap(resultTagMap.get("typeName"));
 			for (String typeToTag : this.typeNames) {
 				if (typeNameValueMap.containsKey(typeToTag)) {

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -179,7 +180,12 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 			for (Map.Entry<String, Object> values : resultValues.entrySet()) {
 				Object value = values.getValue();
 				if (isValidNumber(value)) {
-					String key = KeyUtils.getPrefixedKeyString(query, result, values, typeNames, values.getKey());
+					String key;
+					if(typeNamesAsTags) {
+						key = KeyUtils.getPrefixedKeyString(query, result, values, Collections.<String>emptyList(), values.getKey());
+					} else {
+						key = KeyUtils.getPrefixedKeyString(query, result, values, typeNames, values.getKey());
+					}
 					filteredValues.put(key, value);
 				}
 			}

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -201,6 +201,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 	}
 
 	private Map<String, String> buildResultTagMap(Result result) throws Exception {
+
 		Map<String, String> resultTagMap = new TreeMap<>();
 		for (ResultAttribute resultAttribute : resultAttributesToWriteAsTags) {
 			resultAttribute.addAttribute(resultTagMap, result);
@@ -216,6 +217,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 		}
 
 		return resultTagMap;
+
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -43,6 +43,7 @@ import java.util.List;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.lang.Boolean.TRUE;
+import static java.lang.Boolean.FALSE;
 
 public class InfluxDbWriterFactory implements OutputWriterFactory {
 
@@ -63,6 +64,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	private final InfluxDB influxDB;
 	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
 	private final boolean booleanAsNumber;
+	private final boolean typeNamesAsTags;
 	private final boolean createDatabase;
 	private final ImmutableList<String> typeNames;
 
@@ -84,10 +86,12 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 			@JsonProperty("writeConsistency") String writeConsistency,
 			@JsonProperty("retentionPolicy") String retentionPolicy,
 			@JsonProperty("resultTags") List<String> resultTags,
+			@JsonProperty("typeNamesAsTags") Boolean typeNamesAsTags,
 			@JsonProperty("createDatabase") Boolean createDatabase) {
 		this.typeNames = typeNames;
 		this.booleanAsNumber = booleanAsNumber;
 		this.database = database;
+		this.typeNamesAsTags = firstNonNull(typeNamesAsTags, FALSE);
 		this.createDatabase = firstNonNull(createDatabase, TRUE);
 
 		this.writeConsistency = StringUtils.isNotBlank(writeConsistency)
@@ -125,6 +129,6 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	@Override
 	public ResultTransformerOutputWriter<InfluxDbWriter> create() {
 		return ResultTransformerOutputWriter.booleanToNumber(booleanAsNumber, new InfluxDbWriter(influxDB, database,
-				writeConsistency, retentionPolicy, tags, resultAttributesToWriteAsTags, typeNames, createDatabase));
+				writeConsistency, retentionPolicy, tags, resultAttributesToWriteAsTags, typeNames, typeNamesAsTags, createDatabase));
 	}
 }


### PR DESCRIPTION
This change adds a boolean to the InfluxDB writer, typeNameAsTags

When true, the names in the typeNames array will be sent to influx as tags and the field name will remain the attributeName as if typeNames was not provided.

When false, the original behavior of typeNames continues to function.

The default value is false for compatibility.