### PR TITLE
Make typeName properties individually accessible

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Result.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Result.java
@@ -24,6 +24,7 @@ package com.googlecode.jmxtrans.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableMap;
+import com.googlecode.jmxtrans.model.naming.typename.TypeNameValue;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -38,7 +39,7 @@ import static com.google.common.collect.ImmutableMap.copyOf;
 
 /**
  * Represents the result of a query.
- * 
+ *
  * @author jon
  */
 @JsonSerialize(include = NON_NULL)
@@ -68,4 +69,10 @@ public class Result {
 		this.keyAlias = keyAlias;
 	}
 
+	/**
+	 * Get typeName split into a Map
+     */
+	public Map<String, String> getTypeNameMap() {
+		return TypeNameValue.extractMap(this.typeName);
+	}
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultAttribute.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultAttribute.java
@@ -22,61 +22,50 @@
  */
 package com.googlecode.jmxtrans.model;
 
+import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.ToString;
 import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Method;
 import java.util.Map;
 
-import static org.apache.commons.lang.StringUtils.capitalize;
-
 /**
- * Enumerates the attributes of {@link Result}
- * 
+ * Attributes of {@link Result}
+ *
  * @author Simon Hutchinson
  *         <a href="https://github.com/sihutch">github.com/sihutch</a>
  *
  */
 @ToString
-public enum ResultAttribute {
+public abstract class ResultAttribute {
 
-	TYPE_NAME("typeName"), OBJ_DOMAIN("objDomain"), CLASS_NAME("className"), ATTRIBUTE_NAME("attributeName");
-
+	/**
+	 * Attribute name in camel case
+	 */
+	@Getter
 	@Nonnull
 	private String attributeName;
-	@Nonnull
-	private String accessorMethod;
 
 	ResultAttribute(String attributeName) {
 		this.attributeName = attributeName;
-		this.accessorMethod = "get" + capitalize(attributeName);
 	}
 
 	/**
-	 * Get the {@link ResultAttribute} value from the attribute name
-	 * 
-	 * @param attributeName
-	 *            <p>The attribute name for the {@link ResultAttribute} allowed values are:</p>
-	 *            <ul>
-	 *            	<li>typeName</li>
-	 *              <li>objDomain</li>
-	 *              <li>className</li>
-	 *              <li>attributeName</li>
-	 *            </ul>
-	 * @return the {@link ResultAttribute}
-	 */
-	public static ResultAttribute fromAttribute(@Nonnull String attributeName) {
-		String[] split = StringUtils.splitByCharacterTypeCamelCase(attributeName);
-		StringBuilder sb = new StringBuilder(split[0].toUpperCase()).append("_").append(split[1].toUpperCase());
-		return valueOf(sb.toString());
+	 * Get attribute name in upper case snake case
+     */
+	public String name() {
+		String[] words = StringUtils.splitByCharacterTypeCamelCase(attributeName);
+		return StringUtils.join(words, "_").replaceAll("_\\._", ".").toUpperCase();
 	}
-
 	/**
-	 * Calls the Getter defined by the {@link ResultAttribute} on the
+	 * Get attribute on result
+     */
+	public abstract String getAttribute(Result result);
+	/**
+	 * Calls the Getter defined by the {@link #getAttribute(Result)} on the
 	 * {@link Result} add adds the entry to the supplied {@link Map}
-	 * 
+	 *
 	 * @param attributeMap
 	 *            The map to add the {@link Result} data to
 	 * @param result
@@ -85,7 +74,6 @@ public enum ResultAttribute {
 	// Reflection errors have been covered fully by tests
 	@SneakyThrows
 	public void addAttribute(@Nonnull Map<String, String> attributeMap, @Nonnull Result result) {
-		Method m = result.getClass().getMethod(accessorMethod);
-		attributeMap.put(attributeName, (String) m.invoke(result));
+		attributeMap.put(attributeName, getAttribute(result));
 	}
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultAttribute.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultAttribute.java
@@ -23,9 +23,7 @@
 package com.googlecode.jmxtrans.model;
 
 import lombok.Getter;
-import lombok.SneakyThrows;
 import lombok.ToString;
-import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
@@ -45,25 +43,19 @@ public abstract class ResultAttribute {
 	 */
 	@Getter
 	@Nonnull
-	private String attributeName;
+	private final String name;
 
-	ResultAttribute(String attributeName) {
-		this.attributeName = attributeName;
+	ResultAttribute(String name) {
+		this.name = name;
 	}
 
-	/**
-	 * Get attribute name in upper case snake case
-     */
-	public String name() {
-		String[] words = StringUtils.splitByCharacterTypeCamelCase(attributeName);
-		return StringUtils.join(words, "_").replaceAll("_\\._", ".").toUpperCase();
-	}
 	/**
 	 * Get attribute on result
      */
-	public abstract String getAttribute(Result result);
+	public abstract String get(Result result);
+
 	/**
-	 * Calls the Getter defined by the {@link #getAttribute(Result)} on the
+	 * Calls the Getter defined by the {@link #get(Result)} on the
 	 * {@link Result} add adds the entry to the supplied {@link Map}
 	 *
 	 * @param attributeMap
@@ -71,9 +63,7 @@ public abstract class ResultAttribute {
 	 * @param result
 	 *            The {@link Result} to get the data from
 	 */
-	// Reflection errors have been covered fully by tests
-	@SneakyThrows
-	public void addAttribute(@Nonnull Map<String, String> attributeMap, @Nonnull Result result) {
-		attributeMap.put(attributeName, getAttribute(result));
+	public void addTo(@Nonnull Map<String, String> attributeMap, @Nonnull Result result) {
+		attributeMap.put(name, get(result));
 	}
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultAttributes.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultAttributes.java
@@ -1,0 +1,164 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang.StringUtils;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Enumerates the attributes of {@link Result}
+ *
+ * @author Simon Hutchinson
+ *         <a href="https://github.com/sihutch">github.com/sihutch</a>
+ */
+public final class ResultAttributes {
+	private ResultAttributes() {
+	}
+
+	public static final ResultAttribute TYPE_NAME = new ResultAttribute("typeName") {
+		@Override
+		public String getAttribute(Result result) {
+			return result.getTypeName();
+		}
+	};
+
+	public static final ResultAttribute OBJ_DOMAIN = new ResultAttribute("objDomain") {
+		@Override
+		public String getAttribute(Result result) {
+			return result.getObjDomain();
+		}
+	};
+
+	public static final ResultAttribute CLASS_NAME = new ResultAttribute("className") {
+		@Override
+		public String getAttribute(Result result) {
+			return result.getClassName();
+		}
+	};
+
+	public static final ResultAttribute ATTRIBUTE_NAME = new ResultAttribute("attributeName") {
+		@Override
+		public String getAttribute(Result result) {
+			return result.getAttributeName();
+		}
+	};
+
+	/**
+	 * Implementation of {@link ResultAttribute} to lookup type name properties
+	 */
+	private static final class TypeNameProperty extends ResultAttribute {
+		private static final String PREFIX = "typeName.";
+		private final String propertyName;
+
+		private TypeNameProperty(String propertyName) {
+			super(PREFIX + propertyName);
+			this.propertyName = propertyName;
+		}
+
+		@Override
+		public String getAttribute(Result result) {
+			return result.getTypeNameMap().get(propertyName);
+		}
+	}
+
+	/**
+	 * Get the {@link ResultAttributes} value from the attribute name
+	 *
+	 * @param attributeName <p>The attribute name for the {@link ResultAttribute} allowed values are:</p>
+	 *                      <ul>
+	 *                      <li>typeName</li>
+	 *                      <li>objDomain</li>
+	 *                      <li>className</li>
+	 *                      <li>attributeName</li>
+	 *                      </ul>
+	 * @return the {@link ResultAttribute}
+	 */
+	public static ResultAttribute fromAttribute(@Nonnull String attributeName) {
+		if (attributeName.startsWith(TypeNameProperty.PREFIX)) {
+			return new TypeNameProperty(attributeName.substring(TypeNameProperty.PREFIX.length()));
+		}
+		String[] split = StringUtils.splitByCharacterTypeCamelCase(attributeName);
+		StringBuilder sb = new StringBuilder(split[0].toUpperCase()).append("_").append(split[1].toUpperCase());
+		return valueOf(sb.toString());
+	}
+
+	/**
+	 * Get the {@link ResultAttributes} value for each attribute name.
+	 *
+	 * @return Set of {@link ResultAttribute}
+	 * @see #fromAttribute(String)
+	 */
+	public static ImmutableSet<ResultAttribute> fromAttributes(@Nonnull Collection<String> attributeNames) {
+		Set<ResultAttribute> set = new HashSet<ResultAttribute>(attributeNames.size());
+		for (String attributeName : attributeNames) {
+			set.add(fromAttribute(attributeName));
+		}
+		return ImmutableSet.copyOf(set);
+	}
+
+	/**
+	 * Get {@link ResultAttribute}s by its constant name
+	 *
+	 * @param attributeName <p>The attribute name for the {@link ResultAttribute} allowed values are:</p>
+	 *                      <ul>
+	 *                      <li>TYPE_NAME</li>
+	 *                      <li>OBJ_DOMAIN</li>
+	 *                      <li>CLASS_NAME</li>
+	 *                      <li>ATTRIBUTE_NAME</li>
+	 *                      </ul>
+	 */
+	public static ResultAttribute valueOf(@Nonnull String attributeName) {
+		ResultAttribute value;
+		switch (attributeName) {
+			case "TYPE_NAME":
+				value = TYPE_NAME;
+				break;
+			case "OBJ_DOMAIN":
+				value = OBJ_DOMAIN;
+				break;
+			case "CLASS_NAME":
+				value = CLASS_NAME;
+				break;
+			case "ATTRIBUTE_NAME":
+				value = ATTRIBUTE_NAME;
+				break;
+			default:
+				throw new IllegalArgumentException("Invalid value " + attributeName);
+		}
+		return value;
+	}
+
+	/**
+	 * Get known {@link ResultAttribute}s as if it was an enumeration
+	 */
+	public static List<ResultAttribute> values() {
+		return Arrays.asList(TYPE_NAME, OBJ_DOMAIN, CLASS_NAME, ATTRIBUTE_NAME);
+	}
+}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultAttributes.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultAttributes.java
@@ -28,9 +28,8 @@ import org.apache.commons.lang.StringUtils;
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+
 
 /**
  * Enumerates the attributes of {@link Result}
@@ -44,28 +43,28 @@ public final class ResultAttributes {
 
 	public static final ResultAttribute TYPE_NAME = new ResultAttribute("typeName") {
 		@Override
-		public String getAttribute(Result result) {
+		public String get(Result result) {
 			return result.getTypeName();
 		}
 	};
 
 	public static final ResultAttribute OBJ_DOMAIN = new ResultAttribute("objDomain") {
 		@Override
-		public String getAttribute(Result result) {
+		public String get(Result result) {
 			return result.getObjDomain();
 		}
 	};
 
 	public static final ResultAttribute CLASS_NAME = new ResultAttribute("className") {
 		@Override
-		public String getAttribute(Result result) {
+		public String get(Result result) {
 			return result.getClassName();
 		}
 	};
 
 	public static final ResultAttribute ATTRIBUTE_NAME = new ResultAttribute("attributeName") {
 		@Override
-		public String getAttribute(Result result) {
+		public String get(Result result) {
 			return result.getAttributeName();
 		}
 	};
@@ -83,7 +82,7 @@ public final class ResultAttributes {
 		}
 
 		@Override
-		public String getAttribute(Result result) {
+		public String get(Result result) {
 			return result.getTypeNameMap().get(propertyName);
 		}
 	}
@@ -100,7 +99,7 @@ public final class ResultAttributes {
 	 *                      </ul>
 	 * @return the {@link ResultAttribute}
 	 */
-	public static ResultAttribute fromAttribute(@Nonnull String attributeName) {
+	public static ResultAttribute forName(@Nonnull String attributeName) {
 		if (attributeName.startsWith(TypeNameProperty.PREFIX)) {
 			return new TypeNameProperty(attributeName.substring(TypeNameProperty.PREFIX.length()));
 		}
@@ -113,14 +112,14 @@ public final class ResultAttributes {
 	 * Get the {@link ResultAttributes} value for each attribute name.
 	 *
 	 * @return Set of {@link ResultAttribute}
-	 * @see #fromAttribute(String)
+	 * @see #forName(String)
 	 */
-	public static ImmutableSet<ResultAttribute> fromAttributes(@Nonnull Collection<String> attributeNames) {
-		Set<ResultAttribute> set = new HashSet<ResultAttribute>(attributeNames.size());
+	public static ImmutableSet<ResultAttribute> forNames(@Nonnull Collection<String> attributeNames) {
+		ImmutableSet.Builder<ResultAttribute> builder = ImmutableSet.<ResultAttribute>builder();
 		for (String attributeName : attributeNames) {
-			set.add(fromAttribute(attributeName));
+			builder.add(forName(attributeName));
 		}
-		return ImmutableSet.copyOf(set);
+		return builder.build();
 	}
 
 	/**

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ResultAttributeTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ResultAttributeTests.java
@@ -29,7 +29,6 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,8 +58,8 @@ public class ResultAttributeTests {
 	@Test
 	public void attributeNamesFromResultAreWrittenToMap() throws Exception {
 		for (ResultAttribute resultAttribute : ResultAttributes.values()) {
-			resultAttribute.addAttribute(attributeMap, result);
-			String attributeName = enumValueToAttribute(resultAttribute);
+			resultAttribute.addTo(attributeMap, result);
+			String attributeName = resultAttribute.getName();
 			Method m = result.getClass().getMethod("get" + WordUtils.capitalize(attributeName));
 			String expectedValue = (String) m.invoke(result);
 			assertThat(attributeMap).containsEntry(attributeName, expectedValue);
@@ -69,31 +68,26 @@ public class ResultAttributeTests {
 
 	@Test
 	public void typeNamePropertyResultAttribute() {
-		ResultAttribute typeAttr = ResultAttributes.fromAttribute("typeName.type");
-		assertThat(typeAttr.name()).isEqualTo("TYPE_NAME.TYPE");
-		String type = typeAttr.getAttribute(result);
+		ResultAttribute typeAttr = ResultAttributes.forName("typeName.type");
+		assertThat(typeAttr.getName()).isEqualTo("typeName.type");
+		String type = typeAttr.get(result);
 		assertThat(type).isEqualTo("Type1");
 
-		ResultAttribute nameAttr = ResultAttributes.fromAttribute("typeName.name");
-		assertThat(nameAttr.name()).isEqualTo("TYPE_NAME.NAME");
-		String name = nameAttr.getAttribute(result);
+		ResultAttribute nameAttr = ResultAttributes.forName("typeName.name");
+		assertThat(nameAttr.getName()).isEqualTo("typeName.name");
+		String name = nameAttr.get(result);
 		assertThat(name).isEqualTo("Name1");
 
-		ResultAttribute notExistAttr = ResultAttributes.fromAttribute("typeName.notExist");
-		assertThat(notExistAttr.name()).isEqualTo("TYPE_NAME.NOT_EXIST");
-		String notExist = notExistAttr.getAttribute(result);
+		ResultAttribute notExistAttr = ResultAttributes.forName("typeName.notExist");
+		assertThat(notExistAttr.getName()).isEqualTo("typeName.notExist");
+		String notExist = notExistAttr.get(result);
 		assertThat(notExist).isNull();
 
 		try {
-			ResultAttributes.fromAttribute("notExist");
+			ResultAttributes.forName("notExist");
 			fail("Exception expected");
 		} catch (IllegalArgumentException e) {
 
 		}
-	}
-
-	private String enumValueToAttribute(ResultAttribute attribute) {
-		String[] split = attribute.name().split("_");
-		return StringUtils.lowerCase(split[0]) + WordUtils.capitalizeFully(split[1]);
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterFactory.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.ResultAttribute;
+import com.googlecode.jmxtrans.model.ResultAttributes;
 import com.googlecode.jmxtrans.model.output.support.UdpOutputWriterBuilder;
 import com.googlecode.jmxtrans.model.output.support.WriterPoolOutputWriter;
 import com.googlecode.jmxtrans.model.output.support.pool.FlushStrategy;
@@ -39,13 +40,11 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.net.InetSocketAddress;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.collect.Sets.immutableEnumSet;
 import static com.googlecode.jmxtrans.model.output.support.pool.FlushStrategyUtils.createFlushStrategy;
 
 @EqualsAndHashCode
@@ -98,16 +97,12 @@ public class StatsDTelegrafWriterFactory implements OutputWriterFactory {
 	 * @return
 	 */
 	private ImmutableSet<ResultAttribute> initResultAttributesToWriteAsTags(List<String> resultTags) {
-		EnumSet<ResultAttribute> resultAttributes = EnumSet.noneOf(ResultAttribute.class);
-		if (resultTags != null) {
-			for (String resultTag : resultTags) {
-				resultAttributes.add(ResultAttribute.fromAttribute(resultTag));
-			}
+		ImmutableSet<ResultAttribute> result;
+		if (resultTags == null) {
+			result = ImmutableSet.copyOf(ResultAttributes.values());
 		} else {
-			resultAttributes = EnumSet.allOf(ResultAttribute.class);
+			result = ResultAttributes.fromAttributes(resultTags);
 		}
-
-		ImmutableSet<ResultAttribute> result = immutableEnumSet(resultAttributes);
 		LOG.debug("Result Tags to write set to: {}", result);
 		return result;
 	}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDTelegrafWriterFactory.java
@@ -101,7 +101,7 @@ public class StatsDTelegrafWriterFactory implements OutputWriterFactory {
 		if (resultTags == null) {
 			result = ImmutableSet.copyOf(ResultAttributes.values());
 		} else {
-			result = ResultAttributes.fromAttributes(resultTags);
+			result = ResultAttributes.forNames(resultTags);
 		}
 		LOG.debug("Result Tags to write set to: {}", result);
 		return result;

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -200,7 +200,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 
 		Map<String, String> resultTagMap = new TreeMap<>();
 		for (ResultAttribute resultAttribute : resultAttributesToWriteAsTags) {
-			resultAttribute.addAttribute(resultTagMap, result);
+			resultAttribute.addTo(resultTagMap, result);
 		}
 
 		return resultTagMap;

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.ResultAttribute;
+import com.googlecode.jmxtrans.model.ResultAttributes;
 import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter;
 import org.apache.commons.lang.StringUtils;
 import org.influxdb.InfluxDB;
@@ -37,11 +38,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.collect.Sets.immutableEnumSet;
 import static java.lang.Boolean.TRUE;
 
 public class InfluxDbWriterFactory implements OutputWriterFactory {
@@ -108,16 +107,12 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	}
 
 	private ImmutableSet<ResultAttribute> initResultAttributesToWriteAsTags(List<String> resultTags) {
-		EnumSet<ResultAttribute> resultAttributes = EnumSet.noneOf(ResultAttribute.class);
-		if (resultTags != null) {
-			for (String resultTag : resultTags) {
-				resultAttributes.add(ResultAttribute.fromAttribute(resultTag));
-			}
+		ImmutableSet<ResultAttribute> result;
+		if (resultTags == null) {
+			result = ImmutableSet.copyOf(ResultAttributes.values());
 		} else {
-			resultAttributes = EnumSet.allOf(ResultAttribute.class);
+			result = ResultAttributes.fromAttributes(resultTags);
 		}
-
-		ImmutableSet<ResultAttribute> result = immutableEnumSet(resultAttributes);
 		LOG.debug("Result Tags to write set to: {}", result);
 		return result;
 	}

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -111,7 +111,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 		if (resultTags == null) {
 			result = ImmutableSet.copyOf(ResultAttributes.values());
 		} else {
-			result = ResultAttributes.fromAttributes(resultTags);
+			result = ResultAttributes.forNames(resultTags);
 		}
 		LOG.debug("Result Tags to write set to: {}", result);
 		return result;

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
@@ -31,7 +31,7 @@ import com.googlecode.jmxtrans.guice.JmxTransModule;
 import com.googlecode.jmxtrans.model.JmxProcess;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.ResultAttribute;
-
+import com.googlecode.jmxtrans.model.ResultAttributes;
 import com.googlecode.jmxtrans.util.ProcessConfigUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
@@ -49,20 +49,14 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
-import static com.google.common.collect.Sets.immutableEnumSet;
 import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
 import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static com.googlecode.jmxtrans.model.output.InfluxDbWriter.TAG_HOSTNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link InfluxDbWriter}.
@@ -85,7 +79,7 @@ public class InfluxDbWriterTests {
 
 	private static final ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL = ConsistencyLevel.ALL;
 	private static final String DEFAULT_RETENTION_POLICY = "default";
-	private static final ImmutableSet<ResultAttribute> DEFAULT_RESULT_ATTRIBUTES = immutableEnumSet(EnumSet.allOf(ResultAttribute.class));
+	private static final ImmutableSet<ResultAttribute> DEFAULT_RESULT_ATTRIBUTES = ImmutableSet.copyOf(ResultAttributes.values());
 
 	Result result = new Result(2l, "attributeName", "className", "objDomain", "keyAlias", "type=test,name=name",
 			ImmutableMap.of("key", (Object) 1));
@@ -107,9 +101,9 @@ public class InfluxDbWriterTests {
 		// measurement,<comma separated key=val tags>" " <comma separated
 		// key=val fields>
 		Map<String, String> expectedTags = new TreeMap<String, String>();
-		expectedTags.put(enumValueToAttribute(ResultAttribute.ATTRIBUTE_NAME), result.getAttributeName());
-		expectedTags.put(enumValueToAttribute(ResultAttribute.CLASS_NAME), result.getClassName());
-		expectedTags.put(enumValueToAttribute(ResultAttribute.OBJ_DOMAIN), result.getObjDomain());
+		expectedTags.put(enumValueToAttribute(ResultAttributes.ATTRIBUTE_NAME), result.getAttributeName());
+		expectedTags.put(enumValueToAttribute(ResultAttributes.CLASS_NAME), result.getClassName());
+		expectedTags.put(enumValueToAttribute(ResultAttributes.OBJ_DOMAIN), result.getObjDomain());
 		expectedTags.put(TAG_HOSTNAME, HOST);
 		String lineProtocol = buildLineProtocol(result.getKeyAlias(), expectedTags);
 
@@ -181,7 +175,7 @@ public class InfluxDbWriterTests {
 
 	@Test
 	public void onlyRequestedResultPropertiesAreAppliedAsTags() throws Exception {
-		for (ResultAttribute expectedResultTag : ResultAttribute.values()) {
+		for (ResultAttribute expectedResultTag : ResultAttributes.values()) {
 			ImmutableSet<ResultAttribute> expectedResultTags = ImmutableSet.of(expectedResultTag);
 			InfluxDbWriter writer = getTestInfluxDbWriterWithResultTags(expectedResultTags);
 			writer.doWrite(dummyServer(), dummyQuery(), results);
@@ -191,7 +185,8 @@ public class InfluxDbWriterTests {
 			String lineProtocol = batchPoints.getPoints().get(0).lineProtocol();
 
 			assertThat(lineProtocol).contains(enumValueToAttribute(expectedResultTag));
-			EnumSet<ResultAttribute> unexpectedResultTags = EnumSet.complementOf(EnumSet.of(expectedResultTag));
+			Set<ResultAttribute> unexpectedResultTags = new HashSet<ResultAttribute>(ResultAttributes.values());
+			unexpectedResultTags.remove(expectedResultTag);
 			for (ResultAttribute unexpectedResultTag : unexpectedResultTags) {
 				assertThat(lineProtocol).doesNotContain(enumValueToAttribute(unexpectedResultTag));
 			}

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
@@ -101,9 +101,10 @@ public class InfluxDbWriterTests {
 		// measurement,<comma separated key=val tags>" " <comma separated
 		// key=val fields>
 		Map<String, String> expectedTags = new TreeMap<String, String>();
-		expectedTags.put(enumValueToAttribute(ResultAttributes.ATTRIBUTE_NAME), result.getAttributeName());
-		expectedTags.put(enumValueToAttribute(ResultAttributes.CLASS_NAME), result.getClassName());
-		expectedTags.put(enumValueToAttribute(ResultAttributes.OBJ_DOMAIN), result.getObjDomain());
+		expectedTags.put(ResultAttributes.ATTRIBUTE_NAME.getName() , result.getAttributeName());
+		expectedTags.put(ResultAttributes.CLASS_NAME.getName(), result.getClassName());
+		expectedTags.put(ResultAttributes.OBJ_DOMAIN.getName
+					(), result.getObjDomain());
 		expectedTags.put(TAG_HOSTNAME, HOST);
 		String lineProtocol = buildLineProtocol(result.getKeyAlias(), expectedTags);
 
@@ -184,11 +185,11 @@ public class InfluxDbWriterTests {
 			BatchPoints batchPoints = messageCaptor.getValue();
 			String lineProtocol = batchPoints.getPoints().get(0).lineProtocol();
 
-			assertThat(lineProtocol).contains(enumValueToAttribute(expectedResultTag));
+			assertThat(lineProtocol).contains(expectedResultTag.getName());
 			Set<ResultAttribute> unexpectedResultTags = new HashSet<ResultAttribute>(ResultAttributes.values());
 			unexpectedResultTags.remove(expectedResultTag);
 			for (ResultAttribute unexpectedResultTag : unexpectedResultTags) {
-				assertThat(lineProtocol).doesNotContain(enumValueToAttribute(unexpectedResultTag));
+				assertThat(lineProtocol).doesNotContain(unexpectedResultTag.getName());
 			}
 		}
 	}
@@ -259,10 +260,5 @@ public class InfluxDbWriterTests {
 	private InfluxDbWriter getTestInfluxDbWriter(ConsistencyLevel consistencyLevel, String retentionPolicy, ImmutableMap<String, String> tags,
 												 ImmutableSet<ResultAttribute> resultTags, ImmutableList<String> typeNames, boolean createDatabase) {
 		return new InfluxDbWriter(influxDB, DATABASE_NAME, consistencyLevel, retentionPolicy, tags, resultTags, typeNames, createDatabase);
-	}
-
-	private String enumValueToAttribute(ResultAttribute attribute) {
-		String[] split = attribute.name().split("_");
-		return StringUtils.lowerCase(split[0]) + WordUtils.capitalizeFully(split[1]);
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializer.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializer.java
@@ -81,7 +81,7 @@ public class DefaultResultSerializer implements ResultSerializer {
 		this.booleanAsNumber = booleanAsNumber;
 		this.rootPrefix = rootPrefix;
 		this.tags = tags == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(tags);
-		this.resultAttributesToWriteAsTags = resultTags == null ? ImmutableSet.<ResultAttribute>of() : ResultAttributes.fromAttributes(resultTags);
+		this.resultAttributesToWriteAsTags = resultTags == null ? ImmutableSet.<ResultAttribute>of() : ResultAttributes.forNames(resultTags);
 	}
 
 	@Nonnull
@@ -119,7 +119,7 @@ public class DefaultResultSerializer implements ResultSerializer {
 				generator.writeStringField(tag.getKey(), tag.getValue());
 			}
 			for (ResultAttribute resultAttribute : this.resultAttributesToWriteAsTags) {
-				generator.writeStringField(resultAttribute.getAttributeName(), resultAttribute.getAttribute(result));
+				generator.writeStringField(resultAttribute.getName(), resultAttribute.get(result));
 			}
 
 			generator.writeEndObject();

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializer.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializer.java
@@ -28,8 +28,11 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.ResultAttribute;
+import com.googlecode.jmxtrans.model.ResultAttributes;
 import com.googlecode.jmxtrans.model.Server;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -63,17 +66,22 @@ public class DefaultResultSerializer implements ResultSerializer {
 	private final String rootPrefix;
 	@Getter @Nonnull
 	private final ImmutableMap<String, String> tags;
+	@Nonnull
+	private final ImmutableSet<ResultAttribute> resultAttributesToWriteAsTags;
 
 	@JsonCreator
 	public DefaultResultSerializer(@JsonProperty("typeNames") List<String> typeNames,
 									@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
 									@JsonProperty("rootPrefix") String rootPrefix,
-									@JsonProperty("tags") Map<String, String> tags) {
+									@JsonProperty("tags") Map<String, String> tags,
+									@JsonProperty("resultTags") List<String> resultTags
+									) {
 		this.jsonFactory = new JsonFactory();
 		this.typeNames = typeNames == null ? ImmutableList.<String>of() : ImmutableList.copyOf(typeNames);
 		this.booleanAsNumber = booleanAsNumber;
 		this.rootPrefix = rootPrefix;
 		this.tags = tags == null ? ImmutableMap.<String, String>of() : ImmutableMap.copyOf(tags);
+		this.resultAttributesToWriteAsTags = resultTags == null ? ImmutableSet.<ResultAttribute>of() : ResultAttributes.fromAttributes(resultTags);
 	}
 
 	@Nonnull
@@ -109,6 +117,9 @@ public class DefaultResultSerializer implements ResultSerializer {
 
 			for (Map.Entry<String, String> tag : this.tags.entrySet()) {
 				generator.writeStringField(tag.getKey(), tag.getValue());
+			}
+			for (ResultAttribute resultAttribute : this.resultAttributesToWriteAsTags) {
+				generator.writeStringField(resultAttribute.getAttributeName(), resultAttribute.getAttribute(result));
 			}
 
 			generator.writeEndObject();

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DetailedResultSerializer.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DetailedResultSerializer.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.NON_NULL;
 import static java.util.Collections.singletonList;
@@ -98,6 +99,8 @@ public class DetailedResultSerializer implements ResultSerializer {
 		@Getter
 		private final String typeName;
 		@Getter
+		private final Map<String, String> typeNameMap;
+		@Getter
 		private final long epoch;
 		@Getter
 		private final String keyAlias;
@@ -112,6 +115,7 @@ public class DetailedResultSerializer implements ResultSerializer {
 			className = result.getClassName();
 			objDomain = result.getObjDomain();
 			typeName = result.getTypeName();
+			typeNameMap = result.getTypeNameMap();
 			epoch = result.getEpoch();
 			keyAlias = result.getKeyAlias();
 		}

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
@@ -90,7 +90,7 @@ public class KafkaWriter extends BaseOutputWriter {
 				(String) getSettings().get("rootPrefix"),
 				DEFAULT_ROOT_PREFIX);
 		Map<String, String> aTags = firstNonNull(tags, (Map<String, String>) getSettings().get("tags"), ImmutableMap.<String, String>of());
-		resultSerializer = new DefaultResultSerializer(typeNames, booleanAsNumber, aRootPrefix, aTags);
+		resultSerializer = new DefaultResultSerializer(typeNames, booleanAsNumber, aRootPrefix, aTags, ImmutableList.<String>of());
 	}
 
 

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterFactory.java
@@ -79,7 +79,8 @@ public class KafkaWriterFactory implements OutputWriterFactory<KafkaWriter2> {
 		this.resultSerializer = resultSerializer == null ? new DefaultResultSerializer(
 				Collections.<String>emptyList(),
 				false, "",
-				Collections.<String, String>emptyMap()) : resultSerializer;
+				Collections.<String, String>emptyMap(),
+				Collections.<String>emptyList()) : resultSerializer;
 	}
 
 	@Nonnull

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializerTest.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializerTest.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.googlecode.jmxtrans.model.Result;
 import org.junit.Test;
 
@@ -51,7 +50,7 @@ public class DefaultResultSerializerTest {
 	@Test
 	public void convertSingleNumericToString() throws Exception {
 		ImmutableMap<String, String> tags = ImmutableMap.of("myTagKey1", "myTagValue1");
-		ResultSerializer resultSerializer = new DefaultResultSerializer(ImmutableList.<String>of(), false, "rootPrefix", tags);
+		ResultSerializer resultSerializer = new DefaultResultSerializer(ImmutableList.<String>of(), false, "rootPrefix", tags, asList("typeName.type", "className"));
 
 		long now = System.currentTimeMillis();
 		Collection<String> messages = resultSerializer.serialize(dummyServer(), dummyQuery(), numericResultAt(now));
@@ -65,12 +64,14 @@ public class DefaultResultSerializerTest {
 		assertThat(jsonNode.get("value").asLong()).isEqualTo(10L);
 		assertThat(jsonNode.get("timestamp").asLong()).isEqualTo(now / 1000);
 		assertThat(jsonNode.get("tags").get("myTagKey1").asText()).isEqualTo("myTagValue1");
+		assertThat(jsonNode.get("tags").get("typeName.type").asText()).isEqualTo("Memory");
+		assertThat(jsonNode.get("tags").get("className").asText()).endsWith("MemoryImpl");
 	}
 
 	@Test
 	public void convertSingleNonNumericToString() throws Exception {
 		ImmutableMap<String, String> tags = ImmutableMap.of("myTagKey1", "myTagValue1");
-		ResultSerializer resultSerializer = new DefaultResultSerializer(ImmutableList.<String>of(), false, "rootPrefix", tags);
+		ResultSerializer resultSerializer = new DefaultResultSerializer(ImmutableList.<String>of(), false, "rootPrefix", tags, ImmutableList.<String>of());
 
 		Collection<String> messages = resultSerializer.serialize(dummyServer(), dummyQuery(), stringResult());
 
@@ -80,7 +81,7 @@ public class DefaultResultSerializerTest {
 	@Test
 	public void convertHashToStrings() throws Exception {
 		ImmutableMap<String, String> tags = ImmutableMap.of("myTagKey1", "myTagValue1");
-		ResultSerializer resultSerializer = new DefaultResultSerializer(ImmutableList.<String>of(), false, "rootPrefix", tags);
+		ResultSerializer resultSerializer = new DefaultResultSerializer(ImmutableList.<String>of(), false, "rootPrefix", tags, ImmutableList.<String>of());
 
 		Collection<String> messages = resultSerializer.serialize(dummyServer(), dummyQuery(), hashResult());
 
@@ -97,7 +98,7 @@ public class DefaultResultSerializerTest {
 
 	@Test
 	public void initDefaults() throws Exception {
-		DefaultResultSerializer resultSerializer = new DefaultResultSerializer(null, false, null, null);
+		DefaultResultSerializer resultSerializer = new DefaultResultSerializer(null, false, null, null, null);
 
 		assertThat(resultSerializer.getTypeNames()).isNotNull();
 		assertThat(resultSerializer.getTypeNames()).isEmpty();
@@ -107,8 +108,8 @@ public class DefaultResultSerializerTest {
 
 	@Test
 	public void equalsHashCodeWhenSame() throws Exception {
-		DefaultResultSerializer resultSerializer1 = new DefaultResultSerializer(null, false, null, null);
-		DefaultResultSerializer resultSerializer2 = new DefaultResultSerializer(null, false, null, null);
+		DefaultResultSerializer resultSerializer1 = new DefaultResultSerializer(null, false, null, null, null);
+		DefaultResultSerializer resultSerializer2 = new DefaultResultSerializer(null, false, null, null, null);
 
 		assertThat(resultSerializer1).isEqualTo(resultSerializer2);
 		assertThat(resultSerializer1.hashCode()).isEqualTo(resultSerializer2.hashCode());
@@ -116,8 +117,8 @@ public class DefaultResultSerializerTest {
 
 	@Test
 	public void equalsWhenDifferent() throws Exception {
-		DefaultResultSerializer resultSerializer1 = new DefaultResultSerializer(null, false, null, null);
-		DefaultResultSerializer resultSerializer2 = new DefaultResultSerializer(asList("Type"), true, "root", null);
+		DefaultResultSerializer resultSerializer1 = new DefaultResultSerializer(null, false, null, null, null);
+		DefaultResultSerializer resultSerializer2 = new DefaultResultSerializer(asList("Type"), true, "root", null, null);
 
 		assertThat(resultSerializer1).isNotEqualTo(resultSerializer2);
 	}

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DetailedResultSerializerTest.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DetailedResultSerializerTest.java
@@ -55,7 +55,7 @@ public class DetailedResultSerializerTest {
 		assertThat(jsonNode.get("objDomain").asText()).isEqualTo("ObjectDomainName");
 		assertThat(jsonNode.get("typeName").asText()).isEqualTo("type=Memory");
 		assertThat(jsonNode.get("typeNameMap").get("type").asText()).isEqualTo("Memory");
-		assertThat(jsonNode.get("typeNameMap").size()).isEqualTo(1);
+		assertThat(jsonNode.get("typeNameMap")).hasSize(1);
 		assertThat(jsonNode.get("values").get("ObjectPendingFinalizationCount").asLong()).isEqualTo(10L);
 		assertThat(jsonNode.get("epoch").asLong()).isEqualTo(0L);
 		assertThat(jsonNode.get("keyAlias").asText()).isEqualTo("MemoryAlias");

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DetailedResultSerializerTest.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DetailedResultSerializerTest.java
@@ -54,6 +54,8 @@ public class DetailedResultSerializerTest {
 		assertThat(jsonNode.get("className").asText()).isEqualTo("sun.management.MemoryImpl");
 		assertThat(jsonNode.get("objDomain").asText()).isEqualTo("ObjectDomainName");
 		assertThat(jsonNode.get("typeName").asText()).isEqualTo("type=Memory");
+		assertThat(jsonNode.get("typeNameMap").get("type").asText()).isEqualTo("Memory");
+		assertThat(jsonNode.get("typeNameMap").size()).isEqualTo(1);
 		assertThat(jsonNode.get("values").get("ObjectPendingFinalizationCount").asLong()).isEqualTo(10L);
 		assertThat(jsonNode.get("epoch").asLong()).isEqualTo(0L);
 		assertThat(jsonNode.get("keyAlias").asText()).isEqualTo("MemoryAlias");


### PR DESCRIPTION
* Add getTypeNameMap in Result and use it to detail DetailedResultSerializer
* Add ResultAttribute implementation to get typeName props and use it in DefaultResultSerializer, InfluxdbWriter and StatsdWriter
  * Split ResultAttribute enum into ResultAttribute class + ResultAttributes factory
  * Replace reflection by pure method calls (with Java 8 lambdas code could be even simpler)