### PR TITLE
Replace illegal statsd characters.

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
@@ -68,6 +68,21 @@ public final class ResultFixtures {
 				ImmutableMap.<String, Object>of("ObjectPendingFinalizationCount", numericValue));
 	}
 
+	public static Result numericResultWithColon() {
+		return numericResultWithColon(10);
+	}
+
+	public static Result numericResultWithColon(Object numericValue) {
+		return new Result(
+				0,
+				"Count",
+				"com.yammer.metrics.reporting.JmxReporter$Meter",
+				"fakehostname.example.com-org.openrepose.core",
+				null,
+				"type=\"ResponseCode\",scope=\"127.0.0.1:8008\",name=\"4XX\"",
+				ImmutableMap.<String, Object>of("Count", numericValue));
+	}
+
 	public static Result stringResult() {
 		return stringResult("value is a string");
 	}
@@ -134,6 +149,13 @@ public final class ResultFixtures {
 				booleanTrueResult(),
 				booleanFalseResult());
 	}
+
+	public static ImmutableList<Result> dummyResultWithColon() {
+		return ImmutableList.of(
+				numericResultWithColon(),
+				booleanTrueResult());
+	}
+
 
 	public static ImmutableList<Result> singleResult(Result result) {
 		return ImmutableList.of(result);

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/BaseOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/BaseOutputWriter.java
@@ -107,7 +107,7 @@ public abstract class BaseOutputWriter implements OutputWriter, OutputWriterFact
 				false);
 
 		// Get the value of the boolean from the JSON settings if it exists, otherwise default it to the value
-		// of the boolean passed into the Constructor. 
+		// of the boolean passed into the Constructor.
 		booleanAsNumber = getBooleanSetting(this.settings, BOOLEAN_AS_NUMBER, booleanAsNumber);
 
 		if (booleanAsNumber) {
@@ -119,6 +119,10 @@ public abstract class BaseOutputWriter implements OutputWriter, OutputWriterFact
 
 	protected <T> T firstNonNull(@Nullable T first, @Nullable T second, @Nullable T third) {
 		return first != null ? first : (second != null ? second : checkNotNull(third));
+	}
+
+	protected <T> T firstNonNull(@Nullable T first, @Nullable T second) {
+		return firstNonNull(first, second, null);
 	}
 
 	/**

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/BaseOutputWriter.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/BaseOutputWriter.java
@@ -120,11 +120,7 @@ public abstract class BaseOutputWriter implements OutputWriter, OutputWriterFact
 	protected <T> T firstNonNull(@Nullable T first, @Nullable T second, @Nullable T third) {
 		return first != null ? first : (second != null ? second : checkNotNull(third));
 	}
-
-	protected <T> T firstNonNull(@Nullable T first, @Nullable T second) {
-		return firstNonNull(first, second, null);
-	}
-
+	
 	/**
 	 * @deprecated Don't use the settings Map, please extract necessary bits at construction time.
 	 */

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
@@ -36,6 +36,7 @@ import com.googlecode.jmxtrans.model.results.CPrecisionValueTransformer;
 import com.googlecode.jmxtrans.model.results.ValueTransformer;
 import com.googlecode.jmxtrans.monitoring.ManagedGenericKeyedObjectPool;
 import com.googlecode.jmxtrans.monitoring.ManagedObject;
+import com.google.common.base.MoreObjects;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
@@ -134,7 +135,7 @@ public class StatsDWriter extends BaseOutputWriter {
 		if (port == null) {
 			port = Settings.getIntegerSetting(getSettings(), PORT, null);
 		}
-		this.replacementForInvalidChar = com.google.common.base.MoreObjects.firstNonNull(replacementForInvalidChar, "_");
+		this.replacementForInvalidChar = MoreObjects.firstNonNull(replacementForInvalidChar, "_");
 
 		checkNotNull(host, "Host cannot be null");
 		checkNotNull(port, "Port cannot be null");

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
@@ -76,7 +76,7 @@ public class StatsDWriter extends BaseOutputWriter {
 	private static final String BUCKET_TYPE = "bucketType";
 	private static final String STRING_VALUE_AS_KEY = "stringValuesAsKey";
 	private static final String STRING_VALUE_DEFAULT_COUNTER = "stringValueDefaultCount";
-	private static final Pattern STATSD_INVALID = Pattern.compile("[./]");
+	private static final Pattern STATSD_INVALID = Pattern.compile("[:|]");
 
 	private final ByteBuffer sendBuffer;
 

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
@@ -134,10 +134,11 @@ public class StatsDWriter extends BaseOutputWriter {
 		if (port == null) {
 			port = Settings.getIntegerSetting(getSettings(), PORT, null);
 		}
+		this.replacementForInvalidChar = firstNonNull(replacementForInvalidChar, "_");
+
 		checkNotNull(host, "Host cannot be null");
 		checkNotNull(port, "Port cannot be null");
 		this.address = new InetSocketAddress(host, port);
-		this.replacementForInvalidChar = replacementForInvalidChar;
 	}
 
 	@Override
@@ -197,11 +198,7 @@ public class StatsDWriter extends BaseOutputWriter {
 				String line = KeyUtils.getKeyString(server, query, result, values, typeNames, rootPrefix);
 
 				// These characters can mess with formatting.
-				String replaceString = "_";
-				if (this.replacementForInvalidChar != null){
-					replaceString = this.replacementForInvalidChar;
-				}
-				line = STATSD_INVALID.matcher(line).replaceAll(replaceString);
+				line = STATSD_INVALID.matcher(line).replaceAll(this.replacementForInvalidChar);
 				line += computeActualValue(values.getValue()) + "|" + bucketType + "\n";
 
 				doSend(line.trim());

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
@@ -134,7 +134,7 @@ public class StatsDWriter extends BaseOutputWriter {
 		if (port == null) {
 			port = Settings.getIntegerSetting(getSettings(), PORT, null);
 		}
-		this.replacementForInvalidChar = firstNonNull(replacementForInvalidChar, "_");
+		this.replacementForInvalidChar = com.google.common.base.MoreObjects.firstNonNull(replacementForInvalidChar, "_");
 
 		checkNotNull(host, "Host cannot be null");
 		checkNotNull(port, "Port cannot be null");

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
@@ -82,7 +82,7 @@ public class StatsDWriter extends BaseOutputWriter {
 
 	private final String bucketType;
 	private final String rootPrefix;
-	private final String invalidCharValue;
+	private final String replacementForInvalidChar;
 	private final InetSocketAddress address;
 	private final DatagramChannel channel;
 	private final Boolean stringsValuesAsKey;
@@ -111,7 +111,7 @@ public class StatsDWriter extends BaseOutputWriter {
 			@JsonProperty(STRING_VALUE_AS_KEY) Boolean stringsValuesAsKey,
 			@JsonProperty(STRING_VALUE_DEFAULT_COUNTER) Long stringValueDefaultCount,
 			@JsonProperty("settings") Map<String, Object> settings,
-			@JsonProperty("invalidCharValue") String invalidCharValue
+			@JsonProperty("replacementForInvalidChar") String replacementForInvalidChar
 			) throws IOException {
 		super(typeNames, booleanAsNumber, debugEnabled, settings);
 		log.warn("StatsDWriter is deprecated. Please use StatsDWriterFactory instead.");
@@ -137,7 +137,7 @@ public class StatsDWriter extends BaseOutputWriter {
 		checkNotNull(host, "Host cannot be null");
 		checkNotNull(port, "Port cannot be null");
 		this.address = new InetSocketAddress(host, port);
-		this.invalidCharValue = invalidCharValue;
+		this.replacementForInvalidChar = replacementForInvalidChar;
 	}
 
 	@Override
@@ -198,8 +198,8 @@ public class StatsDWriter extends BaseOutputWriter {
 
 				// These characters can mess with formatting.
 				String replaceString = "_";
-				if (this.invalidCharValue != null){
-					replaceString = this.invalidCharValue;
+				if (this.replacementForInvalidChar != null){
+					replaceString = this.replacementForInvalidChar;
 				}
 				line = STATSD_INVALID.matcher(line).replaceAll(replaceString);
 				line += computeActualValue(values.getValue()) + "|" + bucketType + "\n";

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter.java
@@ -76,6 +76,7 @@ public class StatsDWriter extends BaseOutputWriter {
 	private static final String BUCKET_TYPE = "bucketType";
 	private static final String STRING_VALUE_AS_KEY = "stringValuesAsKey";
 	private static final String STRING_VALUE_DEFAULT_COUNTER = "stringValueDefaultCount";
+	private static final Pattern STATSD_INVALID = Pattern.compile("[./]");
 
 	private final ByteBuffer sendBuffer;
 
@@ -200,8 +201,7 @@ public class StatsDWriter extends BaseOutputWriter {
 				if (this.invalidCharValue != null){
 					replaceString = this.invalidCharValue;
 				}
-				Pattern invalidChar = Pattern.compile("[:|]");
-				line = invalidChar.matcher(line).replaceAll(replaceString);
+				line = STATSD_INVALID.matcher(line).replaceAll(replaceString);
 				line += computeActualValue(values.getValue()) + "|" + bucketType + "\n";
 
 				doSend(line.trim());

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter2.java
@@ -56,7 +56,7 @@ public class StatsDWriter2 implements WriterBasedOutputWriter {
 	@Nonnull
 	private final String stringValueDefaultCount;
 	@Nonnull
-	private final String invalidCharValue;
+	private final String replacementForInvalidChar;
 
 	@Nonnull
 	private final ValueTransformer valueTransformer = new CPrecisionValueTransformer();
@@ -69,13 +69,13 @@ public class StatsDWriter2 implements WriterBasedOutputWriter {
 			@Nonnull String bucketType,
 			boolean stringsValuesAsKey,
 			@Nonnull Long stringValueDefaultCount,
-			@Nonnull String invalidCharValue) {
+			@Nonnull String replacementForInvalidChar) {
 		this.typeNames = typeNames;
 		this.rootPrefix = rootPrefix;
 		this.stringsValuesAsKey = stringsValuesAsKey;
 		this.bucketType = bucketType;
 		this.stringValueDefaultCount = stringValueDefaultCount.toString();
-		this.invalidCharValue = invalidCharValue;
+		this.replacementForInvalidChar = replacementForInvalidChar;
 
 	}
 
@@ -92,7 +92,7 @@ public class StatsDWriter2 implements WriterBasedOutputWriter {
 				String line = KeyUtils.getKeyString(server, query, result, values, typeNames, rootPrefix);
 
 				// These characters can mess with formatting.
-				line = STATSD_INVALID.matcher(line).replaceAll(invalidCharValue);
+				line = STATSD_INVALID.matcher(line).replaceAll(replacementForInvalidChar);
 				line += computeActualValue(values.getValue()) + "|" + bucketType + "\n";
 
 				writer.write(line);

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter2.java
@@ -61,7 +61,7 @@ public class StatsDWriter2 implements WriterBasedOutputWriter {
 	@Nonnull
 	private final ValueTransformer valueTransformer = new CPrecisionValueTransformer();
 
-	private static final Pattern STATSD_INVALID = Pattern.compile("[./]");
+	private static final Pattern STATSD_INVALID = Pattern.compile("[:|]");
 
 	public StatsDWriter2(
 			@Nonnull List<String> typeNames,

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriter2.java
@@ -61,6 +61,8 @@ public class StatsDWriter2 implements WriterBasedOutputWriter {
 	@Nonnull
 	private final ValueTransformer valueTransformer = new CPrecisionValueTransformer();
 
+	private static final Pattern STATSD_INVALID = Pattern.compile("[./]");
+
 	public StatsDWriter2(
 			@Nonnull List<String> typeNames,
 			@Nonnull String rootPrefix,
@@ -90,8 +92,7 @@ public class StatsDWriter2 implements WriterBasedOutputWriter {
 				String line = KeyUtils.getKeyString(server, query, result, values, typeNames, rootPrefix);
 
 				// These characters can mess with formatting.
-				Pattern invalidChar = Pattern.compile("[:|]");
-				line = invalidChar.matcher(line).replaceAll(invalidCharValue);
+				line = STATSD_INVALID.matcher(line).replaceAll(invalidCharValue);
 				line += computeActualValue(values.getValue()) + "|" + bucketType + "\n";
 
 				writer.write(line);

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactory.java
@@ -51,7 +51,7 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 	@Nonnull private final InetSocketAddress server;
 	@Nonnull private final FlushStrategy flushStrategy;
 	private final int poolSize;
-	@Nonnull private final String invalidCharValue;
+	@Nonnull private final String replacementForInvalidChar;
 
 
 	public StatsDWriterFactory(
@@ -65,7 +65,7 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 			@JsonProperty("flushStrategy") String flushStrategy,
 			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
 			@JsonProperty("poolSize") Integer poolSize,
-			@JsonProperty("invalidCharValue") String invalidCharValue
+			@JsonProperty("replacementForInvalidChar") String replacementForInvalidChar
 	) {
 		this.typeNames = firstNonNull(typeNames, ImmutableList.<String>of());
 		this.rootPrefix = firstNonNull(rootPrefix, "servers");
@@ -77,14 +77,14 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 				checkNotNull(port, "Port cannot be null."));
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
 		this.poolSize = firstNonNull(poolSize, 1);
-		this.invalidCharValue = firstNonNull(invalidCharValue, "_");
+		this.replacementForInvalidChar = firstNonNull(replacementForInvalidChar, "_");
 	}
 
 	@Override
 	public WriterPoolOutputWriter<StatsDWriter2> create() {
 		return UdpOutputWriterBuilder.builder(
 				server,
-				new StatsDWriter2(typeNames, rootPrefix, bucketType, stringsValuesAsKey, stringValueDefaultCount, invalidCharValue))
+				new StatsDWriter2(typeNames, rootPrefix, bucketType, stringsValuesAsKey, stringValueDefaultCount, replacementForInvalidChar))
 				.setCharset(UTF_8)
 				.setFlushStrategy(flushStrategy)
 				.setPoolSize(poolSize)

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactory.java
@@ -51,6 +51,8 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 	@Nonnull private final InetSocketAddress server;
 	@Nonnull private final FlushStrategy flushStrategy;
 	private final int poolSize;
+	@Nonnull private final String invalidCharValue;
+
 
 	public StatsDWriterFactory(
 			@JsonProperty("typeNames") ImmutableList<String> typeNames,
@@ -62,7 +64,9 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 			@JsonProperty("port") Integer port,
 			@JsonProperty("flushStrategy") String flushStrategy,
 			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
-			@JsonProperty("poolSize") Integer poolSize) {
+			@JsonProperty("poolSize") Integer poolSize,
+			@JsonProperty("invalidCharValue") String invalidCharValue
+	) {
 		this.typeNames = firstNonNull(typeNames, ImmutableList.<String>of());
 		this.rootPrefix = firstNonNull(rootPrefix, "servers");
 		this.stringsValuesAsKey = stringsValuesAsKey;
@@ -73,13 +77,14 @@ public class StatsDWriterFactory implements OutputWriterFactory {
 				checkNotNull(port, "Port cannot be null."));
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
 		this.poolSize = firstNonNull(poolSize, 1);
+		this.invalidCharValue = firstNonNull(invalidCharValue, "_");
 	}
 
 	@Override
 	public WriterPoolOutputWriter<StatsDWriter2> create() {
 		return UdpOutputWriterBuilder.builder(
 				server,
-				new StatsDWriter2(typeNames, rootPrefix, bucketType, stringsValuesAsKey, stringValueDefaultCount))
+				new StatsDWriter2(typeNames, rootPrefix, bucketType, stringsValuesAsKey, stringValueDefaultCount, invalidCharValue))
 				.setCharset(UTF_8)
 				.setFlushStrategy(flushStrategy)
 				.setPoolSize(poolSize)

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriter2Test.java
@@ -37,7 +37,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void writeNumericResult() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L, null);
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), singleNumericResult());
@@ -48,7 +48,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void valuesTruncatedToCPrecision() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L, null);
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), singleNumericBelowCPrecisionResult());
@@ -59,7 +59,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void ignoreNonNumericValues() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L, null);
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), singleTrueResult());
@@ -69,7 +69,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void handleNaNValues() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L, null);
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), singleResult(numericResult(Double.NaN)));
@@ -80,7 +80,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void nonNumericValuesAsKey() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L, null);
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), singleTrueResult());
@@ -91,7 +91,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void multipleValuesAreSeparatedByNewLine() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L, null);
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), dummyResults());

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriter2Test.java
@@ -37,7 +37,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void writeNumericResult() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L, null);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L, "_");
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), singleNumericResult());
@@ -48,7 +48,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void valuesTruncatedToCPrecision() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L, null);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L, "_");
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), singleNumericBelowCPrecisionResult());
@@ -59,7 +59,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void ignoreNonNumericValues() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L, null);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "c", false, 1L, "_");
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), singleTrueResult());
@@ -69,7 +69,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void handleNaNValues() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L, null);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L, "_");
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), singleResult(numericResult(Double.NaN)));
@@ -80,7 +80,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void nonNumericValuesAsKey() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L, null);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L, "_");
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), singleTrueResult());
@@ -91,7 +91,7 @@ public class StatsDWriter2Test {
 
 	@Test
 	public void multipleValuesAreSeparatedByNewLine() throws IOException {
-		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L, null);
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.<String>of(), "root", "g", true, 1L, "_");
 
 		StringWriter out = new StringWriter();
 		writer.write(out, dummyServer(), dummyQuery(), dummyResults());
@@ -101,4 +101,17 @@ public class StatsDWriter2Test {
 						"root.host_example_net_4321.VerboseMemory.Verbose.true:1|g\n" +
 						"root.host_example_net_4321.VerboseMemory.Verbose.false:1|g\n");
 	}
+
+	@Test
+	public void badKeyNameNoInvalidCharProvided() throws IOException {
+		StatsDWriter2 writer = new StatsDWriter2(ImmutableList.of("scope", "name"), "root", "g", true, 1L, "___");
+
+		StringWriter out = new StringWriter();
+		writer.write(out, dummyServer(), dummyQuery(), dummyResultWithColon());
+
+		assertThat(out.toString())
+				.isEqualTo("root.host_example_net_4321.com_yammer_metrics_reporting_JmxReporter$Meter.127_0_0_1___8008_4XX.Count:10|g\n" +
+						"root.host_example_net_4321.VerboseMemory.Verbose.true:1|g\n");
+	}
+
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactoryIT.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/StatsDWriterFactoryIT.java
@@ -53,7 +53,7 @@ public class StatsDWriterFactoryIT {
 				null, null, false, null,
 				udpLoggingServer.getLocalSocketAddress().getHostName(),
 				udpLoggingServer.getLocalSocketAddress().getPort(),
-				null, null, null
+				null, null, null, null
 		).create();
 
 		statsDWriter.doWrite(dummyServer(), dummyQuery(), dummyResults());


### PR DESCRIPTION
It is possible for JMX to have characters invalid for statsd. This causes to parsing to become incorrect.

The unit test added is what we are seeing, where the scope can have "127.0.0.1:8080" where statsd uses the colon as a delimiter between the key and value.

I added an option "invalidCharValue" so that it can be customized.