### PR TITLE
Handle infinity in CPercisionValueTransformer

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/results/CPrecisionValueTransformer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/results/CPrecisionValueTransformer.java
@@ -39,6 +39,10 @@ public class CPrecisionValueTransformer implements ValueTransformer {
 			return null;
 		}
 
+		if (Double.isInfinite(((Number) input).doubleValue())) {
+			return null;
+		}
+
 		BigDecimal inputNumber = new BigDecimal(input.toString());
 
 		if (inputNumber.abs().compareTo(C_PRECISION) < 0) return 0;

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/results/CPrecisionValueTransformerTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/results/CPrecisionValueTransformerTests.java
@@ -92,4 +92,28 @@ public class CPrecisionValueTransformerTests {
 		assertThat(transformed).isNull();
 	}
 
+	@Test
+	public void positiveInfinityDoubleIsReturnedNull() {
+		ValueTransformer transformer = new CPrecisionValueTransformer();
+		Object transformed = transformer.apply(Double.POSITIVE_INFINITY);
+
+		assertThat(transformed).isNull();
+	}
+
+	@Test
+	public void negativeInfinityFloatIsReturnedNull() {
+		ValueTransformer transformer = new CPrecisionValueTransformer();
+		Object transformed = transformer.apply(Float.NEGATIVE_INFINITY);
+
+		assertThat(transformed).isNull();
+	}
+
+	@Test
+	public void positiveInfinityFloatIsReturnedNull() {
+		ValueTransformer transformer = new CPrecisionValueTransformer();
+		Object transformed = transformer.apply(Float.POSITIVE_INFINITY);
+
+		assertThat(transformed).isNull();
+	}
+
 }

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/results/CPrecisionValueTransformerTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/results/CPrecisionValueTransformerTests.java
@@ -84,4 +84,12 @@ public class CPrecisionValueTransformerTests {
 		assertThat(transformed).isNull();
 	}
 
+	@Test
+	public void negativeInfinityDoubleIsReturnedNull() {
+		ValueTransformer transformer = new CPrecisionValueTransformer();
+		Object transformed = transformer.apply(Double.NEGATIVE_INFINITY);
+
+		assertThat(transformed).isNull();
+	}
+
 }


### PR DESCRIPTION
fix for #615 

CPercisionValueTransformer now returns null if input is infinite