### PR TITLE
Collecting metrics stops when at least one node is down

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -282,12 +282,6 @@ public class Server implements JmxConnectionProvider {
 
 			return results.build();
 		} catch (Exception e) {
-			// since we will invalidate the connection in the pool, prevent connection leaks
-			try {
-				jmxConnection.close();
-			} catch (IOException | RuntimeException re) {
-				// drop these, we don't really know what caused the original exception.
-				logger.warn("An error occurred trying to close a JMX Connection during error handling.", re);
 			if (jmxConnection != null) {
 				pool.invalidateObject(this, jmxConnection);
 				jmxConnection = null;

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -270,15 +270,16 @@ public class Server implements JmxConnectionProvider {
 	}
 
 	public Iterable<Result> execute(Query query) throws Exception {
-		JMXConnection jmxConnection = pool.borrowObject(this);
+		JMXConnection jmxConnection = null;
 		try {
+			jmxConnection = pool.borrowObject(this);
 			ImmutableList.Builder<Result> results = ImmutableList.builder();
 			MBeanServerConnection connection = jmxConnection.getMBeanServerConnection();
 
 			for (ObjectName queryName : query.queryNames(connection)) {
 				results.addAll(query.fetchResults(connection, queryName));
 			}
-			pool.returnObject(this, jmxConnection);
+
 			return results.build();
 		} catch (Exception e) {
 			// since we will invalidate the connection in the pool, prevent connection leaks
@@ -287,9 +288,16 @@ public class Server implements JmxConnectionProvider {
 			} catch (IOException | RuntimeException re) {
 				// drop these, we don't really know what caused the original exception.
 				logger.warn("An error occurred trying to close a JMX Connection during error handling.", re);
+			if (jmxConnection != null) {
+				pool.invalidateObject(this, jmxConnection);
+				jmxConnection = null;
 			}
-			pool.invalidateObject(this, jmxConnection);
 			throw e;
+		}
+		finally {
+			if (jmxConnection != null) {
+				pool.returnObject(this, jmxConnection);
+			}
 		}
 	}
 

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/util/ProcessConfigUtils.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/util/ProcessConfigUtils.java
@@ -57,10 +57,11 @@ public class ProcessConfigUtils {
 	 * tree representation of that json.
 	 */
 	public JmxProcess parseProcess(File file) throws IOException {
-		ObjectMapper mapper = file.getName().endsWith(".yml") || file.getName().endsWith(".yaml") ? yamlMapper : jsonMapper;
+		String fileName = file.getName();
+		ObjectMapper mapper = fileName.endsWith(".yml") || fileName.endsWith(".yaml") ? yamlMapper : jsonMapper;
 		JsonNode jsonNode = mapper.readTree(file);
 		JmxProcess jmx = mapper.treeToValue(jsonNode, JmxProcess.class);
-		jmx.setName(file.getName());
+		jmx.setName(fileName);
 		return jmx;
 	}
 }

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
@@ -302,8 +302,6 @@ public class ServerTests {
 			}
 		}
 
-		verify(conn).close();
-
 		verify(pool, never()).returnObject(server, conn);
 
 		InOrder orderVerifier = inOrder(pool);
@@ -343,8 +341,6 @@ public class ServerTests {
 				fail("Wrong exception thrown (" + e + " instead of mock");
 			}
 		}
-
-		verify(conn).close();
 
 		verify(pool, never()).returnObject(server, conn);
 


### PR DESCRIPTION
My collegue wrote (https://gitter.im/jmxtrans/jmxtrans?at=58e4fdaaad849bcf425405a5)

> Hi! I’m observing a strange side effect when using jmxtrans (build 260) to collect metrics from Cassandra nodes. When at least one node is down, I observe incorrect or missing datapoints on all other metrics coming from the same instance of jmxtrans.
What am I doing wrong?

We've tried to fix this. But I have no idea what's wrong.
There are my investigation results. May be it helps to get answer.

First of all we've covered by logs next methods

- Server.execute
- JmxUtils.processServer

After that we're replayed this scenario at production. One cassandra node was closed by firewall to test instance of jmxtrans.

What actually happened.

Logs from JmxUtils.processServer when we closed node by firewall and our thread pool limit set to 10:
1. ThreadPool ActiveCount=10 | QueueSize=10. All items in queue for node which is down.
2. After one minute we have no metrics from another nodes.
3. After three minutes ThreadPool has stats ActiveCount=10 | QueueSize=2530 and no errors at log.
4. Rollback firewall block.
5. After few seconds app wrote to log some errors about connection timeout. Like this:
```
[01 Dec 2017 14:16:14] [jmxtrans-query-0] 379842 ERROR (com.googlecode.jmxtrans.jmx.ProcessQueryThread:57) - Error executing query Query(objectName=org.apache.cassandra.metrics:type=ColumnFamily,keyspace=*,scope=*,name=MemtableSwitchCount, keys=[], attr=[Value], typeNames=[], resultAlias=ColumnFamily, useObjDomainAsKey=false, allowDottedKeys=true, useAllTypeNames=false, outputWriterInstances=[GraphiteWriter(pool=org.apache.commons.pool.impl.GenericKeyedObjectPool@29f9efa0, rootPrefix=DevOpsTest.Cassandra.WebCluster, address=graphite-relay/7.7.7.7:2003, onlyOnceLogger=com.googlecode.jmxtrans.util.OnlyOnceLogger@457b9597)]) on server Server(pid=null, host=cassandra-134, port=8899, url=service:jmx:rmi:///jndi/rmi://cassandra-134:8899/jmxrmi, cronExpression=null, numQueryThreads=20)
java.rmi.ConnectException: Connection refused to host: 192.168.191.2; nested exception is: 
	java.net.ConnectException: Connection timed out (Connection timed out)
	at sun.rmi.transport.tcp.TCPEndpoint.newSocket(TCPEndpoint.java:619)
	at sun.rmi.transport.tcp.TCPChannel.createConnection(TCPChannel.java:216)
	at sun.rmi.transport.tcp.TCPChannel.newConnection(TCPChannel.java:202)
	at sun.rmi.server.UnicastRef.invoke(UnicastRef.java:130)
	at com.sun.jmx.remote.internal.PRef.invoke(Unknown Source)
	at javax.management.remote.rmi.RMIConnectionImpl_Stub.queryNames(Unknown Source)
	at javax.management.remote.rmi.RMIConnector$RemoteMBeanServerConnection.queryNames(RMIConnector.java:847)
	at com.googlecode.jmxtrans.model.Query.queryNames(Query.java:208)
	at com.googlecode.jmxtrans.model.Server.execute(Server.java:288)
	at com.googlecode.jmxtrans.jmx.ProcessQueryThread.run(ProcessQueryThread.java:54)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.net.ConnectException: Connection timed out (Connection timed out)
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:589)
	at java.net.Socket.connect(Socket.java:538)
	at java.net.Socket.<init>(Socket.java:434)
	at java.net.Socket.<init>(Socket.java:211)
	at sun.rmi.transport.proxy.RMIDirectSocketFactory.createSocket(RMIDirectSocketFactory.java:40)
	at sun.rmi.transport.proxy.RMIMasterSocketFactory.createSocket(RMIMasterSocketFactory.java:148)
	at sun.rmi.transport.tcp.TCPEndpoint.newSocket(TCPEndpoint.java:613)
	... 14 more
```
6. After few seconds app collects metrics again. Thread pool queue decreased.

So @gehel was right

> that's where we should have a circuit breaker... You probably have threads just waiting for the dead server to respond and eating up the threadpool

And we've decided to dump threads through jstack.

First interesting thing: a lot of heartbeat threads slept:
```
Threads count: 194
 - java.lang.Thread.sleep(long) @bci=0 (Compiled frame; information may be imprecise)
 - com.sun.jmx.remote.internal.ClientCommunicatorAdmin$Checker.run() @bci=35, line=175 (Interpreted frame)
 - java.lang.Thread.run() @bci=11, line=745 (Interpreted frame)

Threads count: 150
 - java.lang.Thread.sleep(long) @bci=0 (Compiled frame; information may be imprecise)
 - com.sun.jmx.remote.internal.ClientCommunicatorAdmin$Checker.run() @bci=35, line=175 (Compiled frame)
 - java.lang.Thread.run() @bci=11, line=745 (Compiled frame)

Threads count: 52
 - java.lang.Thread.sleep(long) @bci=0 (Compiled frame; information may be imprecise)
 - com.sun.jmx.remote.internal.ClientCommunicatorAdmin$Checker.run() @bci=35, line=175 (Interpreted frame)
 - java.lang.Thread.run() @bci=11, line=745 (Compiled frame)
```
I don't think it's okay but it's not source of our topic problem.

So let's have a look for next 10 threads:
```
Threads count: 10
 - java.net.PlainSocketImpl.socketConnect(java.net.InetAddress, int, int) @bci=0 (Compiled frame; information may be imprecise)
 - java.net.AbstractPlainSocketImpl.doConnect(java.net.InetAddress, int, int) @bci=64, line=350 (Compiled frame)
 - java.net.AbstractPlainSocketImpl.connectToAddress(java.net.InetAddress, int, int) @bci=23, line=206 (Compiled frame)
 - java.net.AbstractPlainSocketImpl.connect(java.net.SocketAddress, int) @bci=78, line=188 (Compiled frame)
 - java.net.SocksSocketImpl.connect(java.net.SocketAddress, int) @bci=381, line=392 (Compiled frame)
 - java.net.Socket.connect(java.net.SocketAddress, int) @bci=179, line=589 (Compiled frame)
 - java.net.Socket.connect(java.net.SocketAddress) @bci=3, line=538 (Compiled frame)
 - java.net.Socket.<init>(java.net.SocketAddress, java.net.SocketAddress, boolean) @bci=82, line=434 (Compiled frame)
 - java.net.Socket.<init>(java.lang.String, int) @bci=34, line=211 (Compiled frame)
 - sun.rmi.transport.proxy.RMIDirectSocketFactory.createSocket(java.lang.String, int) @bci=6, line=40 (Compiled frame)
 - sun.rmi.transport.proxy.RMIMasterSocketFactory.createSocket(java.lang.String, int) @bci=65, line=148 (Compiled frame)
 - sun.rmi.transport.tcp.TCPEndpoint.newSocket() @bci=62, line=613 (Compiled frame)
 - sun.rmi.transport.tcp.TCPChannel.createConnection() @bci=22, line=216 (Compiled frame)
 - sun.rmi.transport.tcp.TCPChannel.newConnection() @bci=101, line=202 (Compiled frame)
 - sun.rmi.server.UnicastRef.invoke(java.rmi.Remote, java.lang.reflect.Method, java.lang.Object[], long) @bci=65, line=130 (Compiled frame)
 - com.sun.jmx.remote.internal.PRef.invoke(java.rmi.Remote, java.lang.reflect.Method, java.lang.Object[], long) @bci=9 (Compiled frame)
 - javax.management.remote.rmi.RMIConnectionImpl_Stub.queryNames(javax.management.ObjectName, java.rmi.MarshalledObject, javax.security.auth.Subject) @bci=27 (Compiled frame)
 - javax.management.remote.rmi.RMIConnector$RemoteMBeanServerConnection.queryNames(javax.management.ObjectName, javax.management.QueryExp) @bci=76, line=847 (Compiled frame)
 - com.googlecode.jmxtrans.model.Query.queryNames(javax.management.MBeanServerConnection) @bci=6, line=208 (Compiled frame)
 - com.googlecode.jmxtrans.model.Server.execute(com.googlecode.jmxtrans.model.Query) @bci=79, line=288 (Compiled frame)
 - com.googlecode.jmxtrans.jmx.ProcessQueryThread.run() @bci=8, line=54 (Compiled frame)
 - java.util.concurrent.Executors$RunnableAdapter.call() @bci=4, line=511 (Compiled frame)
 - java.util.concurrent.FutureTask.run() @bci=42, line=266 (Compiled frame)
 - java.util.concurrent.ThreadPoolExecutor.runWorker(java.util.concurrent.ThreadPoolExecutor$Worker) @bci=95, line=1142 (Interpreted frame)
 - java.util.concurrent.ThreadPoolExecutor$Worker.run() @bci=5, line=617 (Interpreted frame)
 - java.lang.Thread.run() @bci=11, line=745 (Interpreted frame)
```


Problem localized at Server.execute when it tries to call `query.queryNames(connection)`
```
for (ObjectName queryName : query.queryNames(connection)) {
    results.addAll(query.fetchResults(connection, queryName));
}
```

It corresponds to our logs. We've got waiting after borrow connection from mbeanPool.

According to [sun.rmi Properties documentation](https://docs.oracle.com/javase/7/docs/technotes/guides/rmi/sunrmiproperties.html) we can tune timeouts. So we did it.
We set:
sun.rmi.transport.connectionTimeout=5000
sun.rmi.transport.proxy.connectTimeout=5000
sun.rmi.transport.tcp.handshakeTimeout=5000
sun.rmi.transport.tcp.responseTimeout=5000

Nothing helps.
May be we lose something?

I understand that we can write circuit breaker like tracking health of replica or somthing like that. But first of all we should learn how to cancel dead connections, right?