### PR TITLE
JMXConnector works slowly when server unavailable

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/connections/JMXConnection.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/connections/JMXConnection.java
@@ -62,6 +62,10 @@ public class JMXConnection implements Closeable {
 	public void close() throws IOException {
 		markedAsDestroyed = true;
 		if (connector != null) {
+			// when you call close it tries to notify server about it
+			// so if your server is down you will wait until connection timed out
+			// but we want to release thread asap
+			// that's why we do it here through ExecutorService
 			executor.submit(new Runnable() {
 				public void run() {
 					if (connector != null) {

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/connections/MBeanServerConnectionFactory.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/connections/MBeanServerConnectionFactory.java
@@ -41,7 +41,17 @@ public class MBeanServerConnectionFactory extends BaseKeyedPoolableObjectFactory
 	}
 
 	@Override
-	public void destroyObject(@Nonnull JmxConnectionProvider key, @Nonnull JMXConnection obj) throws IOException {
-		obj.close();
+	public void destroyObject(@Nonnull JmxConnectionProvider key, @Nonnull JMXConnection jmxConnection) throws IOException {
+		if (!jmxConnection.isAlive()) {
+			return;
+		}
+
+		jmxConnection.close();
 	}
+
+	@Override
+	public boolean validateObject(@Nonnull JmxConnectionProvider key, @Nonnull JMXConnection jmxConnection){
+		return jmxConnection.isAlive();
+	}
+
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/connections/MBeanServerConnectionFactory.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/connections/MBeanServerConnectionFactory.java
@@ -27,8 +27,16 @@ import org.apache.commons.pool.BaseKeyedPoolableObjectFactory;
 import javax.annotation.Nonnull;
 import javax.management.remote.JMXConnector;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class MBeanServerConnectionFactory extends BaseKeyedPoolableObjectFactory<JmxConnectionProvider, JMXConnection> {
+	@Nonnull private final ExecutorService executor;
+
+	public MBeanServerConnectionFactory(){
+		executor = Executors.newCachedThreadPool();
+	}
+
 	@Override
 	@Nonnull
 	public JMXConnection makeObject(@Nonnull JmxConnectionProvider server) throws IOException {
@@ -41,12 +49,22 @@ public class MBeanServerConnectionFactory extends BaseKeyedPoolableObjectFactory
 	}
 
 	@Override
-	public void destroyObject(@Nonnull JmxConnectionProvider key, @Nonnull JMXConnection jmxConnection) throws IOException {
+	public void destroyObject(@Nonnull JmxConnectionProvider key, @Nonnull final JMXConnection jmxConnection) throws IOException {
 		if (!jmxConnection.isAlive()) {
 			return;
 		}
 
-		jmxConnection.close();
+		jmxConnection.setMarkedAsDestroyed();
+
+		// when you call close it tries to notify server about it
+		// so if your server is down you will wait until connection timed out
+		// but we want to release thread asap
+		// that's why we do it here through ExecutorService
+		executor.submit(new Runnable() {
+			public void run() {
+				jmxConnection.close();
+			}
+		});
 	}
 
 	@Override

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/guice/JmxTransModule.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/guice/JmxTransModule.java
@@ -157,6 +157,8 @@ public class JmxTransModule extends AbstractModule {
 		pool.setTimeBetweenEvictionRunsMillis(MILLISECONDS.convert(5, MINUTES));
 		pool.setMinEvictableIdleTimeMillis(MILLISECONDS.convert(5, MINUTES));
 		pool.setMaxWait(maxWaitMillis);
+		pool.setTestOnReturn(true);
+		pool.setTestOnBorrow(true);
 
 		try {
 			ManagedGenericKeyedObjectPool mbean =

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/guice/JmxTransModule.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/guice/JmxTransModule.java
@@ -84,11 +84,11 @@ public class JmxTransModule extends AbstractModule {
 	@Override
 	protected void configure() {
 		bind(new TypeLiteral<GenericKeyedObjectPool<InetSocketAddress, Socket>>(){})
-				.toInstance(getObjectPool(new SocketFactory(), SocketFactory.class.getSimpleName()));
+				.toInstance(getObjectPool(new SocketFactory(), SocketFactory.class.getSimpleName(), 0));
 		bind(new TypeLiteral<GenericKeyedObjectPool<SocketAddress, DatagramSocket>>(){})
-				.toInstance(getObjectPool(new DatagramSocketFactory(), DatagramSocketFactory.class.getSimpleName()));
+				.toInstance(getObjectPool(new DatagramSocketFactory(), DatagramSocketFactory.class.getSimpleName(), 0));
 		bind(new TypeLiteral<KeyedObjectPool<JmxConnectionProvider, JMXConnection>>(){}).annotatedWith(Names.named("mbeanPool"))
-				.toInstance(getObjectPool(new MBeanServerConnectionFactory(), MBeanServerConnectionFactory.class.getSimpleName()));
+				.toInstance(getObjectPool(new MBeanServerConnectionFactory(), MBeanServerConnectionFactory.class.getSimpleName(), 20000));
 	}
 
 	@Provides
@@ -149,13 +149,14 @@ public class JmxTransModule extends AbstractModule {
 				.build();
 	}
 
-	private <K, V> GenericKeyedObjectPool<K, V> getObjectPool(KeyedPoolableObjectFactory<K, V> factory, String poolName) {
+	private <K, V> GenericKeyedObjectPool<K, V> getObjectPool(KeyedPoolableObjectFactory<K, V> factory, String poolName, long maxWaitMillis) {
 		GenericKeyedObjectPool<K, V> pool = new GenericKeyedObjectPool<>(factory);
 		pool.setTestOnBorrow(true);
 		pool.setMaxActive(-1);
 		pool.setMaxIdle(-1);
 		pool.setTimeBetweenEvictionRunsMillis(MILLISECONDS.convert(5, MINUTES));
 		pool.setMinEvictableIdleTimeMillis(MILLISECONDS.convert(5, MINUTES));
+		pool.setMaxWait(maxWaitMillis);
 
 		try {
 			ManagedGenericKeyedObjectPool mbean =

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/JmxTransRMIClientSocketFactory.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/JmxTransRMIClientSocketFactory.java
@@ -1,0 +1,49 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model;
+
+import javax.rmi.ssl.SslRMIClientSocketFactory;
+import java.io.IOException;
+import java.net.Socket;
+import java.rmi.server.RMIClientSocketFactory;
+import java.rmi.server.RMISocketFactory;
+
+public class JmxTransRMIClientSocketFactory implements RMIClientSocketFactory {
+	private final int timeoutMillis;
+	private RMIClientSocketFactory rmiClientSocketFactory;
+
+	public JmxTransRMIClientSocketFactory(int timeoutMillis, boolean ssl){
+		this.timeoutMillis = timeoutMillis;
+		this.rmiClientSocketFactory = ssl
+				? new SslRMIClientSocketFactory()
+				: RMISocketFactory.getDefaultSocketFactory();
+	}
+
+	@Override
+	public Socket createSocket(String host, int port) throws IOException {
+		Socket socket = rmiClientSocketFactory.createSocket(host, port);
+		socket.setSoTimeout( timeoutMillis );
+		socket.setSoLinger( false, 0 );
+		return socket;
+	}
+}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -55,7 +55,6 @@ import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
-import javax.rmi.ssl.SslRMIClientSocketFactory;
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -105,6 +104,7 @@ public class Server implements JmxConnectionProvider {
 	private static final String CONNECTOR_ADDRESS = "com.sun.management.jmxremote.localConnectorAddress";
 	private static final String FRONT = "service:jmx:rmi:///jndi/rmi://";
 	private static final String BACK = "/jmxrmi";
+	private static final int DEFAULT_SOCKET_SO_TIMEOUT_MILLIS = 10000;
 
 	private static final Logger logger = LoggerFactory.getLogger(Server.class);
 
@@ -317,17 +317,16 @@ public class Server implements JmxConnectionProvider {
 			environment.put(JMXConnector.CREDENTIALS, credentials);
 		}
 
-		if (ssl) {
-			SslRMIClientSocketFactory rmiClientSocketFactory = new SslRMIClientSocketFactory();
-			// The following is required when JMX is secured with SSL
-			// with com.sun.management.jmxremote.ssl=true
-			// as shown in http://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html#gdfvq
-			environment.put(RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, rmiClientSocketFactory);
-			// The following is required when JNDI Registry is secured with SSL
-			// with com.sun.management.jmxremote.registry.ssl=true
-			// This property is defined in com.sun.jndi.rmi.registry.RegistryContext.SOCKET_FACTORY
-			environment.put("com.sun.jndi.rmi.factory.socket", rmiClientSocketFactory);
-		}
+		JmxTransRMIClientSocketFactory rmiClientSocketFactory = new JmxTransRMIClientSocketFactory(DEFAULT_SOCKET_SO_TIMEOUT_MILLIS, ssl);
+		// The following is required when JMX is secured with SSL
+		// with com.sun.management.jmxremote.ssl=true
+		// as shown in http://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html#gdfvq
+		environment.put(RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, rmiClientSocketFactory);
+		// The following is required when JNDI Registry is secured with SSL
+		// with com.sun.management.jmxremote.registry.ssl=true
+		// This property is defined in com.sun.jndi.rmi.registry.RegistryContext.SOCKET_FACTORY
+		environment.put("com.sun.jndi.rmi.factory.socket", rmiClientSocketFactory);
+
 		return environment.build();
 	}
 

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -284,7 +284,7 @@ public class Server implements JmxConnectionProvider {
 			// since we will invalidate the connection in the pool, prevent connection leaks
 			try {
 				jmxConnection.close();
-			} catch (IOException | RuntimeException re) {
+			} catch (RuntimeException re) {
 				// drop these, we don't really know what caused the original exception.
 				logger.warn("An error occurred trying to close a JMX Connection during error handling.", re);
 			}

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -39,7 +40,7 @@ public class JmxTransformerTest {
 
 	@Test
 	public void startDateIsSpreadAccordingToRunPeriod() {
-		JmxTransformer jmxTransformer = new JmxTransformer(null, new JmxTransConfiguration(), null, null, null, null);
+		JmxTransformer jmxTransformer = new JmxTransformer(null, new JmxTransConfiguration(), null, null, mock(ThreadPoolExecutor.class), mock(ThreadPoolExecutor.class));
 
 		Date now = new Date();
 
@@ -51,7 +52,7 @@ public class JmxTransformerTest {
 	public void findProcessConfigFiles() throws URISyntaxException {
 		JmxTransConfiguration configuration = new JmxTransConfiguration();
 		configuration.setProcessConfigDir(new File(ConfigurationParserTest.class.getResource("/example.json").toURI()).getParentFile());
-		JmxTransformer jmxTransformer = new JmxTransformer(null, configuration, null, null, null, null);
+		JmxTransformer jmxTransformer = new JmxTransformer(null, configuration, null, null, mock(ThreadPoolExecutor.class), mock(ThreadPoolExecutor.class));
 
 		List<File> processConfigFiles = jmxTransformer.getProcessConfigFiles();
 

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/connections/MBeanServerConnectionFactoryTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/connections/MBeanServerConnectionFactoryTest.java
@@ -66,9 +66,12 @@ public class MBeanServerConnectionFactoryTest {
 
 	@Test
 	public void connectionIsClosedOnDestroy() throws IOException {
+		JmxConnectionProvider server = mock(JmxConnectionProvider.class);
 		JMXConnection connection = mock(JMXConnection.class);
 
-		factory.destroyObject(null, connection);
+		when(connection.isAlive()).thenReturn(true);
+
+		factory.destroyObject(server, connection);
 
 		verify(connection).close();
 	}

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/connections/MBeanServerConnectionFactoryTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/connections/MBeanServerConnectionFactoryTest.java
@@ -22,6 +22,7 @@
  */
 package com.googlecode.jmxtrans.connections;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import javax.management.MBeanServer;
@@ -30,9 +31,7 @@ import javax.management.remote.JMXConnector;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class MBeanServerConnectionFactoryTest {
 
@@ -73,7 +72,8 @@ public class MBeanServerConnectionFactoryTest {
 
 		factory.destroyObject(server, connection);
 
-		verify(connection).close();
+		verify(connection).setMarkedAsDestroyed();
+		verify(connection, timeout(2000)).close();
 	}
 
 }

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/JMXConnectionTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/JMXConnectionTest.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 public class JMXConnectionTest {
@@ -52,7 +51,7 @@ public class JMXConnectionTest {
 		JMXConnection jmxConnection = new JMXConnection(jmxConnector, mBeanServerConnection);
 
 		jmxConnection.close();
-		verify(jmxConnector, timeout(2000)).close();
+		verify(jmxConnector).close();
 	}
 
 	@Test

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/JMXConnectionTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/JMXConnectionTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 public class JMXConnectionTest {
@@ -51,8 +52,7 @@ public class JMXConnectionTest {
 		JMXConnection jmxConnection = new JMXConnection(jmxConnector, mBeanServerConnection);
 
 		jmxConnection.close();
-
-		verify(jmxConnector).close();
+		verify(jmxConnector, timeout(2000)).close();
 	}
 
 	@Test

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/ServerTests.java
@@ -327,18 +327,18 @@ public class ServerTests {
 
 		JMXConnection conn = mock(JMXConnection.class);
 		when(conn.getMBeanServerConnection()).thenReturn(mBeanConn);
-		doThrow(new IOException()).when(conn).close();
+		doThrow(new RuntimeException()).when(conn).close();
 
 		when(pool.borrowObject(server)).thenReturn(conn);
 
 		Query query = mock(Query.class);
-		IOException e = mock(IOException.class);
+		RuntimeException e = mock(RuntimeException.class);
 		when(query.queryNames(mBeanConn)).thenThrow(e);
 
 		try {
 			server.execute(query);
 			fail("No exception got throws");
-		} catch (IOException e2) {
+		} catch (RuntimeException e2) {
 			if (e != e2) {
 				fail("Wrong exception thrown (" + e + " instead of mock");
 			}


### PR DESCRIPTION
JMXConnector works slowly when server unavailable and executor thread pool fills up quickly. This changes can reduce awaiting duration.

This fixes refers to https://github.com/jmxtrans/jmxtrans/issues/626