### PR TITLE
Separate thread pool executors

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
@@ -31,6 +31,7 @@ import com.googlecode.jmxtrans.classloader.ClassLoaderEnricher;
 import com.googlecode.jmxtrans.cli.JCommanderArgumentParser;
 import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.executors.ExecutorRepository;
 import com.googlecode.jmxtrans.guice.JmxTransModule;
 import com.googlecode.jmxtrans.jobs.ServerJob;
 import com.googlecode.jmxtrans.model.JmxProcess;
@@ -56,8 +57,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.text.ParseException;
@@ -99,9 +102,13 @@ public class JmxTransformer implements WatchedCallback {
 	private Thread shutdownHook = new ShutdownHook();
 
 	private volatile boolean isRunning = false;
-	@Nonnull private final ThreadPoolExecutor queryProcessorExecutor;
-	@Nonnull private final ThreadPoolExecutor resultProcessorExecutor;
+	@Nonnull private ExecutorRepository queryExecutorRepository;
+	@Nonnull private ExecutorRepository resultExecutorRepository;
 	@Nonnull private final ThreadLocalRandom random = ThreadLocalRandom.current();
+	@Nonnull private final MBeanServer platformMBeanServer;
+	@Nullable private ManagedJmxTransformerProcess jmxTransformerProcessMBean;
+	@Nullable private ImmutableList<ManagedThreadPoolExecutor> queryExecutorMBeans;
+	@Nullable private ImmutableList<ManagedThreadPoolExecutor> resultExecutorMBeans;
 
 	@Inject
 	public JmxTransformer(
@@ -109,14 +116,16 @@ public class JmxTransformer implements WatchedCallback {
 			JmxTransConfiguration configuration,
 			ConfigurationParser configurationParser,
 			Injector injector,
-			@Nonnull @Named("queryProcessorExecutor") ThreadPoolExecutor queryProcessorExecutor,
-			@Nonnull @Named("resultProcessorExecutor") ThreadPoolExecutor resultProcessorExecutor) {
+			@Nonnull @Named("queryExecutorRepository") ExecutorRepository queryExecutorRepository,
+			@Nonnull @Named("resultExecutorRepository") ExecutorRepository resultExecutorRepository) {
 		this.serverScheduler = serverScheduler;
 		this.configuration = configuration;
 		this.configurationParser = configurationParser;
 		this.injector = injector;
-		this.queryProcessorExecutor = queryProcessorExecutor;
-		this.resultProcessorExecutor = resultProcessorExecutor;
+		this.queryExecutorRepository = queryExecutorRepository;
+		this.resultExecutorRepository = resultExecutorRepository;
+
+		this.platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
 	}
 
 	public static void main(String[] args) throws Exception {
@@ -142,17 +151,6 @@ public class JmxTransformer implements WatchedCallback {
 	 * The real main method.
 	 */
 	private void doMain() throws Exception {
-		MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
-
-		ManagedJmxTransformerProcess mbean = new ManagedJmxTransformerProcess(this, configuration);
-		platformMBeanServer.registerMBean(mbean, mbean.getObjectName());
-
-		ManagedThreadPoolExecutor queryExecutorMBean = new ManagedThreadPoolExecutor(queryProcessorExecutor, "queryProcessorExecutor");
-		platformMBeanServer.registerMBean(queryExecutorMBean, queryExecutorMBean.getObjectName());
-
-		ManagedThreadPoolExecutor resultExecutorMBean = new ManagedThreadPoolExecutor(resultProcessorExecutor, "resultProcessorExecutor");
-		platformMBeanServer.registerMBean(resultExecutorMBean, resultExecutorMBean.getObjectName());
-
 		// Start the process
 		this.start();
 
@@ -169,9 +167,7 @@ public class JmxTransformer implements WatchedCallback {
 			}
 		}
 
-		platformMBeanServer.unregisterMBean(mbean.getObjectName());
-		platformMBeanServer.unregisterMBean(queryExecutorMBean.getObjectName());
-		platformMBeanServer.unregisterMBean(resultExecutorMBean.getObjectName());
+		this.unregisterMBeans();
 	}
 
 	public synchronized void start() throws LifecycleException {
@@ -237,8 +233,13 @@ public class JmxTransformer implements WatchedCallback {
 				}
 			}
 
-			shutdownAndAwaitTermination(queryProcessorExecutor, 10, SECONDS);
-			shutdownAndAwaitTermination(resultProcessorExecutor, 10, SECONDS);
+			for (ThreadPoolExecutor executor : queryExecutorRepository.getExecutors()) {
+				shutdownAndAwaitTermination(executor, 10, SECONDS);
+			}
+
+			for (ThreadPoolExecutor executor : resultExecutorRepository.getExecutors()) {
+				shutdownAndAwaitTermination(executor, 10, SECONDS);
+			}
 
 			// Shutdown the file watch service
 			if (watcher != null) {
@@ -317,12 +318,22 @@ public class JmxTransformer implements WatchedCallback {
 	/**
 	 * Processes files into Server objects and then processesServers into jobs
 	 */
-	private void startupSystem() throws LifecycleException {
-		// process all the json files into Server objects
+	private void startupSystem() throws Exception {
 		this.processFilesIntoServers();
-
-		// process the servers into jobs
+		this.initializeExecutors();
+		this.registerMBeans();
 		this.processServersIntoJobs();
+	}
+
+	private void initializeExecutors() throws MalformedObjectNameException {
+		this.initializeExecutors(queryExecutorRepository);
+		this.initializeExecutors(resultExecutorRepository);
+	}
+
+	private void initializeExecutors(ExecutorRepository executorRepository) throws MalformedObjectNameException {
+		for (Server server : this.masterServersList) {
+			executorRepository.put(server);
+		}
 	}
 
 	private void validateSetup(Server server, ImmutableSet<Query> queries) throws ValidationException {
@@ -382,6 +393,41 @@ public class JmxTransformer implements WatchedCallback {
 				throw new LifecycleException("Error scheduling job for server: " + server, ex);
 			} catch (ValidationException ex) {
 				throw new LifecycleException("Error validating json setup for query", ex);
+			}
+		}
+	}
+
+	private void registerMBeans() throws Exception {
+		jmxTransformerProcessMBean = new ManagedJmxTransformerProcess(this, configuration);
+		platformMBeanServer.registerMBean(jmxTransformerProcessMBean, jmxTransformerProcessMBean.getObjectName());
+
+		queryExecutorMBeans = registerExecutors(queryExecutorRepository);
+		resultExecutorMBeans = registerExecutors(resultExecutorRepository);
+	}
+
+	private ImmutableList<ManagedThreadPoolExecutor> registerExecutors(ExecutorRepository executorRepository) throws Exception {
+		ImmutableList.Builder<ManagedThreadPoolExecutor> executorMBeansBuilder = ImmutableList.builder();
+		for (ManagedThreadPoolExecutor executorMBean : executorRepository.getMBeans()) {
+			platformMBeanServer.registerMBean(executorMBean, executorMBean.getObjectName());
+			executorMBeansBuilder.add(executorMBean);
+		}
+
+		return executorMBeansBuilder.build();
+	}
+
+	private void unregisterMBeans() throws Exception {
+		if (jmxTransformerProcessMBean != null) {
+			platformMBeanServer.unregisterMBean(jmxTransformerProcessMBean.getObjectName());
+		}
+
+		unregisterExecutors(queryExecutorMBeans);
+		unregisterExecutors(resultExecutorMBeans);
+	}
+
+	private void unregisterExecutors(ImmutableList<ManagedThreadPoolExecutor> executorMBeans) throws Exception {
+		if (executorMBeans != null) {
+			for (ManagedThreadPoolExecutor executorMBean : executorMBeans) {
+				platformMBeanServer.unregisterMBean(executorMBean.getObjectName());
 			}
 		}
 	}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/cli/JmxTransConfiguration.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/cli/JmxTransConfiguration.java
@@ -144,4 +144,10 @@ public class JmxTransConfiguration {
 	@Getter @Setter
 	private int resultProcessorExecutorWorkQueueCapacity = 100000;
 
+	@Parameter(
+			names = {"--use-separate-executors"},
+			description = "If this set every server node will be handed by separate executor."
+	)
+	@Getter @Setter
+	private boolean useSeparateExecutors = false;
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/CommonExecutorRepository.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/CommonExecutorRepository.java
@@ -1,0 +1,62 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.executors;
+
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.monitoring.ManagedThreadPoolExecutor;
+
+import javax.annotation.Nonnull;
+import javax.management.MalformedObjectNameException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class CommonExecutorRepository implements ExecutorRepository {
+
+	@Nonnull
+	private final ManagedThreadPoolExecutor managedThreadPoolExecutor;
+
+	public CommonExecutorRepository(ExecutorFactory executorFactory) throws MalformedObjectNameException {
+		this.managedThreadPoolExecutor = executorFactory.create(null);
+	}
+
+	@Override
+	public void put(Server server) throws MalformedObjectNameException {
+		//nothing here because every server uses common thread pool
+	}
+
+	@Override
+	public Collection<ThreadPoolExecutor> getExecutors() {
+		return Arrays.asList(managedThreadPoolExecutor.getExecutor());
+	}
+
+	@Override
+	public ThreadPoolExecutor getExecutor(Server server) {
+		return managedThreadPoolExecutor.getExecutor();
+	}
+
+	@Override
+	public Collection<ManagedThreadPoolExecutor> getMBeans() {
+		return Arrays.asList(managedThreadPoolExecutor);
+	}
+}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/ExecutorFactory.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/ExecutorFactory.java
@@ -1,0 +1,69 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.executors;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.googlecode.jmxtrans.monitoring.ManagedThreadPoolExecutor;
+
+import javax.management.MalformedObjectNameException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class ExecutorFactory {
+	private final int defaultPoolSize;
+	private final int defaultWorkQueueCapacity;
+	private final String executorAlias;
+
+	public ExecutorFactory(int defaultPoolSize, int defaultWorkQueueCapacity, String executorAlias) {
+		this.defaultPoolSize = defaultPoolSize;
+		this.defaultWorkQueueCapacity = defaultWorkQueueCapacity;
+		this.executorAlias = executorAlias;
+	}
+
+	public ManagedThreadPoolExecutor create(String aliasSuffix) throws MalformedObjectNameException {
+		final String serverAlias = aliasSuffix == null
+				? executorAlias
+				: String.format("%s-%s", executorAlias, aliasSuffix);
+		ThreadFactory threadFactory = threadFactory(serverAlias);
+
+		BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>(defaultWorkQueueCapacity);
+
+		// each server can have different settings in separate thread pool strategy
+		// this logic can be implemented in json/yaml configs if it will be needed
+		final ThreadPoolExecutor executor = new ThreadPoolExecutor(defaultPoolSize, defaultPoolSize, 0L, MILLISECONDS, workQueue, threadFactory);
+		ManagedThreadPoolExecutor executorMBean = new ManagedThreadPoolExecutor(executor, serverAlias);
+
+		return executorMBean;
+	}
+
+	private static ThreadFactory threadFactory(String alias) {
+		return new ThreadFactoryBuilder()
+				.setDaemon(true)
+				.setNameFormat("jmxtrans-" + alias + "-%d")
+				.build();
+	}
+}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/ExecutorRepository.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/ExecutorRepository.java
@@ -1,0 +1,38 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.executors;
+
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.monitoring.ManagedThreadPoolExecutor;
+
+import javax.management.MalformedObjectNameException;
+import java.util.Collection;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public interface ExecutorRepository {
+	void put(Server server) throws MalformedObjectNameException;
+	Collection<ThreadPoolExecutor> getExecutors();
+	ThreadPoolExecutor getExecutor(Server server);
+	Collection<ManagedThreadPoolExecutor> getMBeans();
+}
+

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/SeparateExecutorRepository.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/SeparateExecutorRepository.java
@@ -1,0 +1,68 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.executors;
+
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.monitoring.ManagedThreadPoolExecutor;
+
+import javax.annotation.Nonnull;
+import javax.management.MalformedObjectNameException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Hashtable;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class SeparateExecutorRepository implements ExecutorRepository {
+	@Nonnull private final Hashtable<Server, ThreadPoolExecutor> repository;
+	@Nonnull private final ExecutorFactory executorFactory;
+	@Nonnull private final ArrayList<ManagedThreadPoolExecutor> mBeans;
+
+	public SeparateExecutorRepository(ExecutorFactory executorFactory){
+		this.executorFactory = executorFactory;
+		this.repository = new Hashtable<>();
+		mBeans = new ArrayList<>();
+	}
+
+	@Override
+	public Collection<ThreadPoolExecutor> getExecutors() {
+		return repository.values();
+	}
+
+	@Override
+	public ThreadPoolExecutor getExecutor(Server server) {
+		return repository.get(server);
+	}
+
+	@Override
+	public Collection<ManagedThreadPoolExecutor> getMBeans() {
+		return mBeans;
+	}
+
+	@Override
+	public void put(Server server) throws MalformedObjectNameException {
+		final ManagedThreadPoolExecutor managedThreadPoolExecutor = executorFactory.create(server.getId());
+		repository.put(server, managedThreadPoolExecutor.getExecutor());
+		mBeans.add(managedThreadPoolExecutor);
+	}
+}
+

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/SeparateExecutorRepository.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/SeparateExecutorRepository.java
@@ -29,17 +29,17 @@ import javax.annotation.Nonnull;
 import javax.management.MalformedObjectNameException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadPoolExecutor;
 
 public class SeparateExecutorRepository implements ExecutorRepository {
-	@Nonnull private final Hashtable<Server, ThreadPoolExecutor> repository;
+	@Nonnull private final ConcurrentHashMap<Server, ThreadPoolExecutor> repository;
 	@Nonnull private final ExecutorFactory executorFactory;
 	@Nonnull private final ArrayList<ManagedThreadPoolExecutor> mBeans;
 
 	public SeparateExecutorRepository(ExecutorFactory executorFactory){
 		this.executorFactory = executorFactory;
-		this.repository = new Hashtable<>();
+		this.repository = new ConcurrentHashMap<>();
 		mBeans = new ArrayList<>();
 	}
 

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/SeparateExecutorRepository.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/SeparateExecutorRepository.java
@@ -27,20 +27,22 @@ import com.googlecode.jmxtrans.monitoring.ManagedThreadPoolExecutor;
 
 import javax.annotation.Nonnull;
 import javax.management.MalformedObjectNameException;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ThreadPoolExecutor;
 
 public class SeparateExecutorRepository implements ExecutorRepository {
 	@Nonnull private final ConcurrentHashMap<Server, ThreadPoolExecutor> repository;
 	@Nonnull private final ExecutorFactory executorFactory;
-	@Nonnull private final ArrayList<ManagedThreadPoolExecutor> mBeans;
+	@Nonnull private final List<ManagedThreadPoolExecutor> mBeans;
 
 	public SeparateExecutorRepository(ExecutorFactory executorFactory){
 		this.executorFactory = executorFactory;
 		this.repository = new ConcurrentHashMap<>();
-		mBeans = new ArrayList<>();
+		mBeans = new CopyOnWriteArrayList<>();
 	}
 
 	@Override
@@ -55,7 +57,7 @@ public class SeparateExecutorRepository implements ExecutorRepository {
 
 	@Override
 	public Collection<ManagedThreadPoolExecutor> getMBeans() {
-		return mBeans;
+		return Collections.unmodifiableList(mBeans);
 	}
 
 	@Override

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/guice/JmxTransModule.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/guice/JmxTransModule.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.module.guice.ObjectMapperModule;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -43,6 +42,10 @@ import com.googlecode.jmxtrans.connections.JMXConnection;
 import com.googlecode.jmxtrans.connections.JmxConnectionProvider;
 import com.googlecode.jmxtrans.connections.MBeanServerConnectionFactory;
 import com.googlecode.jmxtrans.connections.SocketFactory;
+import com.googlecode.jmxtrans.executors.CommonExecutorRepository;
+import com.googlecode.jmxtrans.executors.ExecutorFactory;
+import com.googlecode.jmxtrans.executors.ExecutorRepository;
+import com.googlecode.jmxtrans.executors.SeparateExecutorRepository;
 import com.googlecode.jmxtrans.monitoring.ManagedGenericKeyedObjectPool;
 import org.apache.commons.pool.KeyedObjectPool;
 import org.apache.commons.pool.KeyedPoolableObjectFactory;
@@ -54,6 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.management.MalformedObjectNameException;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -63,10 +67,6 @@ import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -118,35 +118,30 @@ public class JmxTransModule extends AbstractModule {
 
 	@Provides
 	@Singleton
-	@Named("queryProcessorExecutor")
-	ThreadPoolExecutor queryProcessorExecutor() {
+	@Named("queryExecutorRepository")
+	ExecutorRepository queryExecutorRepository() throws MalformedObjectNameException {
 		int poolSize = configuration.getQueryProcessorExecutorPoolSize();
 		int workQueueCapacity = configuration.getQueryProcessorExecutorWorkQueueCapacity();
-		String componentName = "query";
-		return createExecutorService(poolSize, workQueueCapacity, componentName);
+		String executorAlias = "query";
+		return createExecutorRepository(poolSize, workQueueCapacity, executorAlias);
 	}
 
 	@Provides
 	@Singleton
-	@Named("resultProcessorExecutor")
-	ThreadPoolExecutor resultProcessorExecutor() {
+	@Named("resultExecutorRepository")
+	ExecutorRepository resultExecutorRepository() throws MalformedObjectNameException {
 		int poolSize = configuration.getResultProcessorExecutorPoolSize();
 		int workQueueCapacity = configuration.getResultProcessorExecutorWorkQueueCapacity();
-		String componentName = "result";
-		return createExecutorService(poolSize, workQueueCapacity, componentName);
+		String executorAlias = "result";
+		return createExecutorRepository(poolSize, workQueueCapacity, executorAlias);
 	}
 
-	private ThreadPoolExecutor createExecutorService(int poolSize, int workQueueCapacity, String componentName) {
-		BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>(workQueueCapacity);
-		ThreadFactory threadFactory = threadFactory(componentName);
-		return new ThreadPoolExecutor(poolSize, poolSize, 0L, MILLISECONDS, workQueue, threadFactory);
-	}
-
-	private ThreadFactory threadFactory(String componentName) {
-		return new ThreadFactoryBuilder()
-				.setDaemon(true)
-				.setNameFormat("jmxtrans-" + componentName + "-%d")
-				.build();
+	private ExecutorRepository createExecutorRepository(int poolSize, int workQueueCapacity, String executorAlias) throws MalformedObjectNameException {
+		final ExecutorFactory executorFactory = new ExecutorFactory(poolSize, workQueueCapacity, executorAlias);
+		final boolean useSeparateExecutors = configuration.isUseSeparateExecutors();
+		return useSeparateExecutors
+			? new SeparateExecutorRepository(executorFactory)
+			: new CommonExecutorRepository(executorFactory);
 	}
 
 	private <K, V> GenericKeyedObjectPool<K, V> getObjectPool(KeyedPoolableObjectFactory<K, V> factory, String poolName, long maxWaitMillis) {

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jmx/ResultProcessor.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/jmx/ResultProcessor.java
@@ -24,6 +24,7 @@ package com.googlecode.jmxtrans.jmx;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import com.googlecode.jmxtrans.executors.ExecutorRepository;
 import com.googlecode.jmxtrans.model.OutputWriter;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
@@ -41,17 +42,21 @@ public class ResultProcessor {
 
 	private final Logger logger = LoggerFactory.getLogger(ResultProcessor.class);
 
-	@Nonnull private final ThreadPoolExecutor executorService;
+	@Nonnull private final ExecutorRepository resultExecutorRepository;
 
 	@Inject
-	public ResultProcessor(@Named("resultProcessorExecutor") @Nonnull ThreadPoolExecutor executorService) {
-		this.executorService = executorService;
+	public ResultProcessor(
+			@Nonnull @Named("resultExecutorRepository") ExecutorRepository resultExecutorRepository
+	) {
+		this.resultExecutorRepository = resultExecutorRepository;
 	}
 
 	public void submit(@Nonnull final Server server, @Nonnull final Query query, @Nonnull final Iterable<Result> results) {
+		final ThreadPoolExecutor executor = resultExecutorRepository.getExecutor(server);
+
 		for (final OutputWriter writer : concat(query.getOutputWriterInstances(), server.getOutputWriters())) {
 			try {
-				executorService.submit(new Runnable() {
+				executor.submit(new Runnable() {
 					@Override
 					public void run() {
 						try {

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -108,6 +108,9 @@ public class Server implements JmxConnectionProvider {
 
 	private static final Logger logger = LoggerFactory.getLogger(Server.class);
 
+	/** Returns id for internal logic */
+	@Getter private final String id;
+
 	/**
 	 * Some writers (GraphiteWriter) use the alias in generation of the unique
 	 * key which references this server.
@@ -267,6 +270,7 @@ public class Server implements JmxConnectionProvider {
 		this.pool = checkNotNull(pool);
 		this.outputWriterFactories = ImmutableList.copyOf(firstNonNull(outputWriterFactories, ImmutableList.<OutputWriterFactory>of()));
 		this.outputWriters = ImmutableList.copyOf(firstNonNull(outputWriters, ImmutableList.<OutputWriter>of()));
+		this.id = String.format("%s_%s_%s", host, port, pid);
 	}
 
 	public Iterable<Result> execute(Query query) throws Exception {

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/monitoring/ManagedThreadPoolExecutor.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/monitoring/ManagedThreadPoolExecutor.java
@@ -22,6 +22,8 @@
  */
 package com.googlecode.jmxtrans.monitoring;
 
+import lombok.Getter;
+
 import javax.annotation.Nonnull;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -31,7 +33,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class ManagedThreadPoolExecutor implements ThreadPoolExecutorMXBean {
 
-	@Nonnull private final ThreadPoolExecutor executor;
+	@Getter @Nonnull private final ThreadPoolExecutor executor;
 	private ObjectName objectName;
 
 	public ManagedThreadPoolExecutor(@Nonnull ThreadPoolExecutor executor, @Nonnull String name) throws MalformedObjectNameException {

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/JmxTransformerTest.java
@@ -23,13 +23,13 @@
 package com.googlecode.jmxtrans;
 
 import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
+import com.googlecode.jmxtrans.executors.ExecutorRepository;
 import org.junit.Test;
 
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.ThreadPoolExecutor;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -40,7 +40,7 @@ public class JmxTransformerTest {
 
 	@Test
 	public void startDateIsSpreadAccordingToRunPeriod() {
-		JmxTransformer jmxTransformer = new JmxTransformer(null, new JmxTransConfiguration(), null, null, mock(ThreadPoolExecutor.class), mock(ThreadPoolExecutor.class));
+		JmxTransformer jmxTransformer = new JmxTransformer(null, new JmxTransConfiguration(), null, null, mock(ExecutorRepository.class), mock(ExecutorRepository.class));
 
 		Date now = new Date();
 
@@ -52,7 +52,7 @@ public class JmxTransformerTest {
 	public void findProcessConfigFiles() throws URISyntaxException {
 		JmxTransConfiguration configuration = new JmxTransConfiguration();
 		configuration.setProcessConfigDir(new File(ConfigurationParserTest.class.getResource("/example.json").toURI()).getParentFile());
-		JmxTransformer jmxTransformer = new JmxTransformer(null, configuration, null, null, mock(ThreadPoolExecutor.class), mock(ThreadPoolExecutor.class));
+		JmxTransformer jmxTransformer = new JmxTransformer(null, configuration, null, null, mock(ExecutorRepository.class), mock(ExecutorRepository.class));
 
 		List<File> processConfigFiles = jmxTransformer.getProcessConfigFiles();
 


### PR DESCRIPTION
As I mentioned at https://github.com/jmxtrans/jmxtrans/issues/626 I found trouble behavior with common thread pool. For backward compatibility I implemented it though another strategy. I've tried it on production and it works. Dead server didn't affect another servers.

In future it can be extended. Server config may contain executor settings for each server.