### PR TITLE
Added optional time socket expiration for GraphiteWriterFactory.

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
@@ -114,7 +114,6 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 					.setFlushStrategy(flushStrategy)
 					.setPoolSize(poolSize)
 					.setPoolClaimTimeoutSeconds(poolClaimTimeoutSeconds)
-					.setSocketExpirationMs(socketExpirationMs)
 					.build();
 		} else {
 			writerPoolOutputWriter = TcpOutputWriterBuilder.builder(graphiteServer, new GraphiteWriter2(typeNames, rootPrefix))

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/GraphiteWriterFactory.java
@@ -65,6 +65,7 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 	private final int poolSize;
 	private final int socketTimeoutMs;
 	private final Integer poolClaimTimeoutSeconds;
+	private final int socketExpirationMs;
 
 	/**
 	 * protocol to use to send metrics to graphite server.
@@ -84,7 +85,8 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 			@JsonProperty("poolSize") Integer poolSize,
 			@JsonProperty("socketTimeoutMs") Integer socketTimeoutMs,
 			@JsonProperty("poolClaimTimeoutSeconds") Integer poolClaimTimeoutSeconds,
-			@JsonProperty("protocol") String protocol) {
+			@JsonProperty("protocol") String protocol,
+			@JsonProperty("socketExpirationMs") Integer socketExpirationMs) {
 
 		this.typeNames = typeNames;
 		this.booleanAsNumber = booleanAsNumber;
@@ -98,6 +100,7 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 		this.socketTimeoutMs = firstNonNull(socketTimeoutMs, 200);
 		this.poolClaimTimeoutSeconds = firstNonNull(poolClaimTimeoutSeconds, 1);
 		this.protocol = firstNonNull(protocol, DEFAULT_PROTOCOL);
+		this.socketExpirationMs = firstNonNull(socketExpirationMs, 0);
 	}
 
 	@Override
@@ -111,6 +114,7 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 					.setFlushStrategy(flushStrategy)
 					.setPoolSize(poolSize)
 					.setPoolClaimTimeoutSeconds(poolClaimTimeoutSeconds)
+					.setSocketExpirationMs(socketExpirationMs)
 					.build();
 		} else {
 			writerPoolOutputWriter = TcpOutputWriterBuilder.builder(graphiteServer, new GraphiteWriter2(typeNames, rootPrefix))
@@ -119,6 +123,7 @@ public class GraphiteWriterFactory implements OutputWriterFactory {
 					.setPoolSize(poolSize)
 					.setSocketTimeoutMillis(socketTimeoutMs)
 					.setPoolClaimTimeoutSeconds(poolClaimTimeoutSeconds)
+					.setSocketExpirationMs(socketExpirationMs)
 					.build();
 
 		}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriterBuilder.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/TcpOutputWriterBuilder.java
@@ -32,6 +32,7 @@ import com.googlecode.jmxtrans.model.output.support.pool.SocketPoolable;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import stormpot.BlazePool;
+import stormpot.CompoundExpiration;
 import stormpot.Config;
 import stormpot.Expiration;
 import stormpot.LifecycledPool;
@@ -83,7 +84,9 @@ public class TcpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
 		if (socketExpirationMs <= 0) {
 			return new SocketExpiration();
 		} else {
-			return new TimeExpiration<SocketPoolable>(socketExpirationMs, MILLISECONDS);
+			return new CompoundExpiration<>(
+					new TimeExpiration<SocketPoolable>(socketExpirationMs, MILLISECONDS),
+					new SocketExpiration());
 		}
 	}
 

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/UdpOutputWriterBuilder.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/support/UdpOutputWriterBuilder.java
@@ -32,13 +32,16 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import stormpot.BlazePool;
 import stormpot.Config;
+import stormpot.Expiration;
 import stormpot.LifecycledPool;
+import stormpot.TimeExpiration;
 import stormpot.Timeout;
 
 import javax.annotation.Nonnull;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Accessors(chain = true)
@@ -50,6 +53,7 @@ public class UdpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
 	@Setter private int poolSize = 1;
 	@Nonnull @Setter private FlushStrategy flushStrategy = new NeverFlush();
 	@Setter private int poolClaimTimeoutSeconds = 1;
+	@Setter private int socketExpirationMs;
 
 	private UdpOutputWriterBuilder(@Nonnull InetSocketAddress server, @Nonnull T target) {
 		this.server = server;
@@ -69,9 +73,17 @@ public class UdpOutputWriterBuilder<T extends WriterBasedOutputWriter> {
 						bufferSize,
 						charset,
 						flushStrategy))
-				.setExpiration(new DatagramChannelExpiration())
+				.setExpiration(createSocketExpiration())
 				.setSize(poolSize);
 		return new BlazePool<>(config);
+	}
+
+	private Expiration<DatagramChannelPoolable> createSocketExpiration() {
+		if (socketExpirationMs <= 0) {
+			return new DatagramChannelExpiration();
+		} else {
+			return new TimeExpiration<DatagramChannelPoolable>(socketExpirationMs, MILLISECONDS);
+		}
 	}
 
 	public WriterPoolOutputWriter<T> build() {

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/DummySequenceWriterBasedOutputWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/support/DummySequenceWriterBasedOutputWriter.java
@@ -1,0 +1,47 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output.support;
+
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.Writer;
+
+public class DummySequenceWriterBasedOutputWriter implements WriterBasedOutputWriter {
+
+	private final String message;
+	private int sequence;
+
+	public DummySequenceWriterBasedOutputWriter(String message) {
+		this.message = message;
+	}
+
+	@Override
+	public void write(@Nonnull Writer writer, @Nonnull Server server, @Nonnull Query query, @Nonnull Iterable<Result> results) throws IOException {
+		writer.write(message + sequence++ + "\n");
+		writer.flush();
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/resources/graphite-writer-factory-example-with-timed-socket-expiration.json
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/resources/graphite-writer-factory-example-with-timed-socket-expiration.json
@@ -1,0 +1,20 @@
+{
+  "servers" : [ {
+    "port" : "1099",
+    "host" : "w2",
+    "queries" : [ {
+      "obj" : "kafka.server:type=BrokerTopicMetrics,name=*",
+      "resultAlias" : "brokerTopic",
+      "attr" : ["Count","OneMinuteRate","FifteenMinuteRate"],
+      "outputWriters" : [ {
+        "@class" : "com.googlecode.jmxtrans.model.output.GraphiteWriterFactory",
+        "port" : 2003,
+        "host" : "192.168.192.133",
+        "typeNames" : ["name"],
+        "socketTimeoutMs" : 1000,
+        "poolClaimTimeoutSeconds" : 2,
+        "socketExpirationMs" : 15000
+      } ]
+    } ]
+  } ]
+}

--- a/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/TCPEchoServer.java
+++ b/jmxtrans-test-utils/src/main/java/com/googlecode/jmxtrans/test/TCPEchoServer.java
@@ -37,6 +37,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkState;
@@ -50,6 +51,7 @@ public class TCPEchoServer extends ExternalResource {
 
 	private final Object startSynchro = new Object();
 	private final ConcurrentLinkedQueue<String> receivedMessages = new ConcurrentLinkedQueue<>();
+	private final AtomicInteger connectionsAccepted = new AtomicInteger();
 
 	@Override
 	public void before() {
@@ -99,6 +101,7 @@ public class TCPEchoServer extends ExternalResource {
 
 	private void processRequests(ServerSocket server) throws IOException {
 		Socket socket = server.accept();
+		connectionsAccepted.incrementAndGet();
 		try (
 				BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream(), UTF_8));
 				PrintWriter out = new PrintWriter(new OutputStreamWriter(socket.getOutputStream(), UTF_8))
@@ -126,5 +129,9 @@ public class TCPEchoServer extends ExternalResource {
 	public InetSocketAddress getLocalSocketAddress()  {
 		checkState(server != null, "Server not started");
 		return new InetSocketAddress("localhost", server.getLocalPort());
+	}
+
+	public int getConnectionsAccepted() {
+		return connectionsAccepted.get();
 	}
 }


### PR DESCRIPTION
This adds an optional socket expiration timeout for `GraphiteWriterFactory`, which is useful if your graphite host is behind a load balancer that does not support indefinite idle connections, for example AWS classic ELB.