### PR TITLE
Add new ZabbixWriterFactory for outputting metrics to Zabbix

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/ZabbixWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/ZabbixWriter.java
@@ -89,12 +89,12 @@ public class ZabbixWriter implements WriterBasedOutputWriter {
 				g.writeStringField("host", server.getHost());
 				g.writeStringField("key", key);
 				g.writeStringField("value", value.toString());
-				g.writeNumberField("clock", result.getEpoch());
+				g.writeNumberField("clock", result.getEpoch() / 1000);
 				g.writeEndObject();
 			}
 
 			g.writeEndArray();
-			g.writeNumberField("clock", System.currentTimeMillis());
+			g.writeNumberField("clock", System.currentTimeMillis() / 1000);
 			g.writeEndObject();
 			g.flush();
 		} catch (Throwable t) {

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/ZabbixWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/ZabbixWriter.java
@@ -1,0 +1,106 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.naming.KeyUtils;
+import com.googlecode.jmxtrans.model.output.support.WriterBasedOutputWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import java.io.IOException;
+import java.io.Writer;
+
+@ThreadSafe
+public class ZabbixWriter implements WriterBasedOutputWriter {
+	private static final Logger log = LoggerFactory.getLogger(ZabbixWriter.class);
+
+	@Nonnull private final JsonFactory jsonFactory;
+	@Nonnull private final ImmutableList<String> typeNames;
+
+	public ZabbixWriter(@Nonnull JsonFactory jsonFactory, @Nonnull ImmutableList<String> typeNames) {
+		this.jsonFactory = jsonFactory;
+		this.typeNames = typeNames;
+	}
+
+	@Override
+	public void write(
+			@Nonnull Writer writer,
+			@Nonnull Server server,
+			@Nonnull Query query,
+			@Nonnull Iterable<Result> results) throws IOException {
+
+		/* Zabbix Sender JSON
+		{
+			"request":"sender data",
+			"data":[
+				{ "host":"Host name 1", "key":"item_key", "value":"33", "clock": 1381482894 },
+				{ "host":"Host name 2", "key":"item_key", "value":"55", "clock": 1381482894 }
+			],
+			"clock": 1381482905
+		}
+		*/
+		Closer closer = Closer.create();
+
+		try {
+			JsonGenerator g = jsonFactory.createGenerator(writer);
+
+			g.useDefaultPrettyPrinter();
+			g.writeStartObject();
+			g.writeStringField("request", "sender data");
+			g.writeArrayFieldStart("data");
+
+			for (Result result : results) {
+				log.debug("Query result: {}", result);
+
+				Object value = result.getValue();
+
+				String key = "jmxtrans." + KeyUtils.getKeyString(query, result, typeNames);
+
+				g.writeStartObject();
+				g.writeStringField("host", server.getHost());
+				g.writeStringField("key", key);
+				g.writeStringField("value", value.toString());
+				g.writeNumberField("clock", result.getEpoch());
+				g.writeEndObject();
+			}
+
+			g.writeEndArray();
+			g.writeNumberField("clock", System.currentTimeMillis());
+			g.writeEndObject();
+			g.flush();
+		} catch (Throwable t) {
+			throw closer.rethrow(t);
+		} finally {
+			closer.close();
+		}
+	}
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/ZabbixWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/ZabbixWriterFactory.java
@@ -57,8 +57,6 @@ public class ZabbixWriterFactory implements OutputWriterFactory {
 	private final boolean booleanAsNumber;
 	@Nonnull private final FlushStrategy flushStrategy;
 	private final int poolSize;
-	private final int socketTimeoutMs;
-	private final Integer poolClaimTimeoutSeconds;
 
 	public ZabbixWriterFactory(
 			@JsonProperty("typeNames") ImmutableList<String> typeNames,
@@ -67,36 +65,29 @@ public class ZabbixWriterFactory implements OutputWriterFactory {
 			@JsonProperty("port") Integer port,
 			@JsonProperty("flushStrategy") String flushStrategy,
 			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
-			@JsonProperty("poolSize") Integer poolSize,
-			@JsonProperty("socketTimeoutMs") Integer socketTimeoutMs,
-			@JsonProperty("poolClaimTimeoutSeconds") Integer poolClaimTimeoutSeconds) {
-
+			@JsonProperty("poolSize") Integer poolSize) {
 		this.typeNames = typeNames;
 		this.booleanAsNumber = booleanAsNumber;
-
 		this.zabbixServer = new InetSocketAddress(
 				checkNotNull(host, "Host cannot be null."),
 				checkNotNull(port, "Port cannot be null."));
 		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
 		this.poolSize = firstNonNull(poolSize, 1);
-		this.socketTimeoutMs = firstNonNull(socketTimeoutMs, 200);
-		this.poolClaimTimeoutSeconds = firstNonNull(poolClaimTimeoutSeconds, 1);
 	}
 
 	@Override
 	public ResultTransformerOutputWriter<WriterPoolOutputWriter<ZabbixWriter>> create() {
-
-		WriterPoolOutputWriter<ZabbixWriter> writerPoolOutputWriter;
-		writerPoolOutputWriter = TcpOutputWriterBuilder.builder(zabbixServer, new ZabbixWriter(new JsonFactory(), typeNames))
-				.setCharset(UTF_8)
-				.setFlushStrategy(flushStrategy)
-				.setPoolSize(poolSize)
-				.setSocketTimeoutMillis(socketTimeoutMs)
-				.setPoolClaimTimeoutSeconds(poolClaimTimeoutSeconds)
-				.build();
-
-		return ResultTransformerOutputWriter.booleanToNumber(booleanAsNumber, writerPoolOutputWriter);
-
+		return ResultTransformerOutputWriter.booleanToNumber(
+				booleanAsNumber,
+				TcpOutputWriterBuilder.builder(
+						zabbixServer,
+						new ZabbixWriter(new JsonFactory(), typeNames)
+				)
+						.setCharset(UTF_8)
+						.setFlushStrategy(flushStrategy)
+						.setPoolSize(poolSize)
+						.build()
+		);
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/ZabbixWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/ZabbixWriterFactory.java
@@ -1,0 +1,102 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.OutputWriterFactory;
+import com.googlecode.jmxtrans.model.output.support.ResultTransformerOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.TcpOutputWriterBuilder;
+import com.googlecode.jmxtrans.model.output.support.WriterPoolOutputWriter;
+import com.googlecode.jmxtrans.model.output.support.pool.FlushStrategy;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import java.net.InetSocketAddress;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.googlecode.jmxtrans.model.output.support.pool.FlushStrategyUtils.createFlushStrategy;
+
+/**
+ * This low latency and thread safe output writer sends data to a host/port combination
+ * in the Zabbix Sender format.
+ *
+ * @see <a href="https://www.zabbix.org/wiki/Docs/protocols#Zabbix_protocols">Zabbix sender 2.0 protocol</a>
+ */
+@ThreadSafe
+@EqualsAndHashCode
+@ToString
+public class ZabbixWriterFactory implements OutputWriterFactory {
+	@Nonnull private final InetSocketAddress zabbixServer;
+	@Nonnull private final ImmutableList<String> typeNames;
+	private final boolean booleanAsNumber;
+	@Nonnull private final FlushStrategy flushStrategy;
+	private final int poolSize;
+	private final int socketTimeoutMs;
+	private final Integer poolClaimTimeoutSeconds;
+
+	public ZabbixWriterFactory(
+			@JsonProperty("typeNames") ImmutableList<String> typeNames,
+			@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
+			@JsonProperty("host") String host,
+			@JsonProperty("port") Integer port,
+			@JsonProperty("flushStrategy") String flushStrategy,
+			@JsonProperty("flushDelayInSeconds") Integer flushDelayInSeconds,
+			@JsonProperty("poolSize") Integer poolSize,
+			@JsonProperty("socketTimeoutMs") Integer socketTimeoutMs,
+			@JsonProperty("poolClaimTimeoutSeconds") Integer poolClaimTimeoutSeconds) {
+
+		this.typeNames = typeNames;
+		this.booleanAsNumber = booleanAsNumber;
+
+		this.zabbixServer = new InetSocketAddress(
+				checkNotNull(host, "Host cannot be null."),
+				checkNotNull(port, "Port cannot be null."));
+		this.flushStrategy = createFlushStrategy(flushStrategy, flushDelayInSeconds);
+		this.poolSize = firstNonNull(poolSize, 1);
+		this.socketTimeoutMs = firstNonNull(socketTimeoutMs, 200);
+		this.poolClaimTimeoutSeconds = firstNonNull(poolClaimTimeoutSeconds, 1);
+	}
+
+	@Override
+	public ResultTransformerOutputWriter<WriterPoolOutputWriter<ZabbixWriter>> create() {
+
+		WriterPoolOutputWriter<ZabbixWriter> writerPoolOutputWriter;
+		writerPoolOutputWriter = TcpOutputWriterBuilder.builder(zabbixServer, new ZabbixWriter(new JsonFactory(), typeNames))
+				.setCharset(UTF_8)
+				.setFlushStrategy(flushStrategy)
+				.setPoolSize(poolSize)
+				.setSocketTimeoutMillis(socketTimeoutMs)
+				.setPoolClaimTimeoutSeconds(poolClaimTimeoutSeconds)
+				.build();
+
+		return ResultTransformerOutputWriter.booleanToNumber(booleanAsNumber, writerPoolOutputWriter);
+
+	}
+
+}

--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/ZabbixWriterTest.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/ZabbixWriterTest.java
@@ -1,0 +1,69 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.ResultFixtures.dummyResults;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+
+public class ZabbixWriterTest {
+
+	@Test
+	public void metricsAreFormattedCorrectly() throws IOException {
+		ZabbixWriter zabbixWriter = new ZabbixWriter(new JsonFactory(), ImmutableList.<String>of());
+
+		StringWriter writer = new StringWriter();
+
+		zabbixWriter.write(writer, dummyServer(), dummyQuery(), dummyResults());
+
+		String json = writer.toString();
+
+		/* Zabbix Sender JSON
+		{
+			"request":"sender data",
+			"data":[
+				{ "host":"host_example_net_4321", "key":"jmxtrans.MemoryAlias.ObjectPendingFinalizationCount", "value":"10", "clock": 0 }
+			],
+			"clock": 1381482905
+		}
+		*/
+		assertThatJson(json)
+			.node("request").isEqualTo("sender data");
+		assertThatJson(json)
+			.node("data").isArray().ofLength(3);
+		assertThatJson(json)
+			.node("data[0].host").isEqualTo("host.example.net")
+			.node("data[0].key").isEqualTo("jmxtrans.MemoryAlias.ObjectPendingFinalizationCount")
+			.node("data[0].value").isEqualTo("\"10\"")
+			.node("data[0].clock").isEqualTo(0);
+	}
+
+}


### PR DESCRIPTION
Put together a new ZabbixWriterFactory that can send metrics to a Zabbix Server/Proxy using the Zabbix Sender protocol - https://www.zabbix.org/wiki/Docs/protocols#Zabbix_protocols

Here's an example config:
```
{
  "servers" : [ {
    "host" : "localhost",
    "alias" : "tomcat.dev",
    "port" : "1099",
    "queries" : [ {
      "obj" : "java.lang:type=Memory",
      "attr" : [ "HeapMemoryUsage", "NonHeapMemoryUsage" ],
      "outputWriters" : [ {
        "@class" : "com.googlecode.jmxtrans.model.output.ZabbixWriterFactory",
        "port" : 10051,
        "host" : "zabbix.dev"
      } ]
    } ]
  } ]
}
```

And on the Zabbix Server side a user will need to create trapper items matching the keys from jmxtrans (ZabbixWriter prefixes everything with 'jmxtrans.' to avoid collisions in Zabbix):
![zabbix-jmxtrans-trapperitem](https://user-images.githubusercontent.com/971900/35945930-865b4a70-0c27-11e8-8291-8d43f0d3dda3.png)


This output will work with the following Zabbix versions:
- Zabbix 2.0.8+
- Zabbix 2.1.7+
- Zabbix 2.2+
- Zabbix 3+