### PR TITLE
Generalize ResultSerializer 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
-        (new-object System.Net.WebClient).DownloadFile('http://www.us.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.zip', 'C:\maven-bin.zip')
+        (new-object System.Net.WebClient).DownloadFile('https://archive.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.zip', 'C:\maven-bin.zip')
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
   # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/KeyValueResultSerializer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/KeyValueResultSerializer.java
@@ -1,0 +1,57 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.naming.KeyUtils;
+
+import java.util.List;
+
+/**
+ * Format results in the form <code><pre>
+ *     [MBean Id].[Type Name].[Attribute Name]=[Value]
+ * </pre></code>
+ */
+public class KeyValueResultSerializer implements ResultSerializer {
+	private static final String DEFAULT_FORMAT = "%s=%s";
+	private final String format;
+	private final List<String> typeNames;
+
+	public KeyValueResultSerializer(@JsonProperty("format") String format, @JsonProperty List<String> typeNames) {
+		this.format = MoreObjects.firstNonNull(format, DEFAULT_FORMAT);
+		this.typeNames = typeNames;
+	}
+
+	public static KeyValueResultSerializer createDefault(List<String> typeNames) {
+		return new KeyValueResultSerializer(DEFAULT_FORMAT, typeNames);
+	}
+
+	@Override
+	public String serialize(Server server, Query query, Result result) {
+		return String.format(format, KeyUtils.getKeyString(query, result, typeNames), result.getValue());
+	}
+}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/ResultSerializer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/ResultSerializer.java
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.googlecode.jmxtrans.model.output.kafka;
+package com.googlecode.jmxtrans.model.output;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -28,18 +28,18 @@ import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.Collection;
 
 import static com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.NON_NULL;
 
+/**
+ * Converts query result into a string, in order to display it, to write it to disk or send it over the wire.
+ */
 @JsonSerialize(include = NON_NULL)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public interface ResultSerializer {
 	/**
-	 * Converts query result into one or more strings
+	 * Converts query result into zero or one string
 	 */
-	@Nonnull
-	Collection<String> serialize(Server server, Query query, Result result) throws IOException;
+	String serialize(Server server, Query query, Result result) throws IOException;
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/ToStringResultSerializer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/output/ToStringResultSerializer.java
@@ -1,0 +1,57 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.googlecode.jmxtrans.model.Query;
+import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.Server;
+
+/**
+ * Format result using {@link com.googlecode.jmxtrans.model.Result#toString}
+ */
+public class ToStringResultSerializer implements ResultSerializer {
+	/**
+	 * Flag to show Server and Query info as well
+	 */
+	private final boolean verbose;
+
+	public static final ToStringResultSerializer DEFAULT = new ToStringResultSerializer();
+
+	public ToStringResultSerializer() {
+		this(false);
+	}
+
+	public ToStringResultSerializer(@JsonProperty("verbose") boolean verbose) {
+		this.verbose = verbose;
+	}
+
+	@Override
+	public String serialize(Server server, Query query, Result result) {
+		if (verbose) {
+			return server.toString() + " " + query.toString() + " " + result.toString();
+		}
+		return result.toString();
+	}
+
+}

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/output/KeyValueResultSerializerTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/output/KeyValueResultSerializerTest.java
@@ -1,0 +1,20 @@
+package com.googlecode.jmxtrans.model.output;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.ResultFixtures.numericResult;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KeyValueResultSerializerTest {
+
+	@Test
+	public void serialize() {
+		KeyValueResultSerializer serializer = KeyValueResultSerializer.createDefault(ImmutableList.<String>of());
+		String s = serializer.serialize(dummyServer(), dummyQuery(), numericResult());
+		assertThat(s).isEqualTo("MemoryAlias.ObjectPendingFinalizationCount=10");
+	}
+
+}

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/output/KeyValueResultSerializerTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/output/KeyValueResultSerializerTest.java
@@ -1,3 +1,25 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.googlecode.jmxtrans.model.output;
 
 import com.google.common.collect.ImmutableList;

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/output/StdOutWriterTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/output/StdOutWriterTest.java
@@ -1,0 +1,81 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import com.google.common.collect.ImmutableList;
+import com.googlecode.jmxtrans.model.OutputWriter;
+import com.googlecode.jmxtrans.model.ResultFixtures;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Collections;
+
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StdOutWriterTest {
+
+	private PrintStream originalStdOut;
+
+	private ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(1000);
+	private PrintStream dummyStdOut = new PrintStream(byteArrayOutputStream);
+
+	@Before
+	public void setUp() {
+		originalStdOut = System.out;
+		System.setOut(dummyStdOut);
+		assertThat(System.out).isNotSameAs(originalStdOut);
+	}
+
+	@Test
+	public void defaultConfig() throws Exception {
+		StdOutWriter writerFactory = new StdOutWriter(ImmutableList.<String>of(), false, false, null, Collections.<String, Object>emptyMap());
+		OutputWriter writer = writerFactory.create();
+		writer.doWrite(dummyServer(), dummyQuery(), ResultFixtures.dummyResults());
+		assertThat(byteArrayOutputStream.toString()).contains("Result(");
+		assertThat(byteArrayOutputStream.toString()).contains("typeName=type=Memory");
+	}
+
+	@Test
+	public void skipResult() throws Exception {
+		StdOutWriter writerFactory = new StdOutWriter(ImmutableList.<String>of(), false, false, mock(ResultSerializer.class), Collections.<String, Object>emptyMap());
+		OutputWriter writer = writerFactory.create();
+		writer.doWrite(dummyServer(), dummyQuery(), ResultFixtures.dummyResults());
+		assertThat(byteArrayOutputStream.toString()).doesNotContain("Result(");
+		assertThat(byteArrayOutputStream.toString()).doesNotContain("typeName=type=Memory");
+	}
+
+	@After
+	public void tearDown() {
+		System.setOut(originalStdOut);
+		dummyStdOut.close();
+	}
+}

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/output/ToStringResultSerializerTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/output/ToStringResultSerializerTest.java
@@ -1,0 +1,64 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.output;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.ResultFixtures.numericResult;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ToStringResultSerializerTest {
+
+	void assertResultString(String serialized) {
+		assertThat(serialized).contains("attributeName=ObjectPendingFinalizationCount");
+		assertThat(serialized).contains("className=sun.management.MemoryImpl");
+		assertThat(serialized).contains("objDomain=ObjectDomainName");
+		assertThat(serialized).contains("typeName=type=Memory");
+		assertThat(serialized).contains("value=10");
+		assertThat(serialized).contains("keyAlias=MemoryAlias");
+	}
+
+	@Test
+	public void serialize() throws IOException {
+		ResultSerializer resultSerializer = new ToStringResultSerializer();
+		String serialized = resultSerializer.serialize(dummyServer(), dummyQuery(), numericResult());
+		assertThat(serialized).startsWith("Result(");
+		assertResultString(serialized);
+	}
+
+	@Test
+	public void serializeVerbose() throws IOException {
+		ResultSerializer resultSerializer = new ToStringResultSerializer(true);
+		String serialized = resultSerializer.serialize(dummyServer(), dummyQuery(), numericResult());
+		assertThat(serialized).startsWith("Server(");
+		assertThat(serialized).contains("host=host.example.net");
+		assertThat(serialized).contains("port=4321");
+		assertThat(serialized).contains("Query(");
+		assertThat(serialized).contains("objectName=myQuery:key=val");
+		assertResultString(serialized);
+	}
+}

--- a/jmxtrans-examples/src/main/java/com/googlecode/jmxtrans/example/InterestingInfo.java
+++ b/jmxtrans-examples/src/main/java/com/googlecode/jmxtrans/example/InterestingInfo.java
@@ -40,7 +40,7 @@ import static com.google.common.collect.Maps.newHashMap;
 
 /**
  * This class produces the json that is in example.json.
- * 
+ *
  * @author jon
  */
 @SuppressWarnings({"squid:S106", "squid:S1118"}) // using StdOut if fine in an example
@@ -64,7 +64,7 @@ public class InterestingInfo {
 				.setPort(2003)
 				.build();
 
-		StdOutWriter sw = new StdOutWriter(ImmutableList.<String>of(), false, false, Collections.<String, Object>emptyMap());
+		StdOutWriter sw = new StdOutWriter(ImmutableList.<String>of(), false, false, null, Collections.<String, Object>emptyMap());
 
 		Query q = Query.builder()
 				.setObj("java.lang:type=Memory")

--- a/jmxtrans-examples/src/main/java/com/googlecode/jmxtrans/example/Tester.java
+++ b/jmxtrans-examples/src/main/java/com/googlecode/jmxtrans/example/Tester.java
@@ -36,7 +36,7 @@ import java.util.Collections;
 
 /**
  * This class produces the json that is in example.json.
- * 
+ *
  * @author jon
  */
 @SuppressWarnings({"squid:S106", "squid:S1118"}) // using StdOut if fine in an example
@@ -53,17 +53,17 @@ public class Tester {
 				.addQuery(Query.builder()
 						.setObj("java.lang:type=Memory")
 						.addAttr("HeapMemoryUsage", "NonHeapMemoryUsage")
-						.addOutputWriterFactory(new StdOutWriter(ImmutableList.<String>of(), false, false, Collections.<String, Object>emptyMap()))
+						.addOutputWriterFactory(new StdOutWriter(ImmutableList.<String>of(), false, false, null, Collections.<String, Object>emptyMap()))
 						.build())
 				.addQuery(Query.builder()
 						.setObj("java.lang:name=CMS Old Gen,type=MemoryPool")
 						.addAttr("Usage")
-						.addOutputWriterFactory(new StdOutWriter(ImmutableList.<String>of(), false, false, Collections.<String, Object>emptyMap()))
+						.addOutputWriterFactory(new StdOutWriter(ImmutableList.<String>of(), false, false, null, Collections.<String, Object>emptyMap()))
 						.build())
 				.addQuery(Query.builder()
 						.setObj("java.lang:name=ConcurrentMarkSweep,type=GarbageCollector")
 						.addAttr("LastGcInfo")
-						.addOutputWriterFactory(new StdOutWriter(ImmutableList.<String>of(), false, false, Collections.<String, Object>emptyMap()))
+						.addOutputWriterFactory(new StdOutWriter(ImmutableList.<String>of(), false, false, null, Collections.<String, Object>emptyMap()))
 						.build())
 				.build();
 

--- a/jmxtrans-examples/src/main/java/com/googlecode/jmxtrans/example/TreeWalker2.java
+++ b/jmxtrans-examples/src/main/java/com/googlecode/jmxtrans/example/TreeWalker2.java
@@ -43,10 +43,10 @@ import java.util.Set;
 /**
  * Walks a JMX tree and prints out all of the attribute values actually using
  * the JmxTrans api.
- * 
+ *
  * This is a good test of the core engine of JmxTrans to ensure that it covers
  * all cases.
- * 
+ *
  * @author jon
  */
 public class TreeWalker2 {
@@ -83,7 +83,7 @@ public class TreeWalker2 {
 
 			Query.Builder queryBuilder = Query.builder()
 					.setObj(name.getCanonicalName())
-					.addOutputWriterFactory(new StdOutWriter(ImmutableList.<String>of(), false, false, Collections.<String, Object>emptyMap()));
+					.addOutputWriterFactory(new StdOutWriter(ImmutableList.<String>of(), false, false, null, Collections.<String, Object>emptyMap()));
 
 			for (MBeanAttributeInfo attrInfo : attrs) {
 				queryBuilder.addAttr(attrInfo.getName());

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/FileWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/FileWriter.java
@@ -28,7 +28,6 @@ import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.ValidationException;
-import com.googlecode.jmxtrans.model.naming.KeyUtils;
 import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,28 +44,35 @@ import java.util.Map;
 public class FileWriter extends BaseOutputWriter {
 	private static final String PROPERTY_BASEPATH = "filepath";
 	private static final String PROPERTY_LINE_FORMAT = "lineFormat";
-	private static final String DEFAULT_LINE_FORMAT = "%s=%s";
 	private static final Logger log = LoggerFactory.getLogger(FileWriter.class);
 
 	private File outputFile;
 	private File outputTempFile;
-	private String lineFormat;
+	private ResultSerializer resultSerializer;
 
 	public FileWriter(@JsonProperty("typeNames") ImmutableList<String> typeNames,
 					@JsonProperty("booleanAsNumber") boolean booleanAsNumber,
 					@JsonProperty("debug") Boolean debugEnabled,
 					@JsonProperty(PROPERTY_BASEPATH) String filepath,
 					@JsonProperty(PROPERTY_LINE_FORMAT) String lineFormat,
+					@JsonProperty("resultSerializer") ResultSerializer resultSerializer,
 					@JsonProperty("settings") Map<String, Object> settings) throws IOException {
 		super(typeNames, booleanAsNumber, debugEnabled, settings);
 
 		this.outputFile = new File(filepath);
 		Path outputFilePath = outputFile.toPath();
 		this.outputTempFile = new File(outputFilePath.getParent() + File.separator + "." + outputFilePath.getFileName());
-		if (lineFormat == null) {
-			this.lineFormat = DEFAULT_LINE_FORMAT;
+		if (resultSerializer == null) {
+			if (lineFormat == null) {
+				this.resultSerializer= KeyValueResultSerializer.createDefault(typeNames);
+			} else {
+				this.resultSerializer= new KeyValueResultSerializer(lineFormat, typeNames);
+			}
 		} else {
-			this.lineFormat = lineFormat;
+			if (lineFormat != null) {
+				log.warn("Both lineFormat and resultSerializer are defined, lineFormat will be ignored");
+			}
+			this.resultSerializer= resultSerializer;
 		}
 
 		// make sure the permissions allow to manage these files:
@@ -81,7 +87,7 @@ public class FileWriter extends BaseOutputWriter {
 	}
 
 	@Override
-	public void validateSetup(Server server, Query query) throws ValidationException {}
+	public void validateSetup(Server server, Query query) {}
 
 	@Override
 	protected void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
@@ -90,8 +96,10 @@ public class FileWriter extends BaseOutputWriter {
 
 			for (Result result : results) {
 				log.debug(result.toString());
-				outputTempPrintWriter.printf(lineFormat + System.lineSeparator(),
-						KeyUtils.getKeyString(query, result, typeNames), result.getValue());
+				String s = resultSerializer.serialize(server, query, result);
+				if (s != null) {
+					outputTempPrintWriter.println(s);
+				}
 			}
 		}
 		assert(this.outputTempFile.renameTo(this.outputFile));

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/FileWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/FileWriter.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
-import com.googlecode.jmxtrans.model.ValidationException;
 import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/Slf4JOutputWriter.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/main/java/com/googlecode/jmxtrans/model/output/Slf4JOutputWriter.java
@@ -31,7 +31,6 @@ import com.google.common.io.Closer;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
-import com.googlecode.jmxtrans.model.ValidationException;
 import com.googlecode.jmxtrans.model.naming.KeyUtils;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/jmxtrans-output/jmxtrans-output-kafka/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-kafka/pom.xml
@@ -37,7 +37,7 @@
 
 	<properties>
 		<verify.mutationThreshold>51</verify.mutationThreshold>
-		<verify.totalBranchRate>41</verify.totalBranchRate>
+		<verify.totalBranchRate>40</verify.totalBranchRate>
 		<verify.totalLineRate>90</verify.totalLineRate>
 	</properties>
 	<dependencies>

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializer.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializer.java
@@ -34,6 +34,7 @@ import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.ResultAttribute;
 import com.googlecode.jmxtrans.model.ResultAttributes;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.output.ResultSerializer;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.slf4j.Logger;
@@ -42,8 +43,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -84,17 +83,15 @@ public class DefaultResultSerializer implements ResultSerializer {
 		this.resultAttributesToWriteAsTags = resultTags == null ? ImmutableSet.<ResultAttribute>of() : ResultAttributes.forNames(resultTags);
 	}
 
-	@Nonnull
 	@Override
-	public Collection<String> serialize(Server server, Query query, Result result) throws IOException {
+	public String serialize(Server server, Query query, Result result) throws IOException {
 		log.debug("Query result: [{}]", result);
 		Object value = result.getValue();
-		if (isNumeric(value)) {
-			return Collections.singleton(createJsonMessage(server, query, result, result.getValuePath(), value));
-		} else {
+		if (!isNumeric(value)) {
 			log.warn("Unable to submit non-numeric value to Kafka: [{}] from result [{}]", value, result);
-			return Collections.emptyList();
+			return null;
 		}
+		return createJsonMessage(server, query, result, result.getValuePath(), value);
 	}
 
 	private String createJsonMessage(Server server, Query query, Result result, List<String> valuePath, Object value) throws IOException {

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializer.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializer.java
@@ -83,6 +83,10 @@ public class DefaultResultSerializer implements ResultSerializer {
 		this.resultAttributesToWriteAsTags = resultTags == null ? ImmutableSet.<ResultAttribute>of() : ResultAttributes.forNames(resultTags);
 	}
 
+	static DefaultResultSerializer createDefault() {
+		return new DefaultResultSerializer(null, false, "", null, null);
+	}
+
 	@Override
 	public String serialize(Server server, Query query, Result result) throws IOException {
 		log.debug("Query result: [{}]", result);

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DetailedResultSerializer.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/DetailedResultSerializer.java
@@ -29,18 +29,16 @@ import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.output.ResultSerializer;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Map;
 
 import static com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.NON_NULL;
-import static java.util.Collections.singletonList;
 
 @EqualsAndHashCode(exclude = {"objectMapper"})
 public class DetailedResultSerializer implements ResultSerializer {
@@ -51,10 +49,9 @@ public class DetailedResultSerializer implements ResultSerializer {
 		this.objectMapper = new ObjectMapper();
 	}
 
-	@Nonnull
 	@Override
-	public Collection<String> serialize(final Server server, final Query query, final Result result) throws IOException {
-		return singletonList(objectMapper.writeValueAsString(new KResult(server, result)));
+	public String serialize(final Server server, final Query query, final Result result) throws IOException {
+		return objectMapper.writeValueAsString(new KResult(server, result));
 	}
 
 	/**

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter.java
@@ -32,6 +32,7 @@ import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.ValidationException;
 import com.googlecode.jmxtrans.model.output.BaseOutputWriter;
+import com.googlecode.jmxtrans.model.output.ResultSerializer;
 import com.googlecode.jmxtrans.model.output.Settings;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -124,11 +125,10 @@ public class KafkaWriter extends BaseOutputWriter {
 	protected void internalWrite(Server server, Query query, ImmutableList<Result> results) throws Exception {
 		for (Result result : results) {
 			log.debug("Query result: [{}]", result);
-			for (String message : resultSerializer.serialize(server, query, result)) {
-				for (String topic : this.topics) {
-					log.debug("Topic: [{}] ; Kafka Message: [{}]", topic, message);
-					producer.send(new ProducerRecord<String, String>(topic, message));
-				}
+			String message = resultSerializer.serialize(server, query, result);
+			for (String topic : this.topics) {
+				log.debug("Topic: [{}] ; Kafka Message: [{}]", topic, message);
+				producer.send(new ProducerRecord<String, String>(topic, message));
 			}
 		}
 	}

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter2.java
@@ -22,14 +22,12 @@
  */
 package com.googlecode.jmxtrans.model.output.kafka;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.googlecode.jmxtrans.model.OutputWriterAdapter;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.output.ResultSerializer;
-import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -41,9 +39,6 @@ import java.util.Map;
 
 public class KafkaWriter2 extends OutputWriterAdapter {
 	@Nonnull
-	@Getter(AccessLevel.PROTECTED)
-	private final ObjectMapper objectMapper;
-	@Nonnull
 	@Getter
 	private final Map<String, Object> producerConfig;
 	@Nonnull
@@ -54,8 +49,7 @@ public class KafkaWriter2 extends OutputWriterAdapter {
 	@Getter
 	private final ResultSerializer resultSerializer;
 
-	public KafkaWriter2(@Nonnull ObjectMapper objectMapper, @Nonnull Map<String, Object> producerConfig, @Nonnull String topic, @Nonnull ResultSerializer resultSerializer) {
-		this.objectMapper = objectMapper;
+	public KafkaWriter2(@Nonnull Map<String, Object> producerConfig, @Nonnull String topic, @Nonnull ResultSerializer resultSerializer) {
 		this.producerConfig = producerConfig;
 		this.topic = topic;
 		this.resultSerializer = resultSerializer;
@@ -63,8 +57,7 @@ public class KafkaWriter2 extends OutputWriterAdapter {
 	}
 
 	@VisibleForTesting
-	KafkaWriter2(@Nonnull ObjectMapper objectMapper, Producer<String, String> producer, @Nonnull String topic, @Nonnull ResultSerializer resultSerializer) {
-		this.objectMapper = objectMapper;
+	KafkaWriter2(Producer<String, String> producer, @Nonnull String topic, @Nonnull ResultSerializer resultSerializer) {
 		this.producerConfig = Collections.emptyMap();
 		this.topic = topic;
 		this.resultSerializer = resultSerializer;

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter2.java
@@ -29,6 +29,7 @@ import com.googlecode.jmxtrans.model.OutputWriterAdapter;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.Server;
+import com.googlecode.jmxtrans.model.output.ResultSerializer;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -74,14 +75,15 @@ public class KafkaWriter2 extends OutputWriterAdapter {
 	@Override
 	public void doWrite(Server server, Query query, Iterable<Result> results) throws Exception {
 		for (Result result : results) {
-			for (String message : resultSerializer.serialize(server, query, result)) {
+			String message = resultSerializer.serialize(server, query, result);
+			if (message != null) {
 				producer.send(new ProducerRecord<String, String>(topic, message));
 			}
 		}
 	}
 
 	@Override
-	public void close() throws LifecycleException {
+	public void close() {
 		producer.close();
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter2.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter2.java
@@ -24,7 +24,6 @@ package com.googlecode.jmxtrans.model.output.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.OutputWriterAdapter;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterFactory.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.OutputWriterFactory;
+import com.googlecode.jmxtrans.model.output.ResultSerializer;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/main/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterFactory.java
@@ -23,30 +23,22 @@
 package com.googlecode.jmxtrans.model.output.kafka;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.OutputWriterFactory;
 import com.googlecode.jmxtrans.model.output.ResultSerializer;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @EqualsAndHashCode(exclude = {"objectMapper"})
 public class KafkaWriterFactory implements OutputWriterFactory<KafkaWriter2> {
-	@Nonnull
-	@Getter(AccessLevel.PROTECTED)
-	@JsonIgnore
-	private final ObjectMapper objectMapper;
 	@Nonnull
 	@Getter
 	private final Map<String, Object> producerConfig;
@@ -64,7 +56,6 @@ public class KafkaWriterFactory implements OutputWriterFactory<KafkaWriter2> {
 			@JsonProperty("producerConfig") @Nonnull Map<String, Object> producerConfig,
 			@JsonProperty("topic") @Nonnull String topic,
 			@JsonProperty("resultSerializer") ResultSerializer resultSerializer) {
-		this.objectMapper = new ObjectMapper();
 		ImmutableMap.Builder<String, Object> producerConfigBuilder = ImmutableMap.<String, Object>builder()
 				.putAll(producerConfig);
 		// Add default settings
@@ -77,16 +68,12 @@ public class KafkaWriterFactory implements OutputWriterFactory<KafkaWriter2> {
 		this.producerConfig = producerConfigBuilder.build();
 		this.topic = topic;
 		checkNotNull(topic);
-		this.resultSerializer = resultSerializer == null ? new DefaultResultSerializer(
-				Collections.<String>emptyList(),
-				false, "",
-				Collections.<String, String>emptyMap(),
-				Collections.<String>emptyList()) : resultSerializer;
+		this.resultSerializer = resultSerializer == null ? DefaultResultSerializer.createDefault() : resultSerializer;
 	}
 
 	@Nonnull
 	@Override
 	public KafkaWriter2 create() {
-		return new KafkaWriter2(objectMapper, producerConfig, topic, resultSerializer);
+		return new KafkaWriter2(producerConfig, topic, resultSerializer);
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializerTest.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializerTest.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.output.ResultSerializer;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -53,10 +54,8 @@ public class DefaultResultSerializerTest {
 		ResultSerializer resultSerializer = new DefaultResultSerializer(ImmutableList.<String>of(), false, "rootPrefix", tags, asList("typeName.type", "className"));
 
 		long now = System.currentTimeMillis();
-		Collection<String> messages = resultSerializer.serialize(dummyServer(), dummyQuery(), numericResultAt(now));
+		String message = resultSerializer.serialize(dummyServer(), dummyQuery(), numericResultAt(now));
 
-		assertThat(messages).hasSize(1);
-		String message = messages.iterator().next();
 		// Check JSON syntax
 		assertThat(message).endsWith("}}");
 		JsonNode jsonNode = objectMapper.readValue(message, JsonNode.class);
@@ -73,13 +72,13 @@ public class DefaultResultSerializerTest {
 		ImmutableMap<String, String> tags = ImmutableMap.of("myTagKey1", "myTagValue1");
 		ResultSerializer resultSerializer = new DefaultResultSerializer(ImmutableList.<String>of(), false, "rootPrefix", tags, ImmutableList.<String>of());
 
-		Collection<String> messages = resultSerializer.serialize(dummyServer(), dummyQuery(), stringResult());
+		String message = resultSerializer.serialize(dummyServer(), dummyQuery(), stringResult());
 
-		assertThat(messages).isEmpty();
+		assertThat(message).isNull();
 	}
 
 	@Test
-	public void initDefaults() throws Exception {
+	public void initDefaults() {
 		DefaultResultSerializer resultSerializer = new DefaultResultSerializer(null, false, null, null, null);
 
 		assertThat(resultSerializer.getTypeNames()).isNotNull();
@@ -89,7 +88,7 @@ public class DefaultResultSerializerTest {
 	}
 
 	@Test
-	public void equalsHashCodeWhenSame() throws Exception {
+	public void equalsHashCodeWhenSame() {
 		DefaultResultSerializer resultSerializer1 = new DefaultResultSerializer(null, false, null, null, null);
 		DefaultResultSerializer resultSerializer2 = new DefaultResultSerializer(null, false, null, null, null);
 
@@ -98,7 +97,7 @@ public class DefaultResultSerializerTest {
 	}
 
 	@Test
-	public void equalsWhenDifferent() throws Exception {
+	public void equalsWhenDifferent() {
 		DefaultResultSerializer resultSerializer1 = new DefaultResultSerializer(null, false, null, null, null);
 		DefaultResultSerializer resultSerializer2 = new DefaultResultSerializer(asList("Type"), true, "root", null, null);
 

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializerTest.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DefaultResultSerializerTest.java
@@ -79,7 +79,7 @@ public class DefaultResultSerializerTest {
 
 	@Test
 	public void initDefaults() {
-		DefaultResultSerializer resultSerializer = new DefaultResultSerializer(null, false, null, null, null);
+		DefaultResultSerializer resultSerializer = DefaultResultSerializer.createDefault();
 
 		assertThat(resultSerializer.getTypeNames()).isNotNull();
 		assertThat(resultSerializer.getTypeNames()).isEmpty();
@@ -89,8 +89,8 @@ public class DefaultResultSerializerTest {
 
 	@Test
 	public void equalsHashCodeWhenSame() {
-		DefaultResultSerializer resultSerializer1 = new DefaultResultSerializer(null, false, null, null, null);
-		DefaultResultSerializer resultSerializer2 = new DefaultResultSerializer(null, false, null, null, null);
+		DefaultResultSerializer resultSerializer1 = DefaultResultSerializer.createDefault();
+		DefaultResultSerializer resultSerializer2 = DefaultResultSerializer.createDefault();
 
 		assertThat(resultSerializer1).isEqualTo(resultSerializer2);
 		assertThat(resultSerializer1.hashCode()).isEqualTo(resultSerializer2.hashCode());
@@ -98,7 +98,7 @@ public class DefaultResultSerializerTest {
 
 	@Test
 	public void equalsWhenDifferent() {
-		DefaultResultSerializer resultSerializer1 = new DefaultResultSerializer(null, false, null, null, null);
+		DefaultResultSerializer resultSerializer1 = DefaultResultSerializer.createDefault();
 		DefaultResultSerializer resultSerializer2 = new DefaultResultSerializer(asList("Type"), true, "root", null, null);
 
 		assertThat(resultSerializer1).isNotEqualTo(resultSerializer2);

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DetailedResultSerializerTest.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/DetailedResultSerializerTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.googlecode.jmxtrans.model.Result;
+import com.googlecode.jmxtrans.model.output.ResultSerializer;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -42,11 +43,8 @@ public class DetailedResultSerializerTest {
 
 		Result result = numericResult();
 		result = new Result(result.getEpoch(), result.getAttributeName(), result.getClassName(), result.getObjDomain(), result.getKeyAlias(), result.getTypeName(), ImmutableList.<String>of("used"), result.getValue());
-		Collection<String> messages = resultSerializer.serialize(dummyServer(), dummyQuery(), result);
+		String message = resultSerializer.serialize(dummyServer(), dummyQuery(), result);
 
-		assertThat(messages).hasSize(1);
-
-		String message = messages.iterator().next();
 		// Check JSON Syntax and detailed content
 		JsonNode jsonNode = new ObjectMapper().readValue(message, JsonNode.class);
 		assertThat(jsonNode.get("host").asText()).isEqualTo("host.example.net");
@@ -68,10 +66,8 @@ public class DetailedResultSerializerTest {
 	public void serializeNumericResult() throws Exception {
 		ResultSerializer resultSerializer = new DetailedResultSerializer();
 
-		Collection<String> messages = resultSerializer.serialize(dummyServer(), dummyQuery(), numericResult());
+		String message = resultSerializer.serialize(dummyServer(), dummyQuery(), numericResult());
 
-		assertThat(messages).hasSize(1);
-		String message = messages.iterator().next();
 		assertThat(message)
 				.contains("\"host\":\"host.example.net\"")
 				.contains("\"attributeName\":\"ObjectPendingFinalizationCount\"")
@@ -82,7 +78,7 @@ public class DetailedResultSerializerTest {
 	}
 
 	@Test
-	public void equalsHashCodeWhenSame() throws Exception {
+	public void equalsHashCodeWhenSame() {
 		DetailedResultSerializer resultSerializer1 = new DetailedResultSerializer();
 		DetailedResultSerializer resultSerializer2 = new DetailedResultSerializer();
 

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter2Test.java
@@ -55,7 +55,6 @@ public class KafkaWriter2Test {
     public void testWrite() throws Exception {
         // Given
         KafkaWriter2 writer = new KafkaWriter2(
-                objectMapper,
                 producerMock,
                 TOPIC,
                 new DetailedResultSerializer());
@@ -80,7 +79,6 @@ public class KafkaWriter2Test {
 	public void producerClosed() throws Exception {
 		// Given
 		KafkaWriter2 writer = new KafkaWriter2(
-				objectMapper,
 				producerMock,
 				TOPIC,
 				new DetailedResultSerializer());
@@ -94,7 +92,6 @@ public class KafkaWriter2Test {
 	public void testFilterResultSerializer() throws Exception {
 		// Given
 		KafkaWriter2 writer = new KafkaWriter2(
-				objectMapper,
 				producerMock,
 				TOPIC,
 				mock(ResultSerializer.class));

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter2Test.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriter2Test.java
@@ -24,26 +24,29 @@ package com.googlecode.jmxtrans.model.output.kafka;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
 import static com.googlecode.jmxtrans.model.ResultFixtures.dummyResults;
 import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static com.googlecode.jmxtrans.model.ServerFixtures.DEFAULT_HOST;
+
+import com.googlecode.jmxtrans.model.output.ResultSerializer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(org.mockito.junit.MockitoJUnitRunner.class)
 public class KafkaWriter2Test {
 
-    public static final String TOPIC = "topic";
+    private static final String TOPIC = "topic";
     private final ObjectMapper objectMapper =  new ObjectMapper();
     @Mock
     public Producer<String, String> producerMock;
@@ -85,6 +88,20 @@ public class KafkaWriter2Test {
 		writer.close();
 
 		verify(producerMock).close();
+	}
+
+	@Test
+	public void testFilterResultSerializer() throws Exception {
+		// Given
+		KafkaWriter2 writer = new KafkaWriter2(
+				objectMapper,
+				producerMock,
+				TOPIC,
+				mock(ResultSerializer.class));
+		// When
+		writer.doWrite(dummyServer(), dummyQuery(), dummyResults());
+		// Then
+		verifyNoMoreInteractions(producerMock);
 	}
 
 }

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterFactoryTest.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterFactoryTest.java
@@ -23,9 +23,11 @@
 package com.googlecode.jmxtrans.model.output.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.output.ResultSerializer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.Test;
 
 import java.io.FileNotFoundException;
@@ -53,7 +55,6 @@ public class KafkaWriterFactoryTest {
             assertThat(writerFactory.getTopic()).isEqualTo("jmxtrans");
             assertThat(writerFactory.getProducerConfig().get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo("localhost:9092");
             assertThat(writerFactory.getResultSerializer()).isInstanceOf(DefaultResultSerializer.class);
-			assertThat(writerFactory.getObjectMapper()).isNotNull();
             try (KafkaWriter2 writer = writerFactory.create()) {
                 assertThat(writer.getTopic()).isEqualTo("jmxtrans");
                 assertThat(writer.getProducerConfig().get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo("localhost:9092");
@@ -117,5 +118,13 @@ public class KafkaWriterFactoryTest {
 		assertThat(defaultResultSerializer.getRootPrefix()).isEmpty();
 		assertThat(defaultResultSerializer.getTypeNames()).isEmpty();
 		assertThat(defaultResultSerializer.isBooleanAsNumber()).isFalse();
+	}
+
+	@Test
+	public void testDefaultSerializers() {
+    	KafkaWriterFactory writerFactory = new KafkaWriterFactory(ImmutableMap.<String, Object>of(), "topic", null);
+		String defaultSerializer = StringSerializer.class.getName();
+		assertThat(writerFactory.getProducerConfig().get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)).isEqualTo(defaultSerializer);
+		assertThat(writerFactory.getProducerConfig().get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG)).isEqualTo(defaultSerializer);
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterFactoryTest.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterFactoryTest.java
@@ -24,6 +24,7 @@ package com.googlecode.jmxtrans.model.output.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
+import com.googlecode.jmxtrans.model.output.ResultSerializer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.Test;
 

--- a/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-kafka/src/test/java/com/googlecode/jmxtrans/model/output/kafka/KafkaWriterTests.java
@@ -45,7 +45,7 @@ import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(org.mockito.junit.MockitoJUnitRunner.class)
 public class KafkaWriterTests {
 
 	@Mock
@@ -82,7 +82,7 @@ public class KafkaWriterTests {
 	}
 
 	@Test
-	public void producerClosed() throws Exception {
+	public void producerClosed() {
 		KafkaWriter writer = new KafkaWriter(ImmutableList.<String>of(), true, "rootPrefix", true, "myTopic", tags, settings, producer);
 
 		writer.close();
@@ -91,10 +91,16 @@ public class KafkaWriterTests {
 	}
 
 	@Test
-	public void createKafkaProducer() throws Exception {
+	public void createKafkaProducer() {
 		try(KafkaWriter writer = new KafkaWriter(ImmutableList.<String>of(), true, "rootPrefix", true, "myTopic", tags, settings)) {
 			assertThat(writer.getProducer()).isInstanceOf(KafkaProducer.class);
 		}
 	}
 
+	@Test
+	public void filteringResultSerializer() {
+		try(KafkaWriter writer = new KafkaWriter(ImmutableList.<String>of(), true, "rootPrefix", true, "myTopic", tags, settings)) {
+			assertThat(writer.getProducer()).isInstanceOf(KafkaProducer.class);
+		}
+	}
 }


### PR DESCRIPTION
Pull this interface in core and use it in many outputwriters: stdout, file, slf4j, kafka...

Removing code in the Kafka output, I add to add test and refactor a bit to satisfy mutation testing. 