### PR TITLE
Fixed deb / systemd start script to pick up the log4j configuration.

### DIFF
--- a/jmxtrans-packaging/jmxtrans-systemd/src/etc/jmxtrans
+++ b/jmxtrans-packaging/jmxtrans-systemd/src/etc/jmxtrans
@@ -9,4 +9,4 @@ if [ -z "$JAVACMD" ] ; then
   fi
 fi
 
-${JAVACMD} -Dlog4j.configuration=/etc/jmxtrans/log4j.xml ${JAVA_OPTS} -jar /usr/share/java/jmxtrans-all.jar "$@"
+${JAVACMD} -Dlog4j.configuration=file:///etc/jmxtrans/log4j.xml ${JAVA_OPTS} -jar /usr/share/java/jmxtrans-all.jar "$@"


### PR DESCRIPTION
Fixed deb / systemd start script to pick up the log4j configuration.

The logs could be viewed with:
* `journalctl -u jmxtrans.service`
* `/var/log/jmxtrans/jmxtrans.log`