### PR TITLE
Fixed : Timestamp in milliseconds

### DIFF
--- a/jmxtrans-output/jmxtrans-output-logback/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-logback/pom.xml
@@ -69,6 +69,10 @@
 			<artifactId>jmxtrans-utils</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.jmxtrans</groupId>
+			<artifactId>jmxtrans-output-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>

--- a/jmxtrans-output/jmxtrans-output-logback/pom.xml
+++ b/jmxtrans-output/jmxtrans-output-logback/pom.xml
@@ -66,11 +66,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jmxtrans</groupId>
-			<artifactId>jmxtrans-utils</artifactId>
+			<artifactId>jmxtrans-output-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jmxtrans</groupId>
-			<artifactId>jmxtrans-output-core</artifactId>
+			<artifactId>jmxtrans-utils</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/jmxtrans-output/jmxtrans-output-logback/src/main/java/com/googlecode/jmxtrans/model/output/KeyOutWriter.java
+++ b/jmxtrans-output/jmxtrans-output-logback/src/main/java/com/googlecode/jmxtrans/model/output/KeyOutWriter.java
@@ -78,9 +78,8 @@ public class KeyOutWriter extends BaseOutputWriter {
 	protected static final String MAX_LOG_FILE_SIZE = "10MB";
 	protected static final String DEFAULT_LOG_PATTERN = "%msg%n";
 	protected static final String DEFAULT_DELIMITER = "\t";
-	protected LogWriter logwriter;
-
-
+	
+	private LogWriter logwriter;
 	private final String outputFile;
 	private final String maxLogFileSize;
 	private final int maxLogBackupFiles;
@@ -158,8 +157,8 @@ public class KeyOutWriter extends BaseOutputWriter {
 	 */
 	public static class LogWriter extends Writer{
 		
-		private Logger logger;
-		private String delimiter;
+		private final Logger logger;
+		private final String delimiter;
 		
 		public LogWriter(Logger logger, String delimiter) {
 			this.logger = logger;

--- a/jmxtrans-output/jmxtrans-output-logback/src/main/java/com/googlecode/jmxtrans/model/output/KeyOutWriter.java
+++ b/jmxtrans-output/jmxtrans-output-logback/src/main/java/com/googlecode/jmxtrans/model/output/KeyOutWriter.java
@@ -159,7 +159,7 @@ public class KeyOutWriter extends BaseOutputWriter {
 			if (isNumeric(result.getValue())) {
 
 				logger.info(KeyUtils.getKeyString(server, query, result, typeNames, null) + delimiter
-						+ result.getValue().toString() + delimiter + result.getEpoch());
+						+ result.getValue().toString() + delimiter + result.getEpoch()/1000);
 			}
 		}
 	}


### PR DESCRIPTION
Graphite plaintext protocol uses a timestamp in secondes, but the writer writes this timestamp in ms. I just divided the value by 1000 to fit the protocol.