### PR TITLE
Add UUID suffix to trigger name

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
@@ -69,6 +69,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.UUID;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
@@ -463,7 +464,7 @@ public class JmxTransformer implements WatchedCallback {
 			trigger = TriggerUtils.makeSecondlyTrigger(runPeriod);
 			// TODO replace Quartz with a ScheduledExecutorService
 		}
-		trigger.setName(server.getHost() + ":" + server.getPort() + "-" + Long.toString(System.nanoTime()));
+		trigger.setName(server.getHost() + ":" + server.getPort() + "-" + Long.toString(System.nanoTime()) + "-" + UUID.randomUUID().toString().substring(0, 8));
 		trigger.setStartTime(computeSpreadStartDate(runPeriod));
 		return trigger;
 	}


### PR DESCRIPTION
We saw the following error in our logs:
```
[20 Apr 2018 06:10:15] [WrapperSimpleAppMain] 1004   ERROR (com.googlecode.jmxtrans.JmxTransformer:190) - Error scheduling job for server: Server(pid=null, host=10.x.y.z, port=9016, url=service:jmx:rmi:///jndi/rmi://10.x.y.z:9016/jmxrmi, cronExpression=null, numQueryThreads=8)
com.googlecode.jmxtrans.exceptions.LifecycleException: Error scheduling job for server: Server(pid=null, host=10.x.y.z, port=9016, url=service:jmx:rmi:///jndi/rmi://10.x.y.z:9016/jmxrmi, cronExpression=null, numQueryThreads=8)
        at com.googlecode.jmxtrans.JmxTransformer.processServersIntoJobs(JmxTransformer.java:375)
        at com.googlecode.jmxtrans.JmxTransformer.startupSystem(JmxTransformer.java:318)
        at com.googlecode.jmxtrans.JmxTransformer.start(JmxTransformer.java:187)
        at com.googlecode.jmxtrans.JmxTransformer.doMain(JmxTransformer.java:157)
        at com.googlecode.jmxtrans.JmxTransformer.main(JmxTransformer.java:138)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.tanukisoftware.wrapper.WrapperSimpleApp.run(WrapperSimpleApp.java:240)
        at java.lang.Thread.run(Thread.java:745)
Caused by: org.quartz.ObjectAlreadyExistsException: Unable to store Trigger with name: '10.x.y.z:9016-1524204615162' and group: 'DEFAULT', because one already exists with this identification.
        at org.quartz.simpl.RAMJobStore.storeTrigger(RAMJobStore.java:314)
        at org.quartz.simpl.RAMJobStore.storeJobAndTrigger(RAMJobStore.java:194)
        at org.quartz.core.QuartzScheduler.scheduleJob(QuartzScheduler.java:822)
        at org.quartz.impl.StdScheduler.scheduleJob(StdScheduler.java:243)
        at com.googlecode.jmxtrans.JmxTransformer.scheduleJob(JmxTransformer.java:410)
        at com.googlecode.jmxtrans.JmxTransformer.processServersIntoJobs(JmxTransformer.java:371)
        ... 10 more

```

From what we could see it seems that just the `nanoTime()` is not enough to uniquely name the trigger