### PR TITLE
Build Docker image from Maven

### DIFF
--- a/jmxtrans/pom.xml
+++ b/jmxtrans/pom.xml
@@ -473,6 +473,41 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>docker</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>io.fabric8</groupId>
+						<artifactId>docker-maven-plugin</artifactId>
+						<version>0.26.0</version>
+						<configuration>
+							<images>
+								<image>
+									<alias>jmxtrans</alias>
+									<name>jmxtrans/jmxtrans:${project.version}</name>
+
+									<build>
+										<from>openjdk:8-jre-alpine</from>
+										<assembly>
+											<descriptor>docker.xml</descriptor>
+										</assembly>
+										<dockerFileDir>files</dockerFileDir>
+									</build>
+								</image>
+							</images>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>build</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 </project>

--- a/jmxtrans/src/main/docker/docker-entrypoint.sh
+++ b/jmxtrans/src/main/docker/docker-entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# The MIT License
+# Copyright © 2010 JmxTrans team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+
+export JSON_DIR=${JMXTRANS_CONF_DIR}
+export LOG_DIR=${JMXTRANS_LOG_DIR}
+export MONITOR_OPTS=""
+
+if [[ "$1" = 'jmxtrans.sh' && "$(id -u)" = '0' ]]; then
+    exec su-exec "$JMXTRANS_USER" "$0" "$@"
+fi
+
+exec "$@"

--- a/jmxtrans/src/main/docker/docker.xml
+++ b/jmxtrans/src/main/docker/docker.xml
@@ -1,0 +1,72 @@
+<!--
+
+    The MIT License
+    Copyright © 2010 JmxTrans team
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>dist</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+
+    <files>
+        <file>
+            <source>target/jmxtrans-${project.version}-all.jar</source>
+            <outputDirectory>lib</outputDirectory>
+            <destName>jmxtrans-all.jar</destName>
+            <fileMode>644</fileMode>
+        </file>
+    </files>
+
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}</directory>
+            <outputDirectory>bin</outputDirectory>
+            <directoryMode>755</directoryMode>
+            <fileMode>775</fileMode>
+            <includes>
+                <include>*.sh</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}</directory>
+            <outputDirectory>config</outputDirectory>
+            <directoryMode>755</directoryMode>
+            <fileMode>644</fileMode>
+            <lineEnding>unix</lineEnding>
+            <includes>
+                <include>*.json</include>
+            </includes>
+        </fileSet>
+		<fileSet>
+			<directory>src/main/docker</directory>
+			<outputDirectory></outputDirectory>
+			<directoryMode>755</directoryMode>
+			<fileMode>755</fileMode>
+			<lineEnding>unix</lineEnding>
+			<includes>
+				<include>*.sh</include>
+			</includes>
+		</fileSet>
+    </fileSets>
+</assembly>

--- a/jmxtrans/src/main/docker/files/Dockerfile
+++ b/jmxtrans/src/main/docker/files/Dockerfile
@@ -1,0 +1,51 @@
+#
+# The MIT License
+# Copyright © 2010 JmxTrans team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+FROM openjdk:8-jre-alpine
+
+# Install required packages
+RUN apk add --no-cache \
+    bash \
+    su-exec
+
+ENV JMXTRANS_HOME_DIR=/jmxtrans \
+	JMXTRANS_USER=jmxtrans \
+    JMXTRANS_CONF_DIR=/jmxtrans/conf \
+    JMXTRANS_LOG_DIR=/jmxtrans/log
+
+COPY maven $JMXTRANS_HOME_DIR
+
+RUN set -ex; \
+    mv $JMXTRANS_HOME_DIR/docker-entrypoint.sh / ; \
+    adduser -D "$JMXTRANS_USER"; \
+    mkdir -p "$JMXTRANS_LOG_DIR"; \
+    chown -R "$JMXTRANS_USER:$JMXTRANS_USER" "$JMXTRANS_HOME_DIR"
+
+WORKDIR $JMXTRANS_HOME_DIR
+VOLUME ["$JMXTRANS_CONF_DIR", "$JMXTRANS_LOG_DIR"]
+
+
+ENV PATH=$PATH:$JMXTRANS_HOME_DIR/bin
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["jmxtrans.sh", "run"]


### PR DESCRIPTION
- [x] Builds a Docker from image as part of Maven build (not only releases but also snapshots)
- [x] Uses same binaries and startup script as tarball, deb and rpm packages
- [x] Based on Alpine with JRE8 image (inspired by Zookeeper official image)
- [x] Uses Docker Maven plugin from Fabric8 (RedHat) team https://dmp.fabric8.io
- [ ] Run and test image as part of the Maven build
- [ ] Pushes Docker image to Docker Hub on Maven Release

Comments and feedback are welcome