### PR TITLE
InfluxDB : Allow string values and more

### DIFF
--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -22,7 +22,6 @@
  */
 package com.googlecode.jmxtrans.model.output;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableList;
@@ -81,13 +80,6 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 	private final boolean typeNamesAsTags;
 	private final boolean allowStringValues;
 	private final boolean reportJmxPortAsTag;
-
-	private final Predicate<Object> isNotNaN = new Predicate<Object>() {
-		@Override
-		public boolean apply(Object input) {
-			return !input.toString().equals("NaN");
-		}
-	};
 
 	public InfluxDbWriter(
 			@Nonnull InfluxDB influxDB,

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -227,7 +227,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 		}
 
 		if (typeNamesAsTags) {
-			Map<String, String> typeNameValueMap = TypeNameValue.extractMap(resultTagMap.get("typeName"));
+			Map<String, String> typeNameValueMap = result.getTypeNameMap();
 			for (String typeToTag : this.typeNames) {
 				if (typeNameValueMap.containsKey(typeToTag)) {
 					resultTagMap.put(typeToTag, typeNameValueMap.get(typeToTag));

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -80,7 +80,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 
 	private final boolean createDatabase;
 	private final boolean typeNamesAsTags;
-	private final boolean segregateStringValues;
+	private final boolean allowStringValues;
 	private final boolean reportJmxPortAsTag;
 
 	private final Predicate<Object> isNotNaN = new Predicate<Object>() {
@@ -101,7 +101,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 			boolean createDatabase,
 			boolean reportJmxPortAsTag,
 			boolean typeNamesAsTags,
-			boolean segregateStringValues) {
+			boolean allowStringValues) {
 		this.typeNames = typeNames;
 		this.database = database;
 		this.writeConsistency = writeConsistency;
@@ -112,7 +112,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 		this.createDatabase = createDatabase;
 		this.reportJmxPortAsTag = reportJmxPortAsTag;
 		this.typeNamesAsTags = typeNamesAsTags;
-		this.segregateStringValues = segregateStringValues;
+		this.allowStringValues = allowStringValues;
 	}
 
 	/**
@@ -196,7 +196,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 			String key = KeyUtils.getPrefixedKeyString(query, result, typeNamesParam);
 			if (isValidNumber(value)) {
 				filteredValues.put(key, value);
-			}else if (segregateStringValues && value instanceof String) {
+			}else if (allowStringValues && value instanceof String) {
 				filteredValues.put(key, value);
 			}
 

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -186,19 +186,17 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 			HashMap<String, Object> filteredValues = newHashMap();
 			Object value = result.getValue();
 
-			ImmutableList<String> typeNamesParam = this.typeNames;
-			// if typeNamesAsTag, we don't concat typeName in values.
-			if (typeNamesAsTags) {
-				typeNamesParam = ImmutableList.<String>of();
+			ImmutableList<String> typeNamesParam = null;
+			// if not typeNamesAsTag, we concat typeName in values.
+			if (!typeNamesAsTags) {
+				typeNamesParam = this.typeNames;
 			}
 
 			String key = KeyUtils.getPrefixedKeyString(query, result, typeNames);
 			if (isValidNumber(value)) {
 				filteredValues.put(key, value);
-			}else {
-				if (segregateStringValues) {
+			}else if (segregateStringValues) {
 					filteredValues.put(key + "_str", value);
-				}
 			}
 
 			// send the point if filteredValues isn't empty

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -230,7 +230,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 		if (typeNamesAsTags) {
 			Map<String, String> typeNameValueMap = TypeNameValue.extractMap(resultTagMap.get("typeName"));
 			for (String typeToTag : this.typeNames) {
-				if (typeNameValueMap.containsKey(typeToTag)) {
+				if (typeNameValueMap.get(typeToTag) != null) {
 					resultTagMap.put(typeToTag, typeNameValueMap.get(typeToTag));
 				}
 			}

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriter.java
@@ -32,7 +32,6 @@ import com.googlecode.jmxtrans.model.Result;
 import com.googlecode.jmxtrans.model.ResultAttribute;
 import com.googlecode.jmxtrans.model.Server;
 import com.googlecode.jmxtrans.model.naming.KeyUtils;
-import com.googlecode.jmxtrans.model.naming.typename.TypeNameValue;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDB.ConsistencyLevel;
 import org.influxdb.dto.BatchPoints;
@@ -194,9 +193,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 			Object value = result.getValue();
 
 			String key = KeyUtils.getPrefixedKeyString(query, result, typeNamesParam);
-			if (isValidNumber(value)) {
-				filteredValues.put(key, value);
-			}else if (allowStringValues && value instanceof String) {
+			if (isValidNumber(value) || allowStringValues && value instanceof String) {
 				filteredValues.put(key, value);
 			}
 
@@ -219,7 +216,7 @@ public class InfluxDbWriter extends OutputWriterAdapter {
 		influxDB.write(batchPoints);
 	}
 
-	private Map<String, String> buildResultTagMap(Result result) throws Exception {
+	private Map<String, String> buildResultTagMap(Result result) {
 
 		Map<String, String> resultTagMap = new TreeMap<>();
 		for (ResultAttribute resultAttribute : resultAttributesToWriteAsTags) {

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -91,7 +91,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 			@JsonProperty("reportJmxPortAsTag") Boolean reportJmxPortAsTag,
 			@JsonProperty("typeNamesAsTags") Boolean typeNamesAsTags,
 			@JsonProperty("segregateStringValues") Boolean segregateStringValues) {
-		this.typeNames = typeNames;
+		this.typeNames = firstNonNull(typeNames,ImmutableList.<String>of());
 		this.booleanAsNumber = booleanAsNumber;
 		this.database = database;
 		this.createDatabase = firstNonNull(createDatabase, TRUE);

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/main/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterFactory.java
@@ -43,7 +43,6 @@ import java.util.List;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static java.lang.Boolean.FALSE;
 
 public class InfluxDbWriterFactory implements OutputWriterFactory {
 
@@ -68,6 +67,7 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	private final boolean createDatabase;
 	private final boolean reportJmxPortAsTag;
 	private final ImmutableList<String> typeNames;
+	private final boolean segregateStringValues;
 
 	/**
 	 * @param url      - The url e.g http://localhost:8086 to InfluxDB
@@ -87,14 +87,16 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 			@JsonProperty("writeConsistency") String writeConsistency,
 			@JsonProperty("retentionPolicy") String retentionPolicy,
 			@JsonProperty("resultTags") List<String> resultTags,
-			@JsonProperty("typeNamesAsTags") Boolean typeNamesAsTags,
 			@JsonProperty("createDatabase") Boolean createDatabase,
-			@JsonProperty("reportJmxPortAsTag") Boolean reportJmxPortAsTag) {
+			@JsonProperty("reportJmxPortAsTag") Boolean reportJmxPortAsTag,
+			@JsonProperty("typeNamesAsTags") Boolean typeNamesAsTags,
+			@JsonProperty("segregateStringValues") Boolean segregateStringValues) {
 		this.typeNames = typeNames;
 		this.booleanAsNumber = booleanAsNumber;
 		this.database = database;
-		this.typeNamesAsTags = firstNonNull(typeNamesAsTags, FALSE);
 		this.createDatabase = firstNonNull(createDatabase, TRUE);
+		this.typeNamesAsTags = firstNonNull(typeNamesAsTags, FALSE);
+		this.segregateStringValues = firstNonNull(segregateStringValues, FALSE);
 
 		this.writeConsistency = StringUtils.isNotBlank(writeConsistency)
 				? InfluxDB.ConsistencyLevel.valueOf(writeConsistency) : InfluxDB.ConsistencyLevel.ALL;
@@ -129,6 +131,6 @@ public class InfluxDbWriterFactory implements OutputWriterFactory {
 	@Override
 	public ResultTransformerOutputWriter<InfluxDbWriter> create() {
 		return ResultTransformerOutputWriter.booleanToNumber(booleanAsNumber, new InfluxDbWriter(influxDB, database,
-				writeConsistency, retentionPolicy, tags, resultAttributesToWriteAsTags, typeNames, createDatabase, reportJmxPortAsTag, typeNamesAsTags));
+				writeConsistency, retentionPolicy, tags, resultAttributesToWriteAsTags, typeNames, createDatabase, reportJmxPortAsTag, typeNamesAsTags, segregateStringValues));
 	}
 }

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
@@ -42,7 +42,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.verification.VerificationMode;
 
 import java.io.File;
@@ -60,7 +60,7 @@ import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServer;
 import static com.googlecode.jmxtrans.model.output.InfluxDbWriter.JMX_PORT_KEY;
 import static com.googlecode.jmxtrans.model.output.InfluxDbWriter.TAG_HOSTNAME;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -225,7 +225,7 @@ public class InfluxDbWriterTests {
 		assertThat(points).hasSize(1);
 	
 		Point point = points.get(0);
-		assertThat(point.lineProtocol()).contains("key");
+		assertThat(point.lineProtocol()).contains("key=\"hello\"");
 	}
 
 	private void verifyJMXPortOnlyInToken(String lineProtocol, int tokenContainingJMXPort) {

--- a/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-influxdb/src/test/java/com/googlecode/jmxtrans/model/output/InfluxDbWriterTests.java
@@ -225,7 +225,7 @@ public class InfluxDbWriterTests {
 		assertThat(points).hasSize(1);
 	
 		Point point = points.get(0);
-		assertThat(point.lineProtocol()).contains("key_str");
+		assertThat(point.lineProtocol()).contains("key");
 	}
 
 	private void verifyJMXPortOnlyInToken(String lineProtocol, int tokenContainingJMXPort) {


### PR DESCRIPTION
Continuation of the work from #660 with the segregateStringValues parameter (renamed allowStringValues) which allows the InfluxDBWriter to write string fields in InfluxDB.

Additional work was also done: 
- Fix 2 bugs with the typeNames parameter
- Update the tests
- Add description of the InfluxDBWriterFactory parameters


I'm also working on a new parameter for the InfluxDBWriter, called "attributesAsTag": 
In InfluxDB, you can store values as tag or as fields. Tags are indexed, fields not. (See [here](https://docs.influxdata.com/influxdb/v1.5/concepts/key_concepts/).) Actually, the InfluxDbWriter stores every attributes value as fields. If this format is adapted for metrics (counters, averages, etc...), you can have performance issues when reading if you try to filter with them. Tags are more adapted for filtering, that's why it is recommended to store IDs, names, metadata, etc... as tags. Actually, only JMX port (with reportJmxPortAsTag parameter), typeName, objDomain, className, attributeName (with resultTags parameter) and full custom tags are written. "attributesAsTag" will be a list of attributes to write as tags instead of fields.
I haven't yet pushed the commits of "attributesAsTag" because I prefer to wait your opinion on this.