### PR TITLE
Relax JDK dependency in Debian package

### DIFF
--- a/jmxtrans-packaging/jmxtrans-systemd/src/deb/control/control
+++ b/jmxtrans-packaging/jmxtrans-systemd/src/deb/control/control
@@ -4,6 +4,6 @@ Maintainer: Guillaume Lederrey <guillaume.lederrey@gmail.com>
 Architecture: all
 Section: admin
 Priority: optional
-Depends: java7-runtime-headless | openjdk-7-jre-headless
+Depends: java7-runtime-headless | openjdk-7-jre-headless | java8-runtime-headless | default-jre-headless
 Description: [[version]] - jmxtrans
  dependency package, installs jmxtrans


### PR DESCRIPTION
The system java installation may come from a different package than the ones listed, so make it optional (with `Recommended`) rather than a strict dependency.