### PR TITLE
Preventing InstanceAlreadyExistsException on Reload

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
@@ -308,6 +308,41 @@ public class JmxTransformer implements WatchedCallback {
 		this.processServersIntoJobs();
 	}
 
+	/**
+	 * Reloads servers from watchdir.
+	 */
+	private void reloadSystem() throws Exception {
+		serverScheduler.unscheduleAll();
+		this.removeExecutors();
+		this.processFilesIntoServers();
+		this.startExecutors();
+		this.processServersIntoJobs();
+	}
+
+	/**
+	 * Stops executors and removes servers for a reload.
+	 */
+	private void removeExecutors() throws Exception {
+		log.debug("Clearing executors for reload.");
+
+		unregisterExecutors(queryExecutorMBeans);
+		unregisterExecutors(resultExecutorMBeans);
+
+		for (Server server : masterServersList) {
+			queryExecutorRepository.remove(server);
+			resultExecutorRepository.remove(server);
+		}
+	}
+
+	/**
+	 * Starts executors for a reload.
+	 */
+	private void startExecutors() throws Exception {
+		initializeExecutors();
+		queryExecutorMBeans = registerExecutors(queryExecutorRepository);
+		resultExecutorMBeans = registerExecutors(resultExecutorRepository);
+	}
+
 	private void initializeExecutors() throws MalformedObjectNameException {
 		this.initializeExecutors(queryExecutorRepository);
 		this.initializeExecutors(resultExecutorRepository);
@@ -475,9 +510,9 @@ public class JmxTransformer implements WatchedCallback {
 			@Override
 			public void run() {
 				try {
-					serverScheduler.unscheduleAll();
-					startupSystem();
+					reloadSystem();
 				} catch(Exception e) {
+					log.error("Error during reload.", e);
 					throw new RuntimeException(e);
 				}
 			}

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/CommonExecutorRepository.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/CommonExecutorRepository.java
@@ -59,4 +59,9 @@ public class CommonExecutorRepository implements ExecutorRepository {
 	public Collection<ManagedThreadPoolExecutor> getMBeans() {
 		return Arrays.asList(managedThreadPoolExecutor);
 	}
+
+	@Override
+	public void remove(Server server) {
+		//nothing here because every server uses common thread pool
+	}
 }

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/ExecutorRepository.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/executors/ExecutorRepository.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.concurrent.ThreadPoolExecutor;
 
 public interface ExecutorRepository {
+	void remove(Server server);
 	void put(Server server) throws MalformedObjectNameException;
 	Collection<ThreadPoolExecutor> getExecutors();
 	ThreadPoolExecutor getExecutor(Server server);


### PR DESCRIPTION
When a file was added/deleted/modified in the watchdir, the reload
would attempt to add the same mbeans to the JmxMBeanServer. This
would cause jmxtrans to hang and the watchdir functionality to be
useless.

Restructured reload to remove stale beans. Also, removes stale
server instances from the executor repositories so the repositories
don't grow unbounded when running with --use-separate-executors.

Possibly related to issue #678.

The exception:
```
javax.management.InstanceAlreadyExistsException: com.googlecode.jmxtrans:Type=JmxTransformerProcess,Name=JmxTransformerProcess
	at com.sun.jmx.mbeanserver.Repository.addMBean(Repository.java:437)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerWithRepository(DefaultMBeanServerInterceptor.java:1898)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerDynamicMBean(DefaultMBeanServerInterceptor.java:966)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerObject(DefaultMBeanServerInterceptor.java:900)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:324)
	at com.sun.jmx.mbeanserver.JmxMBeanServer.registerMBean(JmxMBeanServer.java:522)
	at com.googlecode.jmxtrans.JmxTransformer.registerMBeans(JmxTransformer.java:388)
	at com.googlecode.jmxtrans.JmxTransformer.startupSystem(JmxTransformer.java:312)
	at com.googlecode.jmxtrans.JmxTransformer.access$100(JmxTransformer.java:77)
	at com.googlecode.jmxtrans.JmxTransformer$1.run(JmxTransformer.java:480)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```