### PR TITLE
Skip separator when key prefix is empty

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/ResultFixtures.java
@@ -58,13 +58,18 @@ public final class ResultFixtures {
 	public static Result numericResult() {
 		return numericResult(10);
 	}
+
 	public static Result numericResult(Object numericValue) {
+		return numericResult("MemoryAlias", numericValue);
+	}
+
+	public static Result numericResult(String keyAlias, Object numericValue) {
 		return new Result(
 				0,
 				"ObjectPendingFinalizationCount",
 				"sun.management.MemoryImpl",
 				"ObjectDomainName",
-				"MemoryAlias",
+				keyAlias,
 				"type=Memory",
 				ImmutableList.<String>of(),
 				numericValue);

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/KeyUtils.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/naming/KeyUtils.java
@@ -47,9 +47,9 @@ public final class KeyUtils {
 		StringBuilder sb = new StringBuilder();
 		addRootPrefix(rootPrefix, sb);
 		addAlias(server, sb);
-		sb.append(".");
+		addSeparator(sb);
 		addMBeanIdentifier(query, result, sb);
-		sb.append(".");
+		addSeparator(sb);
 		addTypeName(query, result, typeNames, sb);
 		addKeyString(query, result, sb);
 		return sb.toString();
@@ -66,10 +66,16 @@ public final class KeyUtils {
 	public static String getKeyString(Query query, Result result, List<String> typeNames) {
 		StringBuilder sb = new StringBuilder();
 		addMBeanIdentifier(query, result, sb);
-		sb.append(".");
+		addSeparator(sb);
 		addTypeName(query, result, typeNames, sb);
 		addKeyString(query, result, sb);
 		return sb.toString();
+	}
+
+	private static void addSeparator(StringBuilder sb) {
+		if (sb.length() > 0 && !sb.substring(sb.length() - 1).equals(".")) {
+			sb.append(".");
+		}
 	}
 
 	/**
@@ -88,7 +94,7 @@ public final class KeyUtils {
 	}
 
 	private static void addRootPrefix(String rootPrefix, StringBuilder sb) {
-		if (rootPrefix != null) {
+		if (rootPrefix != null && rootPrefix.length() > 0) {
 			sb.append(rootPrefix);
 			sb.append(".");
 		}

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/naming/KeyUtilsTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/naming/KeyUtilsTest.java
@@ -1,0 +1,76 @@
+/**
+ * The MIT License
+ * Copyright © 2018 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.model.naming;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQuery;
+import static com.googlecode.jmxtrans.model.QueryFixtures.dummyQueryWithResultAlias;
+import static com.googlecode.jmxtrans.model.ResultFixtures.numericResult;
+import static com.googlecode.jmxtrans.model.ServerFixtures.SERVER_ALIAS;
+import static com.googlecode.jmxtrans.model.ServerFixtures.dummyServerBuilder;
+import static com.googlecode.jmxtrans.model.ServerFixtures.serverWithAliasAndNoQuery;
+import static org.junit.Assert.assertEquals;
+
+public class KeyUtilsTest {
+
+	@Test
+	public void testKeyString() {
+		assertEquals("rootPrefix." + SERVER_ALIAS + ".MemoryAlias.ObjectPendingFinalizationCount",
+				KeyUtils.getKeyString(
+						serverWithAliasAndNoQuery(),
+						dummyQueryWithResultAlias(),
+						numericResult(),
+						ImmutableList.of("typeName"),
+						"rootPrefix"));
+		assertEquals("rootPrefix.ObjectPendingFinalizationCount",
+				KeyUtils.getKeyString(
+						dummyServerBuilder().setAlias("").build(),
+						dummyQuery(),
+						numericResult("", 10),
+						ImmutableList.of("typeName"),
+						"rootPrefix"));
+		assertEquals("MemoryAlias.ObjectPendingFinalizationCount",
+				KeyUtils.getKeyString(
+						dummyServerBuilder().setAlias("").build(),
+						dummyQuery(),
+						numericResult(10),
+						ImmutableList.of("typeName"),
+						""));
+		assertEquals(SERVER_ALIAS + ".ObjectPendingFinalizationCount",
+				KeyUtils.getKeyString(
+						dummyServerBuilder().setAlias(SERVER_ALIAS).build(),
+						dummyQuery(),
+						numericResult("", 10),
+						ImmutableList.of("typeName"),
+						""));
+		assertEquals("ObjectPendingFinalizationCount",
+				KeyUtils.getKeyString(
+						dummyServerBuilder().setAlias("").build(),
+						dummyQuery(),
+						numericResult("", 10),
+						ImmutableList.of("typeName"),
+						""));
+	}
+}

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/naming/KeyUtilsTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/model/naming/KeyUtilsTest.java
@@ -1,6 +1,6 @@
 /**
  * The MIT License
- * Copyright © 2018 JmxTrans team
+ * Copyright © 2010 JmxTrans team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
It is often convenient not to have any key prefix but only attribute name.

For instance when storing metrics in CloudWatch Agent via statsd instead of having long metric name:
`coordinator_presto_memory_NonHeapMemoryUsage_used`
I would rather have:
`NonHeapMemoryUsage_used`
as I can identify metric source via so called "dimensions" (statsd attributes).