### PR TITLE
Add support for keys filtering to jmx result processor

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/JmxResultProcessor.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/JmxResultProcessor.java
@@ -143,6 +143,10 @@ public class JmxResultProcessor {
 			CompositeType t = cds.getCompositeType();
 			Set<String> keys = t.keySet();
 			for (String key : keys) {
+				if (!query.getKeys().isEmpty() && !query.getKeys().contains(key)) {
+					continue;
+				}
+
 				Object value = cds.get(key);
 				add(attributeName, newValuePath(valuePath, key), value);
 			}


### PR DESCRIPTION
Keys filtering is useful in cloud environments where one pays
price per metric. In some cases, (e.g: `NonHeapMemoryUsage`) some
keys have meaningless values, so it doesn't make sense to evaluate them
for every machine.