### PR TITLE
Fix configure reload

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/JmxTransformer.java
@@ -182,7 +182,8 @@ public class JmxTransformer implements WatchedCallback {
 				this.serverScheduler.start();
 
 				this.startupWatchdir();
-
+				this.initializeExecutors();
+				this.registerMBeans();
 				this.startupSystem();
 
 			} catch (Exception e) {
@@ -309,8 +310,6 @@ public class JmxTransformer implements WatchedCallback {
 	 */
 	private void startupSystem() throws Exception {
 		this.processFilesIntoServers();
-		this.initializeExecutors();
-		this.registerMBeans();
 		this.processServersIntoJobs();
 	}
 


### PR DESCRIPTION
Reload of configuration fail because MBean is tried to be registered twice (one at startup, then once when scheduleReload call startupSystem).

This regression appear with #629 which moved the MBean initialization from doMain to startupSystem.

This PR move the MBean initialization outside startupSystem to restore old behavior and javadoc of statupSystem.

# Step to reproduce the issue

Note: the exception won't be logged, because #711 moved the actual reloading in a Runnable future and transform the exception in RuntimeException. If you want to see the exception, a log should be added in the try/catch.

* Create directory

```
mkdir -p log conf.d
```

* Create a configuration file (it assume a JVM with JMX on port 7999 is running on localhost):

```
cat > conf.d/config.json << EOF
{
  "servers": [
    {
      "host": "127.0.0.1",
      "outputWriters": [
        {
          "@class": "com.googlecode.jmxtrans.model.output.StdOutWriter"
        }
      ],
      "port": 2101,
      "queries": [
        {
          "attr": [
            "HeapMemoryUsage"
          ],
          "obj": "java.lang:type=Memory"
        }
      ],
      "runPeriodSeconds": 1
    }
  ]
}
EOF
```

* Run JMX

```
java -Djmxtrans.log.level=debug -Djmxtrans.log.dir=./log -jar jmxtrans-271-SNAPSHOT-all.jar -e -j ./conf.d/ -s 60 -c false
```

* Metrics are shown in stdout
* Update configuration any one of the following solution
   * Re-run the cat command of step 2
   * Run vi and do ":w"
   * Use mv to update config (since mv is atomic on Linux, jmxtrans could *not* read a partial file): `mv conf.d/config.json config.json; mv config.json conf.d/config.json`
   * Any other method to update the configuration
* Without this PR, metrics stop being shown in stdout. A restart of jmxtrans if require.
* With this PR, the reload happen and metrics continue to be shown in stdout.

If a `log.info("{}", e)` is added in the try-catch of reloadScheduledFuture, the exception is:
```
javax.management.InstanceAlreadyExistsException: com.googlecode.jmxtrans:Type=JmxTransformerProcess,Name=JmxTransformerProcess
	at java.management/com.sun.jmx.mbeanserver.Repository.addMBean(Repository.java:436)
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerWithRepository(DefaultMBeanServerInterceptor.java:1855)
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerDynamicMBean(DefaultMBeanServerInterceptor.java:955)
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerObject(DefaultMBeanServerInterceptor.java:890)
	at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:320)
	at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.registerMBean(JmxMBeanServer.java:522)
	at com.googlecode.jmxtrans.JmxTransformer.registerMBeans(JmxTransformer.java:387)
	at com.googlecode.jmxtrans.JmxTransformer.startupSystem(JmxTransformer.java:313)
	at com.googlecode.jmxtrans.JmxTransformer.access$100(JmxTransformer.java:79)
	at com.googlecode.jmxtrans.JmxTransformer$1.run(JmxTransformer.java:485)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:844)
```