### PR TITLE
CloudWatchWriter support for AWS ECS & Fargate credentials discovery

### DIFF
--- a/jmxtrans-output/jmxtrans-output-cloudwatch/src/main/java/com/googlecode/jmxtrans/model/output/CloudWatchWriter.java
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/src/main/java/com/googlecode/jmxtrans/model/output/CloudWatchWriter.java
@@ -22,10 +22,8 @@
  */
 package com.googlecode.jmxtrans.model.output;
 
-import com.amazonaws.auth.InstanceProfileCredentialsProvider;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
 import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
@@ -56,7 +54,6 @@ import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
@@ -91,11 +88,10 @@ public class CloudWatchWriter implements OutputWriterFactory {
 	/**
 	 * Configuring the CloudWatch client.
 	 *
-	 * Credentials are loaded from the Amazon EC2 Instance Metadata Service
+	 * Credentials are loaded using the default credential provider chain.
 	 */
-	private AmazonCloudWatchClient createCloudWatchClient() {
-		AmazonCloudWatchClient cloudWatchClient = new AmazonCloudWatchClient(new InstanceProfileCredentialsProvider());
-		cloudWatchClient.setRegion(checkNotNull(Regions.getCurrentRegion(), "Problems getting AWS metadata"));
+	private AmazonCloudWatch createCloudWatchClient() {
+		AmazonCloudWatch cloudWatchClient = AmazonCloudWatchClientBuilder.defaultClient();
 		return cloudWatchClient;
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
 	</distributionManagement>
 	<properties>
 		<animal-sniffer.version>1.16</animal-sniffer.version>
-		<aws.java.sdk.version>1.11.428</aws.java.sdk.version>
+		<aws.java.sdk.version>1.11.533</aws.java.sdk.version>
 		<!--
 			Maximum number of checkstyle violations allowed. Build will fail
 			if there are more than this number of violations. Feel free to


### PR DESCRIPTION
CloudWatchWriter assumes AWS EC2 credential and region discovery mechanisms. This pull request instantiates the CloudWatch client in a more idiomatic way, allowing credentials and region discovery in AWS ECS containers including a Fargate task sidecar container.