### PR TITLE
Cloudwatch writer get metadata from provider chain

### DIFF
--- a/jmxtrans-output/jmxtrans-output-cloudwatch/src/main/java/com/googlecode/jmxtrans/model/output/CloudWatchWriter.java
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/src/main/java/com/googlecode/jmxtrans/model/output/CloudWatchWriter.java
@@ -22,8 +22,8 @@
  */
 package com.googlecode.jmxtrans.model.output;
 
-import com.amazonaws.auth.InstanceProfileCredentialsProvider;
-import com.amazonaws.regions.Regions;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
 import com.amazonaws.services.cloudwatch.model.Dimension;
@@ -93,10 +93,11 @@ public class CloudWatchWriter implements OutputWriterFactory {
 	 *
 	 * Credentials are loaded from the Amazon EC2 Instance Metadata Service
 	 */
-	private AmazonCloudWatchClient createCloudWatchClient() {
-		AmazonCloudWatchClient cloudWatchClient = new AmazonCloudWatchClient(new InstanceProfileCredentialsProvider());
-		cloudWatchClient.setRegion(checkNotNull(Regions.getCurrentRegion(), "Problems getting AWS metadata"));
-		return cloudWatchClient;
+	private AmazonCloudWatch createCloudWatchClient() {
+		return AmazonCloudWatchClient.builder()
+				.withCredentials(checkNotNull(DefaultAWSCredentialsProviderChain.getInstance(), "Problems getting AWS credentials"))
+				.withRegion(checkNotNull(new DefaultAwsRegionProviderChain().getRegion(), "Problems getting AWS region"))
+				.build();
 	}
 
 	private ImmutableList<Dimension> createDimensions(Iterable<Map<String, Object>> dimensions) {

--- a/jmxtrans-output/jmxtrans-output-cloudwatch/src/test/java/com/googlecode/jmxtrans/model/output/CloudWatchWriterIT.java
+++ b/jmxtrans-output/jmxtrans-output-cloudwatch/src/test/java/com/googlecode/jmxtrans/model/output/CloudWatchWriterIT.java
@@ -22,33 +22,21 @@
  */
 package com.googlecode.jmxtrans.model.output;
 
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
 import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
 import com.googlecode.jmxtrans.model.JmxProcess;
 import com.googlecode.jmxtrans.test.IntegrationTest;
 import com.googlecode.jmxtrans.test.RequiresIO;
 import com.googlecode.jmxtrans.util.ProcessConfigUtils;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static com.amazonaws.regions.Region.getRegion;
-import static com.amazonaws.regions.Regions.AP_NORTHEAST_1;
 import static com.googlecode.jmxtrans.guice.JmxTransModule.createInjector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 /**
  * Tests for {@link CloudWatchWriter}.
@@ -56,22 +44,8 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
  * @author <a href="mailto:sascha.moellering@gmail.com">Sascha Moellering</a>
  */
 @Category({RequiresIO.class, IntegrationTest.class})
-@RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")
-@PrepareForTest({CloudWatchWriter.class, Regions.class})
 public class CloudWatchWriterIT {
-
-	@Mock private AmazonCloudWatchClient cloudWatchClient;
-
-	@Before
-	public void mockAmazonAPI() throws Exception {
-		whenNew(AmazonCloudWatchClient.class)
-				.withAnyArguments()
-				.thenReturn(cloudWatchClient);
-
-		mockStatic(Regions.class);
-		when(Regions.getCurrentRegion()).thenReturn(getRegion(AP_NORTHEAST_1));
-	}
 
 	@Test
 	public void loadingFromFile() throws URISyntaxException, IOException {
@@ -79,6 +53,7 @@ public class CloudWatchWriterIT {
 		File input = new File(CloudWatchWriterIT.class.getResource("/cloud-watch.json").toURI());
 		JmxProcess process = processConfigUtils.parseProcess(input);
 		assertThat(process.getName()).isEqualTo("cloud-watch.json");
+
 	}
 
 }


### PR DESCRIPTION
The current implementation of CloudWatch output writer will fail to work on ECS/Fargate. It uses EC2Metadata to provide region info. This change to using RegionProviderChain to work on EC2 and ECS.