### PR TITLE
Print simple error message when addition jar on Java 9+

### DIFF
--- a/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/classloader/ClassLoaderEnricher.java
+++ b/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/classloader/ClassLoaderEnricher.java
@@ -24,7 +24,6 @@ package com.googlecode.jmxtrans.classloader;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -48,18 +47,14 @@ public class ClassLoaderEnricher {
 	 * @param url
 	 */
 	public void add(URL url) {
-		URLClassLoader sysLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
-		Class sysClass = URLClassLoader.class;
-
 		try {
+			// SystemClassLoader is not of type URLClassLoader for Java 9+
+			URLClassLoader sysLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+			Class sysClass = URLClassLoader.class;
 			Method method = sysClass.getDeclaredMethod("addURL", URL.class);
 			method.setAccessible(true);
 			method.invoke(sysLoader, new Object[]{ url });
-		} catch (InvocationTargetException e) {
-			throw new JarLoadingException(e);
-		} catch (NoSuchMethodException e) {
-			throw new JarLoadingException(e);
-		} catch (IllegalAccessException e) {
+		} catch (ClassCastException|ReflectiveOperationException e) {
 			throw new JarLoadingException(e);
 		}
 	}


### PR DESCRIPTION
SystemClassLoader is not of type URLClassLoader,
as a result additional jar feature doesn't work on recent Java versions.
Fix the error message in that situation.

I wonder whether we shouldn't remove the additional jar option as well.