### PR TITLE
Externalize jdk.attach API usage

### DIFF
--- a/jmxtrans-core/pom.xml
+++ b/jmxtrans-core/pom.xml
@@ -38,7 +38,6 @@
 	<description>This module contains most of the core logic of JmxTrans.</description>
 
 	<properties>
-		<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
 		<verify.mutationThreshold>25</verify.mutationThreshold>
 		<verify.totalBranchRate>38</verify.totalBranchRate>
 		<verify.totalLineRate>45</verify.totalLineRate>
@@ -122,13 +121,6 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.sun</groupId>
-			<artifactId>tools</artifactId>
-			<version>1.6.0</version>
-			<scope>system</scope>
-			<systemPath>${toolsjar}</systemPath>
 		</dependency>
 		<dependency>
 			<groupId>com.jayway.awaitility</groupId>

--- a/jmxtrans-utils/pom.xml
+++ b/jmxtrans-utils/pom.xml
@@ -23,7 +23,8 @@
     THE SOFTWARE.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jmxtrans</groupId>
@@ -105,5 +106,25 @@
 			</plugin>
 		</plugins>
 	</build>
-
+	<profiles>
+		<profile>
+			<id>jdk_less_or_equal_than_8</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+				<jdk>(,1.8]</jdk>
+			</activation>
+			<properties>
+				<toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+			</properties>
+			<dependencies>
+				<dependency>
+					<groupId>com.sun</groupId>
+					<artifactId>tools</artifactId>
+					<version>1.6.0</version>
+					<scope>system</scope>
+					<systemPath>${toolsjar}</systemPath>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>

--- a/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/attach/JVMAttacher.java
+++ b/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/attach/JVMAttacher.java
@@ -1,0 +1,69 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.attach;
+
+import com.sun.tools.attach.AgentInitializationException;
+import com.sun.tools.attach.AgentLoadException;
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Util to class to attach to running JVM using PID
+ */
+public class JVMAttacher {
+	private static final String CONNECTOR_ADDRESS = "com.sun.management.jmxremote.localConnectorAddress";
+
+	/**
+	 * Connecto to JVM
+	 *
+	 * @param pid JVM PID
+	 * @return JMX Connector address
+	 * @throws JVMAttacherException Failed to attach
+	 */
+	public static String attachToJVM(String pid) {
+		try {
+			VirtualMachine vm = VirtualMachine.attach(pid);
+			try {
+				String connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
+
+				if (connectorAddress == null) {
+					String agent = vm.getSystemProperties().getProperty("java.home") +
+							File.separator + "lib" + File.separator + "management-agent.jar";
+					vm.loadAgent(agent);
+
+					connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
+				}
+
+				return connectorAddress;
+			} finally {
+				vm.detach();
+			}
+		} catch (AttachNotSupportedException | IOException | AgentLoadException | AgentInitializationException e) {
+			throw new JVMAttacherException(e);
+		}
+	}
+
+}

--- a/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/attach/JVMAttacherException.java
+++ b/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/attach/JVMAttacherException.java
@@ -1,0 +1,32 @@
+/**
+ * The MIT License
+ * Copyright © 2010 JmxTrans team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.googlecode.jmxtrans.attach;
+
+/**
+ * JVMAttacher failure
+ */
+public class JVMAttacherException extends RuntimeException {
+	public JVMAttacherException(Exception e) {
+		super("Failed to attach to JVM", e);
+	}
+}


### PR DESCRIPTION
The purpose is to be able to build with Java 11+