### PR TITLE
Upgrade InfluxDb-java client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
 			<dependency>
 				<groupId>org.influxdb</groupId>
 				<artifactId>influxdb-java</artifactId>
-				<version>2.7</version>
+				<version>2.21</version>
 			</dependency>
 			<dependency>
 				<groupId>org.jhades</groupId>
@@ -931,7 +931,7 @@
 				<plugin>
 					<groupId>org.basepom.maven</groupId>
 					<artifactId>duplicate-finder-maven-plugin</artifactId>
-					<version>1.3.0</version>
+					<version>1.5.0</version>
 					<configuration>
 						<failBuildInCaseOfDifferentContentConflict>true</failBuildInCaseOfDifferentContentConflict>
 						<failBuildInCaseOfEqualContentConflict>false</failBuildInCaseOfEqualContentConflict>


### PR DESCRIPTION
Upgrade influxdb to 2.21 (latest version)
Need upgrade of duplicate-finder-maven-plugin to 1.4.0+ to handle multi-release jars dependencies of influxdb (kotlin-std-lib)

This version of influxDB client uses a newer version of OkHttp which spawns less threads