### PR TITLE
Keep outputwriters in server copy

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/ServerListBuilder.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/ServerListBuilder.java
@@ -110,6 +110,7 @@ public class ServerListBuilder {
 
 		public Server build() {
 			Server.Builder builder = Server.builder(server)
+					.clearOutputWriters()
 					.addOutputWriters(createOutputWriters(temporaryOutputWriters))
 					.clearQueries();
 			for (Map.Entry<Query, Set<OutputWriterFactory>> queryEntry : queries.entrySet()) {

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -31,9 +31,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.inject.name.Named;
-import com.googlecode.jmxtrans.ServerListBuilder;
 import com.googlecode.jmxtrans.connections.JMXConnection;
 import com.googlecode.jmxtrans.connections.JmxConnectionProvider;
 import com.sun.tools.attach.VirtualMachine;
@@ -159,7 +157,7 @@ public class Server implements JmxConnectionProvider {
 
 	@Getter private final ImmutableSet<Query> queries;
 
-	@Nonnull @Getter private final Iterable<OutputWriter> outputWriters;
+	@Nonnull @Getter private final ImmutableList<OutputWriter> outputWriters;
 
 	@Nonnull private final KeyedObjectPool<JmxConnectionProvider, JMXConnection> pool;
 	@Nonnull @Getter private final ImmutableList<OutputWriterFactory> outputWriterFactories;
@@ -510,7 +508,7 @@ public class Server implements JmxConnectionProvider {
 			this.local = server.local;
 			this.ssl = server.ssl;
 			this.queries.addAll(server.queries);
-			Iterables.addAll(this.outputWriters, server.outputWriters);
+			this.outputWriters.addAll(server.outputWriters);
 			this.pool = server.pool;
 		}
 

--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/model/Server.java
@@ -31,7 +31,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.inject.name.Named;
+import com.googlecode.jmxtrans.ServerListBuilder;
 import com.googlecode.jmxtrans.connections.JMXConnection;
 import com.googlecode.jmxtrans.connections.JmxConnectionProvider;
 import com.sun.tools.attach.VirtualMachine;
@@ -508,6 +510,7 @@ public class Server implements JmxConnectionProvider {
 			this.local = server.local;
 			this.ssl = server.ssl;
 			this.queries.addAll(server.queries);
+			Iterables.addAll(this.outputWriters, server.outputWriters);
 			this.pool = server.pool;
 		}
 
@@ -528,6 +531,11 @@ public class Server implements JmxConnectionProvider {
 
 		public Builder addOutputWriterFactory(OutputWriterFactory outputWriterFactory) {
 			this.outputWriterFactories.add(outputWriterFactory);
+			return this;
+		}
+
+		public Builder clearOutputWriters() {
+			this.outputWriters.clear();
 			return this;
 		}
 

--- a/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/ServerListBuilderTest.java
+++ b/jmxtrans-core/src/test/java/com/googlecode/jmxtrans/ServerListBuilderTest.java
@@ -74,6 +74,24 @@ public class ServerListBuilderTest {
 	}
 
 	@Test
+	public void outputWritersAreKeptOnServerCopy() {
+		Server server1 = Server.builder(dummyServer())
+				.addOutputWriterFactory(new DummyOutputWriterFactory("output 1"))
+				.addOutputWriterFactory(new DummyOutputWriterFactory("output 2"))
+				.build();
+
+		ImmutableList<Server> serverList = new ServerListBuilder()
+				.add(ImmutableList.of(server1))
+				.build();
+		assertThat(serverList).hasSize(1);
+
+		Server createdServer = serverList.iterator().next();
+
+		Server server2 = Server.builder(createdServer).build();
+		assertThat(server2.getOutputWriters()).hasSize(2);
+	}
+
+	@Test
 	public void outputWritersAreReusedOnQueries() {
 		Query q1 = Query.builder(dummyQuery())
 				.addOutputWriterFactory(new DummyOutputWriterFactory("output1"))


### PR DESCRIPTION
Copy the builded outputwriters when building a server from an other one.

Fixes #796

Note that in SeverListBuilder.TemporaryServer.build we clean this copied list in order to use the singleton value of the outputwriters