### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 install:
 - mvn compile -DskipTests=true -Dmaven.javadoc.skip=true -Dcobertura.skip=true -B
   -V
-script: travis_wait 120 ./travis-script.sh
+script: ./travis-script.sh
 after_success:
 - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && mvn site
   site:stage scm-publish:publish-scm --settings ${HOME}/travis/settings.xml -B -V


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
