### PR TITLE
Remove the jpathwatch dependency and just use the nio classes.

### DIFF
--- a/jmxtrans-utils/pom.xml
+++ b/jmxtrans-utils/pom.xml
@@ -53,10 +53,6 @@
 			<artifactId>commons-lang</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>net.sf.jpathwatch</groupId>
-			<artifactId>jpathwatch</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.codehaus.mojo</groupId>
 			<artifactId>animal-sniffer-annotations</artifactId>
 			<optional>true</optional>

--- a/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/util/WatchDir.java
+++ b/jmxtrans-utils/src/main/java/com/googlecode/jmxtrans/util/WatchDir.java
@@ -22,14 +22,14 @@
  */
 package com.googlecode.jmxtrans.util;
 
-import name.pachler.nio.file.ClosedWatchServiceException;
-import name.pachler.nio.file.FileSystems;
-import name.pachler.nio.file.Path;
-import name.pachler.nio.file.Paths;
-import name.pachler.nio.file.StandardWatchEventKind;
-import name.pachler.nio.file.WatchEvent;
-import name.pachler.nio.file.WatchKey;
-import name.pachler.nio.file.WatchService;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +55,7 @@ public class WatchDir extends Thread {
 		this.keys = newHashMap();
 		watchService = FileSystems.getDefault().newWatchService();
 		Path watchedPath = Paths.get(dir.getAbsolutePath());
-		WatchKey signalledKey = watchedPath.register(watchService, StandardWatchEventKind.ENTRY_CREATE, StandardWatchEventKind.ENTRY_DELETE, StandardWatchEventKind.ENTRY_MODIFY);
+		WatchKey signalledKey = watchedPath.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
 		// Store the path that we're watching, so we can later retrieve it and build a proper path to the file
 		keys.put(signalledKey, watchedPath);
 	}
@@ -88,15 +88,15 @@ public class WatchDir extends Thread {
 			Path dir = keys.get(signalledKey);
 			try {
 				for (WatchEvent<?> e : list) {
-					if (e.kind() == StandardWatchEventKind.ENTRY_CREATE) {
+					if (e.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
 						Path context = (Path) e.context();
 						Path fullPath = dir.resolve(context);
 						watched.fileAdded(new File(fullPath.toString()));
-					} else if (e.kind() == StandardWatchEventKind.ENTRY_DELETE) {
+					} else if (e.kind() == StandardWatchEventKinds.ENTRY_DELETE) {
 						Path context = (Path) e.context();
 						Path fullPath = dir.resolve(context);
 						watched.fileDeleted(new File(fullPath.toString()));
-					} else if (e.kind() == StandardWatchEventKind.ENTRY_MODIFY) {
+					} else if (e.kind() == StandardWatchEventKinds.ENTRY_MODIFY) {
 						Path context = (Path) e.context();
 						Path fullPath = dir.resolve(context);
 						watched.fileModified(new File(fullPath.toString()));

--- a/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/WatchDirTest.java
+++ b/jmxtrans-utils/src/test/java/com/googlecode/jmxtrans/util/WatchDirTest.java
@@ -102,7 +102,7 @@ public class WatchDirTest {
 		try {
 			new WatchDir(watchedDir.newFile("toWatch"), callback);
 		} catch (IOException ioe) {
-			assertThat(ioe).hasMessageEndingWith("is not a directory");
+			assertThat(ioe).hasMessageEndingWith("toWatch");
 			throw ioe;
 		}
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -257,11 +257,6 @@
 				<version>1</version>
 			</dependency>
 			<dependency>
-				<groupId>net.sf.jpathwatch</groupId>
-				<artifactId>jpathwatch</artifactId>
-				<version>0.95</version>
-			</dependency>
-			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-jexl</artifactId>
 				<version>2.1.1</version>


### PR DESCRIPTION
This PR removes the dependency on jpathwatch and replaces it with the standard nio implementation.

jmxtrans has a dependency on [jpathwatch](https://jpathwatch.wordpress.com/) which is used to watch directories for file changes. jpathwatch contains jni code and native libs for a few x86 platforms. It provides a pure java fallback for the rest but logs a lot of exceptions about the missing native libs which makes it look like there is a problem. jpathwatch also has not been updated since 2013.

Since Java 1.7, file watching is part of the standard Java runtime. Now that jmxtrans specifies Java 1.8, we should be able to switch to the standard Java classes and drop the dependency on jpathwatch.