### PR TITLE
preserve OutputWriters when cloning server to set default RunPeriod

### DIFF
--- a/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/scheduler/ServerScheduler.java
+++ b/jmxtrans-core/src/main/java/com/googlecode/jmxtrans/scheduler/ServerScheduler.java
@@ -22,6 +22,7 @@
  */
 package com.googlecode.jmxtrans.scheduler;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.googlecode.jmxtrans.cli.JmxTransConfiguration;
@@ -83,7 +84,9 @@ public class ServerScheduler {
 
 	public void schedule(Server server) {
 		if (server.getRunPeriodSeconds() == null || server.getRunPeriodSeconds().intValue() <= 0) {
-			server = Server.builder(server).setRunPeriodSeconds(configuration.getRunPeriod()).build();
+			server = Server.builder(server)
+					.addOutputWriters(ImmutableList.copyOf(server.getOutputWriters()))
+					.setRunPeriodSeconds(configuration.getRunPeriod()).build();
 		}
 		ServerCommand serverCommand = new ServerCommand(server, queryExecutorRepository, resultProcessor);
 		long runPeriod = server.getRunPeriodSeconds();


### PR DESCRIPTION
due to changes in commit 63bd2fb489e9015520f432577751bd1eaf3ede9c (Set runPeriodSeconds in Server for OutputWriters) 
the OutputWriters are not being preserved when setting RunPeriod to the default value